### PR TITLE
Opera 12.10 partial support for resize property.

### DIFF
--- a/features-json/css-resize.json
+++ b/features-json/css-resize.json
@@ -86,8 +86,8 @@
       "11.5":"n",
       "11.6":"n",
       "12":"n",
-      "12.1":"n",
-      "12.5":"n"
+      "12.1":"p",
+      "12.5":"p"
     },
     "ios_saf":{
       "3.2":"n",
@@ -125,7 +125,7 @@
       "0":"n"
     }
   },
-  "notes":"",
+  "notes":"Opera 12.10+ currently only supports the resize property for textarea elements.",
   "usage_perc_y":52.78,
   "usage_perc_a":0,
   "ucprefix":false,


### PR DESCRIPTION
But textarea elements only right now.

e.g., `data:text/html, <textarea>hi</textarea><style>textarea{resize:vertical}</style>`
