### PR TITLE
EventSource's note update

### DIFF
--- a/features-json/eventsource.json
+++ b/features-json/eventsource.json
@@ -15,7 +15,7 @@
   ],
   "bugs":[
     {
-      "description":"Reportedly, CORS in EventSource is currently only supported in Firefox 10+ and Opera 12+. "
+      "description":"Reportedly, CORS in EventSource is currently supported in Firefox 10+, Opera 12+, Chrome 26, other WebKit-based browsers will support soon."
     },
     {
       "description":"Appears to work in some (modified) versions of the Android 4 browser."


### PR DESCRIPTION
The patch for CORS has landed in WebKit - https://bugs.webkit.org/show_bug.cgi?id=61862
EventSource+CORS tested on Chrome 26
