### PR TITLE
Tested column-span in latest Firefox Beta

### DIFF
--- a/features-json/multicolumn.json
+++ b/features-json/multicolumn.json
@@ -15,7 +15,7 @@
   ],
   "bugs":[
     {
-      "description":"In Firefox 6, the property column-span (or -moz-column-span) does not yet work."
+      "description":"In Firefox 17, the property column-span (or -moz-column-span) does not yet work. See the bug 616436 on Bugzilla: https://bugzilla.mozilla.org/show_bug.cgi?id=616436."
     }
   ],
   "categories":[


### PR DESCRIPTION
Just tested in Firefox 17 beta 3, it still doesn't work.
