### PR TITLE
IE10 Supports Number Inputs

### DIFF
--- a/features-json/input-number.json
+++ b/features-json/input-number.json
@@ -143,7 +143,7 @@
       "0":"n"
     }
   },
-  "notes":"iOS Safari, Android 4 and Chrome for Android show number input, but do not use \"step\", \"min\" or \"max\" attributes or show increment/decrement buttons.",
+  "notes":"iOS Safari, Android 4 and Chrome for Android show number input, but do not use \"step\", \"min\" or \"max\" attributes or show increment/decrement buttons. Internet Explorer 10 does not show increment/decrement buttons.",
   "usage_perc_y":37.04,
   "usage_perc_a":10.11,
   "ucprefix":false,


### PR DESCRIPTION
Their [documentation on MSDN](http://msdn.microsoft.com/en-us/library/ie/hh773064%28v=vs.85%29.aspx) isn't a superb witness to this, but the control is in the browser (sans spinners, but I see no indication these are a requirement).

You can test this various ways: 1) Retention of the "number" value for the element.type, and 2) Removal of any non-numberical characters in the element.value property.

Attributes min, max, and step are all operational: http://jsfiddle.net/sDVK4/
