### PR TITLE
SVG as CSS background bugs

### DIFF
--- a/features-json/svg-css.json
+++ b/features-json/svg-css.json
@@ -11,7 +11,9 @@
   ],
   "bugs":[
     {
-      "description":"SVG-as-image is <a href=\"https://bugzilla.mozilla.org/show_bug.cgi?id=600207\">fuzzy/pixelated</a> when zoomed or printed in Firefox"
+      "description":"SVG-as-image is <a href=\"https://bugzilla.mozilla.org/show_bug.cgi?id=600207\">fuzzy/pixelated</a> when zoomed or printed in Firefox",
+      "description":"SVG-as-image is fuzzy/pixelated when zoomed in Opera 12.12, Safari 5.1.7",
+      "description":"Problems with positioning of SVG backgrounds in Opera 12.12"
     }
   ],
   "categories":[


### PR DESCRIPTION
Hi,

If I'm not mistaken SVG background scaling works fine only in Chrome 23 and IE9.

I've added the info about bugs in Opera and Safari.
