### PR TITLE
Fixed quote escaping 

### DIFF
--- a/features-json/deviceorientation.json
+++ b/features-json/deviceorientation.json
@@ -139,7 +139,7 @@
       "0":"y"
     }
   },
-  "notes":"Firefox 3.6, 4 and 5 support the non-standard <a href=\\\"https://developer.mozilla.org/en/DOM/MozOrientation\\\">MozOrientation</a> event. ",
+  "notes":"Firefox 3.6, 4 and 5 support the non-standard <a href=\"https://developer.mozilla.org/en/DOM/MozOrientation\">MozOrientation</a> event. ",
   "usage_perc_y":42.42,
   "usage_perc_a":0,
   "ucprefix":false,


### PR DESCRIPTION
Fixed escaping for the mozOrientation MDN link.

the following link: 

```
https://developer.mozilla.org/en/DOM/MozOrientation/caniuse.com
```

is rendered as: 

```
caniuse.com"https://developer.mozilla.org/en/DOM/MozOrientation/"
```
