### PR TITLE
Added IE10 CORS bug

### DIFF
--- a/features-json/cors.json
+++ b/features-json/cors.json
@@ -22,7 +22,7 @@
     }
   ],
   "bugs":[
-    
+    "IE10 does not send cookies when withCredential=true (<a href=\"https://connect.microsoft.com/IE/feedback/details/759587/ie10-doesnt-support-cookies-on-cross-origin-xmlhttprequest-withcredentials-true\">IE Bug #759587</a>)"
   ],
   "categories":[
     "JS API"


### PR DESCRIPTION
IE10 doesn't send cookies when withCredentials=true. Bug filed in August 2012 and reproduced by Microsoft.
