### PR TITLE
x-doc-messaging.json: MDN says min 6.0 for objects

### DIFF
--- a/features-json/x-doc-messaging.json
+++ b/features-json/x-doc-messaging.json
@@ -23,7 +23,7 @@
   ],
   "bugs":[
     {
-      "description":"Internet Explorer 8 and 9, and Firefox versions 3.6 and below only support strings as postMessage's message. Reference: http://dev.opera.com/articles/view/window-postmessage-messagechannel/#crossdoc"
+      "description":"Internet Explorer 8 and 9, and Firefox versions 6.0 and below only support strings as postMessage's message. References: http://dev.opera.com/articles/view/window-postmessage-messagechannel/#crossdoc, https://developer.mozilla.org/en-US/docs/DOM/window.postMessage"
     }
   ],
   "categories":[


### PR DESCRIPTION
Update "Cross-document messaging" (window.postMessage) to state that Firefox 6.0 is required for non-strings as data.

https://developer.mozilla.org/en-US/docs/DOM/window.postMessage:

Prior to Gecko 6.0 (Firefox 6.0 / Thunderbird 6.0 / SeaMonkey 2.3), the data parameter must be a string. Starting in Gecko 6.0 (Firefox 6.0 / Thunderbird 6.0 / SeaMonkey 2.3), the data parameter is serialized using the structured clone algorithm.
