### PR TITLE
Update xhr timeout support bug.

### DIFF
--- a/features-json/xhr2.json
+++ b/features-json/xhr2.json
@@ -23,7 +23,7 @@
   ],
   "bugs":[
     {
-      "description":"In both Firefox 9 and Chrome 16, xhr.timeout and xhr.ontimeout don't appear to be supported."
+      "description":"xhr.timeout and xhr.ontimeout are supported in Chrome 29+ and Firefox 12+."
     }
   ],
   "categories":[


### PR DESCRIPTION
Chrome supports it since M29:
  https://code.google.com/p/chromium/issues/detail?id=231959
Firefox supports it since M12:
  https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest#Browser_Compatibility

You can test it in Chrome 29.0.1541.0 canary.
