### PR TITLE
No partial support for Touch event in IE10/11 but a polyfill using Point...

### DIFF
--- a/features-json/touch.json
+++ b/features-json/touch.json
@@ -20,9 +20,6 @@
   "bugs":[
     {
       "description":"Beware, android 2.3 and below do not detect multiple touches."
-    },
-    {
-      "description":"Firefox 4 & 5 support a <a href=\"https://hacks.mozilla.org/2010/08/firefox4-beta3/\">non-standard</a> implementation to achieve the same."
     }
   ],
   "categories":[
@@ -36,8 +33,8 @@
       "7":"n",
       "8":"n",
       "9":"n",
-      "10":"a",
-      "11":"a"
+      "10":"p",
+      "11":"p"
     },
     "firefox":{
       "2":"n",
@@ -154,7 +151,7 @@
       "0":"y"
     }
   },
-  "notes":"Partial support in IE10 refers to using \"<a href=\"http://msdn.microsoft.com/en-us/ie/hh272903.aspx#_DOMTouch\">Pointer events</a>\".",
+  "notes":"Firefox 4 & 5 support a <a href=\"https://hacks.mozilla.org/2010/08/firefox4-beta3/\">non-standard</a> implementation to achieve the same. Internet Explorer implements Pointer Events specification which supports more input devices than Touch Events one.",
   "usage_perc_y":61.63,
   "usage_perc_a":7.69,
   "ucprefix":false,


### PR DESCRIPTION
...er events

Touch events never work by itself in IE, so we cannot consider IE as partially supported.
Additionally I moved some items from `bug` to `notes` as they are not bugs really...
