### PR TITLE
Removed misleading note

### DIFF
--- a/features-json/pointer-events.json
+++ b/features-json/pointer-events.json
@@ -134,7 +134,7 @@
       "0":"y"
     }
   },
-  "notes":"Already part of the SVG specification, and all SVG-supporting browsers appear to support the property on SVG elements.",
+  "notes":"",
   "usage_perc_y":64.45,
   "usage_perc_a":0,
   "ucprefix":false,


### PR DESCRIPTION
The note was wrong, since Internet Explorer 9/10 implements SVG, but does not implement pointer-events for HTML.

I was sure it is implemented due to that note, until I tested my website and noticed the horror...
