### PR TITLE
PlaybackRate not working on stock android browser + removed old note regarding iOS

### DIFF
--- a/features-json/audio.json
+++ b/features-json/audio.json
@@ -35,10 +35,10 @@
   ],
   "bugs":[
     {
-      "description":"Audio played from the element in iOS always plays in a full screen player."
+      "description":"Firefox does not play MP3 audio because of licensing issues."
     },
     {
-      "description":"Firefox does not play MP3 audio because of licensing issues."
+      "description":"Playback rate not supported on the stock android browser"
     }
   ],
   "categories":[


### PR DESCRIPTION
I've done a lot of playbackRate-testing, and it only works partially. First off, only playbackRate works, and you have to wait until the audio is actually playing before setting it.

I can't recognize the note regarding audio elements on iOS, so I have removed it. (I am working with audio on this platform every day and haven't noticed anything like it.)
