### PR TITLE
Update input-number.json

### DIFF
--- a/features-json/input-number.json
+++ b/features-json/input-number.json
@@ -30,7 +30,7 @@
       "7":"n",
       "8":"n",
       "9":"n",
-      "10":"n"
+      "10":"a"
     },
     "firefox":{
       "2":"n",
@@ -143,7 +143,7 @@
       "0":"n"
     }
   },
-  "notes":"iOS Safari, Android 4 and Chrome for Android show number input, but do not use \"step\", \"min\" or \"max\" attributes or show increment/decrement buttons.",
+  "notes":"iOS Safari, Android 4 and Chrome for Android show number input, but do not use \"step\", \"min\" or \"max\" attributes or show increment/decrement buttons. IE10 does not display UI",
   "usage_perc_y":37.04,
   "usage_perc_a":10.11,
   "ucprefix":false,


### PR DESCRIPTION
This updates the references for IE10 and it's support for HTML5 number input type - see this JS Fiddle for validation: http://jsfiddle.net/sDVK4/show/ 

And here's a screenshot of the above if you don't have IE10 handy:
http://i.imgur.com/dwY2ALV.png
