### PR TITLE
Mozilla's Opus codec

### DIFF
--- a/features-json/opus.json
+++ b/features-json/opus.json
@@ -140,7 +140,7 @@
       "0":"n"
     }
   },
-  "notes":"Chrome does not support Opus by default but users can enable it by turn on 'enable-opus-playback' option in chrome://flags page. When it comes to Opera, It is said that the Linux version may be able to play it when the GStreamer module is up to date and the served mime-type is 'audio/ogg'.",
+  "notes":"Chrome does not support Opus by default but users can enable it via the 'enable-opus-playback' flag. When it comes to Opera, It is said that the Linux version may be able to play it when the GStreamer module is up to date and the served mime-type is 'audio/ogg'.",
   "usage_perc_y":0,
   "usage_perc_a":0,
   "ucprefix":false,


### PR DESCRIPTION
Opus audio codec is supported since Firefox 15, and is being introduced as the codec which provides the highest quality and lowest latency with the same bitrate as of today.

Google proposed this codec as the standard audio codec for WebRTC, and Chrome does support it but with '--enable-opus-playback' parameter.
http://www.ietf.org/mail-archive/web/rtcweb/current/msg04953.html
http://code.google.com/p/chromium/issues/detail?id=104241
