### PR TITLE
IE10 Supports Objects, and Cross-Window Messaging

### DIFF
--- a/features-json/x-doc-messaging.json
+++ b/features-json/x-doc-messaging.json
@@ -36,7 +36,7 @@
       "7":"n",
       "8":"a",
       "9":"a",
-      "10":"a"
+      "10":"y"
     },
     "firefox":{
       "2":"n",
@@ -149,7 +149,7 @@
       "0":"y"
     }
   },
-  "notes":"Partial support in IE refers to only working in frames/iframes (not other tabs/windows). Also in IE an object cannot be sent using postMessage.",
+  "notes":"Partial support in IE refers to only working in frames/iframes (not other tabs/windows). Also in IE 9 and below an object cannot be sent using postMessage.",
   "usage_perc_y":70.2,
   "usage_perc_a":24.51,
   "ucprefix":false,


### PR DESCRIPTION
Internet Explorer 10 supports both cross-window messaging, as well as transporting objects over the wire. The following is a small demonstration of this. Once the message is passed, a stringified version of it will appear originating from the child window.
### Parent Window

``` html
<!DOCTYPE html>
<html>
  <body>
    <script>
      // Object to send
      var message = { txt: "Hello", val: 42 };
      // Reference to other window
      var child = window.open( "child.html", "popup", "width=320,height=240" );
      // After a couple of seconds
      setTimeout(function () {
        // Post the object
        child.postMessage( message, "*" );
      }, 2000);
    </script>
  </body>
</html>
```
### Child Window

``` html
<!DOCTYPE html>
<html>
  <body>
    <script>
      // Handler for our messages
      function handleMessage ( event ) {
        alert( "You sent: " + JSON.stringify(event.data) );
      }
      // Bind up a listener for the message event
      window.addEventListener( "message", handleMessage, false );
    </script>
  </body>
</html>
```
