### PR TITLE
Update features-json/datauri.json

### DIFF
--- a/features-json/datauri.json
+++ b/features-json/datauri.json
@@ -1,5 +1,5 @@
 {
-  "title":"Data URLs",
+  "title":"Data URIs",
   "description":"Method of embedding images and other files in webpages as a string of text",
   "spec":"http://www.ietf.org/rfc/rfc2397.txt",
   "status":"other",


### PR DESCRIPTION
Have you considered changing the title to "Data URIs"? That is the correct term. The IETF RFC appears to not care about the URI/URL distinction, but that was in 1998, and modern resources use the correct term. Nicholas Zakas even addresses this issue in [his article](http://www.nczonline.net/blog/2009/10/27/data-uris-explained/).
