### PR TITLE
Updated pointer events title

### DIFF
--- a/features-json/pointer.json
+++ b/features-json/pointer.json
@@ -1,5 +1,5 @@
 {
-  "title":"Pointer events",
+  "title":"Javascript Pointer events",
   "description":"This specification integrates various inputs from mice, touchscreens, and pens, making separate implementations no longer necessary and authoring for cross-device pointers easier.",
   "spec":"http://www.w3.org/TR/pointerevents/",
   "status":"cr",


### PR DESCRIPTION
I was a bit confused when I saw the new pointer events, until I realized these were the not pointer-events.
Since we are specifying "CSS pointer-events (for HTML)", I thought we should do the same here and say "Javascript Pointer events"
