### PR TITLE
Update info for Firefox support

### DIFF
--- a/features-json/deviceorientation.json
+++ b/features-json/deviceorientation.json
@@ -14,7 +14,7 @@
     }
   ],
   "bugs":[
-    
+
   ],
   "categories":[
     "JS API"
@@ -36,24 +36,24 @@
       "3.6":"n",
       "4":"n",
       "5":"n",
-      "6":"n",
-      "7":"n",
-      "8":"n",
-      "9":"n",
-      "10":"n",
-      "11":"n",
-      "12":"n",
-      "13":"n",
-      "14":"n",
-      "15":"n",
-      "16":"n",
-      "17":"n",
-      "18":"n",
-      "19":"n",
-      "20":"n",
-      "21":"n",
-      "22":"n",
-      "23":"n"
+      "6":"y",
+      "7":"y",
+      "8":"y",
+      "9":"y",
+      "10":"y",
+      "11":"y",
+      "12":"y",
+      "13":"y",
+      "14":"y",
+      "15":"y",
+      "16":"y",
+      "17":"y",
+      "18":"y",
+      "19":"y",
+      "20":"y",
+      "21":"y",
+      "22":"y",
+      "23":"y"
     },
     "chrome":{
       "4":"n",
@@ -144,7 +144,7 @@
       "0":"y"
     }
   },
-  "notes":"Firefox 3.6, 4 and 5 support the non-standard <a href=\"https://developer.mozilla.org/en/DOM/MozOrientation\">MozOrientation</a> event. ",
+  "notes":"Firefox 3.6, 4 and 5 support the non-standard <a href=\"https://developer.mozilla.org/en/DOM/MozOrientation\">MozOrientation</a> event. <br/>Firefox and Chrome doesn't handle the orientation angles the same ways.",
   "usage_perc_y":43.52,
   "usage_perc_a":0,
   "ucprefix":false,


### PR DESCRIPTION
Firefox actually support deviceorientation events since FF6. However there is some inconsistency between Firefox and Chrome. This pull request add those information.
