### PR TITLE
Adding 'Content-Security-Policy' support data.

### DIFF
--- a/features-json/contentsecuritypolicy.json
+++ b/features-json/contentsecuritypolicy.json
@@ -1,6 +1,5 @@
 {
   "title":"Content Security Policy",
-  "description":"API allowing a more efficient way of running script-based animation, compared to traditional methods using timeouts.",
   "description":"Mitigate cross-site scripting attacks by whitelisting allowed sources of script, style, and other resources.",
   "spec":"http:\/\/www.w3.org\/TR\/CSP\/",
   "status":"wd",


### PR DESCRIPTION
Thanks for throwing this onto GitHub!

Would you mind taking a look at this patch to add Content-Security-Policy support? (http://goo.gl/mod/ZpFq from the suggestion Moderator)  I expect to be unprefixing it in Chrome/WebKit when the spec goes to CR (which should happen in the next few weeks).
