### PR TITLE
Set Safari 6 to partial support for bg img options.

### DIFF
--- a/features-json/background-img-opts.json
+++ b/features-json/background-img-opts.json
@@ -98,7 +98,7 @@
       "4":"a",
       "5":"y",
       "5.1":"y",
-      "6":"y"
+      "6":"a"
     },
     "opera":{
       "9":"n",
@@ -152,7 +152,7 @@
       "0":"y"
     }
   },
-  "notes":"Partial support in Opera Mini refers to not supporting background sizing or background attachments.",
+  "notes":"Partial support in Opera Mini refers to not supporting background sizing or background attachments. Partial support in Safari 6 refers to not supporting background sizing offset from edges syntax.",
   "usage_perc_y":83.98,
   "usage_perc_a":2.66,
   "ucprefix":false,


### PR DESCRIPTION
I updated Safari 6 to have partial support because it does not support the background sizing offset from edges syntax.

Test case: http://codepen.io/foiseworth/details/BAGjs#pen-details-tab

In Chrome, the logo appears in the bottom right (with a 20px offset from bottom and side) but in Safari it appears in top left and web inspector states the property is invalid.
