### PR TITLE
Mark BB10 IndexedDB support as partial

### DIFF
--- a/features-json/indexeddb.json
+++ b/features-json/indexeddb.json
@@ -154,7 +154,7 @@
       "0":"y"
     }
   },
-  "notes":"",
+  "notes":"Partial support in BB10 refers to an <a href=\"http://www.w3.org/TR/2011/WD-IndexedDB-20110419/\">outdated specification</a> being implemented. Code targeting the <a href=\"http://www.w3.org/TR/IndexedDB/\">current state of the specification</a> might not work.",
   "usage_perc_y":55.87,
   "usage_perc_a":3.18,
   "ucprefix":false,


### PR DESCRIPTION
BB10 has an outdated IndexedDB implementation following the spec from April 2011 (http://www.w3.org/TR/2011/WD-IndexedDB-20110419/).

As the current spec differs in regards of transaction types and versioning, and code working with up-to-date implementations doesn't work on BB10, it would be cool to have BB10 support marked as partial. Even if it's just a heads-up for developers that their code might not work on a BB10.

As reference, see this example code from RIM: https://github.com/grahamzibar/Folio/blob/master/folio/db/Indexed.js
