### PR TITLE
Add second option for Firefox Add-on polyfill

### DIFF
--- a/features-json/ruby.json
+++ b/features-json/ruby.json
@@ -9,8 +9,12 @@
       "title":"HTML5 Doctor article"
     },
     {
-      "url":"https://addons.mozilla.org/en-US/firefox/addon/1935/",
-      "title":"Add-on for support in Firefox"
+      "url":"https://addons.mozilla.org/firefox/addon/1935/",
+      "title":"Add-on &#34;XHTML Ruby Support&#34; for Firefox"
+    },
+    {
+      "url":"https://addons.mozilla.org/firefox/addon/6812/"
+      "title":"Addon &#34;HTML Ruby&#34; for Firefox support"
     },
     {
       "url":"http://docs.webplatform.org/wiki/html/elements/ruby",


### PR DESCRIPTION
Add second option for Firefox Add-on polyfill, and changed link text to indicate the add-on's name(s).
Also removed locale string from Firefox Add-on link(s), so Mozilla's site will auto-detect the browser's language/locale.
