### PR TITLE
Removed the (now duplicate) locale specific link to "XHTML Ruby Support"

### DIFF
--- a/features-json/ruby.json
+++ b/features-json/ruby.json
@@ -17,10 +17,6 @@
       "title":"HTML5 Doctor article"
     },
     {
-      "url":"https://addons.mozilla.org/en-US/firefox/addon/1935/",
-      "title":"Add-on for support in Firefox"
-    },
-    {
       "url":"http://docs.webplatform.org/wiki/html/elements/ruby",
       "title":"WebPlatform Docs"
     }


### PR DESCRIPTION
When you added the new link without the /en-us your data updating system missed the removal of the link that has it.

Thanks for all the work you put into CanIuse.com it's a very helpful site.
