### PR TITLE
Update features-json/css-gencontent.json

### DIFF
--- a/features-json/css-gencontent.json
+++ b/features-json/css-gencontent.json
@@ -16,6 +16,9 @@
   "bugs":[
     {
       "description":"Firefox currently doesn't allow :before and :after on checkbox and radio fields.\r\n"
+    },
+    {
+      "description":"WebKit (Chrome, Safari) does not support transitions on pseudo elements."
     }
   ],
   "categories":[


### PR DESCRIPTION
WebKit (Chrome, Safari) does not support transitions on pseudo elements.
