### PR TITLE
Update css-hyphens's notes about chrome 30

### DIFF
--- a/features-json/css-hyphens.json
+++ b/features-json/css-hyphens.json
@@ -153,7 +153,7 @@
       "0":"y x"
     }
   },
-  "notes":"Chrome and Android 4.0 Browser support \"-webkit-hyphens: none\", but not the \"auto\" property.",
+  "notes":"Chrome 29- and Android 4.0 Browser support \"-webkit-hyphens: none\", but not the \"auto\" property. Chrome 30+ doesn't support it too.",
   "usage_perc_y":35.28,
   "usage_perc_a":0,
   "ucprefix":false,


### PR DESCRIPTION
In Blink, -webkit-hyphens's implementation is removed. It can confirm in Chromium 30.0.1584.0 (215055).
https://src.chromium.org/viewvc/blink?revision=155171&view=revision
