### PR TITLE
"types", rather than "tyles"

### DIFF
--- a/features-json/input-datetime.json
+++ b/features-json/input-datetime.json
@@ -152,7 +152,7 @@
       "0":"n"
     }
   },
-  "notes":"Safari provides date-formatted text fields, but no real calendar widget. Partial support in Chrome refers to a missing calendar widget for the \"datetime\" type (and other tyles in older versions). Some modified versions of the Android 4.x browser do have support for date/time fields. ",
+  "notes":"Safari provides date-formatted text fields, but no real calendar widget. Partial support in Chrome refers to a missing calendar widget for the \"datetime\" type (and other types in older versions). Some modified versions of the Android 4.x browser do have support for date/time fields. ",
   "usage_perc_y":8.16,
   "usage_perc_a":32.1,
   "ucprefix":false,


### PR DESCRIPTION
This is just a simple typo
