### PR TITLE
Update features-json/getcomputedstyle.json

### DIFF
--- a/features-json/getcomputedstyle.json
+++ b/features-json/getcomputedstyle.json
@@ -1,7 +1,7 @@
 {
   "title":"getComputedStyle",
   "description":"API to get the current computed CSS styles applied to an element. This may be the current value applied by an animation or as set by a stylesheet.",
-  "spec":"http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSview-getComputedStyle",
+  "spec":"http://www.w3.org/TR/cssom/#dom-window-getcomputedstyle",
   "status":"rec",
   "links":[
     {


### PR DESCRIPTION
The CSSOM standard is the successor of DOM 2 Style.
