### PR TITLE
Update nav-timing.json

### DIFF
--- a/features-json/nav-timing.json
+++ b/features-json/nav-timing.json
@@ -14,7 +14,9 @@
     }
   ],
   "bugs":[
-    
+    {
+      "description":"Chrome on Windows - window.performance timing is millisecond resolution."
+    }    
   ],
   "categories":[
     "DOM",


### PR DESCRIPTION
Documenting issue with Chrome on Windows platform.  window.performance only gives millisecond resolution.  Issue is documented on the chromium issue log  https://code.google.com/p/chromium/issues/detail?id=158234
