### PR TITLE
Update features-json/flexbox.json for Firefox 18

### DIFF
--- a/features-json/flexbox.json
+++ b/features-json/flexbox.json
@@ -57,8 +57,8 @@
       "15":"a x",
       "16":"a x",
       "17":"a x",
-      "18":"a x",
-      "19":"a x"
+      "18":"y",
+      "19":"y"
     },
     "chrome":{
       "4":"a x",
@@ -143,7 +143,7 @@
       "0":"a x"
     }
   },
-  "notes":"Partial support refers to supporting an <a href=\"http://www.w3.org/TR/2009/WD-css3-flexbox-20090723/\">older version</a> of the specification or an <a href=\"http://www.w3.org/TR/2012/WD-css3-flexbox-20120322/\">older syntax</a>. The new spec is to be supported unprefixed in Firefox 20.",
+  "notes":"Partial support refers to supporting an <a href=\"http://www.w3.org/TR/2009/WD-css3-flexbox-20090723/\">older version</a> of the specification or an <a href=\"http://www.w3.org/TR/2012/WD-css3-flexbox-20120322/\">older syntax</a>. The new spec is to be supported unprefixed in Firefox 18.",
   "usage_perc_y":28.97,
   "usage_perc_a":36.29,
   "ucprefix":false,


### PR DESCRIPTION
Per http://thenextweb.com/apps/2013/01/08/you-can-download-firefox-18-for-windows-mac-and-linux-right-now-official-launch-this-week/?fromcat=all , FlexBox will be supported on Firefox 18.
