### PR TITLE
Update webgl.json

### DIFF
--- a/features-json/webgl.json
+++ b/features-json/webgl.json
@@ -154,13 +154,13 @@
       "14":"y"
     },
     "and_chr":{
-      "0":"a"
+      "0":"n"
     },
     "and_ff":{
       "0":"y"
     }
   },
-  "notes":"Support listed as \"partial\" refers to the fact that not all users with these browsers have WebGL access. This is due to the additional requirement for users to have <a href=\"http://blog.mozilla.com/bjacob/2011/03/28/do-users-actually-get-hardware-acceleration/\">up to date video drivers</a>. This problem was <a href=\"http://www.geek.com/articles/news/chrome-18-adds-gpu-acceleration-and-swiftshader-for-better-gaming-performance-20120329/\">solved in Chrome</a> as of version 18.\r\n\r\nNote that WebGL is part of the <a href=\"http://www.khronos.org/webgl/\">Khronos Group</a>, not the W3C. Partial support on Chrome for Android means being disabled by default, but can be enabled by enabling the \"Enable WebGL\" flag under chrome://flags",
+  "notes":"Support listed as \"partial\" refers to the fact that not all users with these browsers have WebGL access. This is due to the additional requirement for users to have <a href=\"http://blog.mozilla.com/bjacob/2011/03/28/do-users-actually-get-hardware-acceleration/\">up to date video drivers</a>. This problem was <a href=\"http://www.geek.com/articles/news/chrome-18-adds-gpu-acceleration-and-swiftshader-for-better-gaming-performance-20120329/\">solved in Chrome</a> as of version 18.\r\n\r\nNote that WebGL is part of the <a href=\"http://www.khronos.org/webgl/\">Khronos Group</a>, not the W3C. On Chrome for Android, WebGL is disabled by default, but can be enabled by enabling the \"Enable WebGL\" flag under chrome://flags",
   "usage_perc_y":33.97,
   "usage_perc_a":21.54,
   "ucprefix":false,


### PR DESCRIPTION
WebGL is supported on Chrome for Android since 25 by enabling "Enable WebGL" flag in chrome://flags
