### PR TITLE
Update features-json/getelementsbyclassname.json

### DIFF
--- a/features-json/getelementsbyclassname.json
+++ b/features-json/getelementsbyclassname.json
@@ -1,7 +1,7 @@
 {
   "title":"getElementsByClassName",
   "description":"Method of accessing DOM elements by class name",
-  "spec":"http://www.whatwg.org/specs/web-apps/current-work/multipage/dom.html#dom-document-getelementsbyclassname",
+  "spec":"http://www.w3.org/TR/dom/#dom-document-getelementsbyclassname",
   "status":"wd",
   "links":[
     {


### PR DESCRIPTION
`getElementsByClassName` has apparently been moved to the DOM standard.
