### PR TITLE
Downgrade IE8's support of CSS Generated Content

### DIFF
--- a/features-json/css-gencontent.json
+++ b/features-json/css-gencontent.json
@@ -23,14 +23,14 @@
     }
   ],
   "categories":[
-    "CSS2"
+    "CSS2", "CSS3"
   ],
   "stats":{
     "ie":{
       "5.5":"n",
       "6":"n",
       "7":"n",
-      "8":"y",
+      "8":"a",
       "9":"y",
       "10":"y",
       "11":"y"
@@ -149,7 +149,7 @@
       "0":"y"
     }
   },
-  "notes":"",
+  "notes":"IE8 only supports the single-colon CSS 2.1 syntax (i.e. pseudo-class). It does not support the double-colon CSS3 syntax (i.e. pseudo-element)",
   "usage_perc_y":94.93,
   "usage_perc_a":0,
   "ucprefix":false,


### PR DESCRIPTION
IE8 only supports the CSS 2.1 syntax (`:before` and `:after`). It does not support the CSS 3 syntax (`::before` and `::after`). Other browsers support both for backwards compatibility. The CSS 2.1 syntax is restricted only to pseudo-elements that existed in the 2.1 spec. Future (including all CSS3-introduced) pseudo-elements are restricted to the double-colon syntax exclusively.

The syntax change was introduced to clearly distinguish _pseudo-elements_ (double-colon) from _pseudo-classes_ (single-colon).
