### PR TITLE
Update features-json/png-alpha.json

### DIFF
--- a/features-json/png-alpha.json
+++ b/features-json/png-alpha.json
@@ -15,7 +15,7 @@
   ],
   "bugs":[
     {
-      "description":"IE7 & 8 do not support PNG alpha transparency, if you put an alpha filter on them or a parent element."
+      "description":"IE7 & 8 do not support PNG's alpha transparency when you apply CSS alpha filter on them or a parent element."
     }
   ],
   "categories":[


### PR DESCRIPTION
Making it clear that IE7 & 8 do in fact support alpha transparency of PNG by default. Does not work only when alpha filter is applied via CSS.
