### PR TITLE
Update workers.

### DIFF
--- a/features-json/sharedworkers.json
+++ b/features-json/sharedworkers.json
@@ -2,19 +2,15 @@
   "title":"Shared Web Workers",
   "description":"Method of allowing multiple scripts to communicate with a single web worker.",
   "spec":"http://www.w3.org/TR/workers/#shared-workers-introduction",
-  "status":"wd",
+  "status":"cr",
   "links":[
     {
       "url":"http://greenido.wordpress.com/2011/11/03/web-workers-part-3-out-of-3-shared-wrokers/",
       "title":"Blog post"
     },
     {
-      "url":"https://raw.github.com/phiggins42/has.js/master/detect/features.js#native-sharedworker",
-      "title":"has.js test"
-    },
-    {
       "url":"http://www.sitepoint.com/javascript-shared-web-workers-html5/",
-      "title":"Sitepoint article"
+      "title":"SitePoint article"
     }
   ],
   "bugs":[
@@ -56,8 +52,8 @@
       "19":"n",
       "20":"n",
       "21":"n",
-      "22":"u",
-      "23":"u"
+      "22":"n",
+      "23":"n"
     },
     "chrome":{
       "4":"y",

--- a/features-json/webworkers.json
+++ b/features-json/webworkers.json
@@ -1,11 +1,11 @@
 {
   "title":"Web Workers",
   "description":"Method of running scripts in the background, isolated from the web page",
-  "spec":"http://www.whatwg.org/specs/web-workers/current-work/",
-  "status":"wd",
+  "spec":"http://www.w3.org/TR/workers/",
+  "status":"cr",
   "links":[
     {
-      "url":"http://code.google.com/p/ie-web-worker/",
+      "url":"https://code.google.com/p/ie-web-worker/",
       "title":"Polyfill for IE (single threaded)"
     },
     {
@@ -13,12 +13,8 @@
       "title":"Web Worker demo"
     },
     {
-      "url":"https://developer.mozilla.org/En/Using_web_workers",
+      "url":"https://developer.mozilla.org/en-US/docs/Web/Guide/Performance/Using_web_workers",
       "title":"MDN article"
-    },
-    {
-      "url":"https://raw.github.com/phiggins42/has.js/master/detect/features.js#native-worker",
-      "title":"has.js test"
     },
     {
       "url":"http://net.tutsplus.com/tutorials/javascript-ajax/getting-started-with-web-workers/",


### PR DESCRIPTION
- Upgraded to candidate recommendation.
- Changed the spec url to the w3.org one as we use it to check the status.
- Removed the has.js urls, IMHO they didn't add any real value, `return ("Worker" in g)` isn't a groundbreaking test.
- Some updated urls and other nitpicks.
