### PR TITLE
move firefox to partial because of a known bug

### DIFF
--- a/features-json/svg-css.json
+++ b/features-json/svg-css.json
@@ -136,7 +136,7 @@
       "0":"y"
     }
   },
-  "notes":"Partial support in iOS Safari and older Safari versions refers to failing to support tiling or the background-position property.",
+  "notes":"Partial support in Firefox refers to a known bug where SVG images are blurry when scaled. Partial support in iOS Safari and older Safari versions refers to failing to support tiling or the background-position property.",
   "usage_perc_y":81.78,
   "usage_perc_a":0.19,
   "ucprefix":false,


### PR DESCRIPTION
the main use case is for SVG background images is to be scaled arbitrarily without being blurry, but that use case results in blurred images in firefox.
