### PR TITLE
Add ::placeholder data

### DIFF
--- a/features-json/css-placeholder.json
+++ b/features-json/css-placeholder.json
@@ -1,0 +1,161 @@
+{
+  "title":"::placeholder CSS psuedo-element",
+  "description":"The ::placeholder psuedo-element represents any form element displaying placeholder text.",
+  "spec":"https://developer.mozilla.org/en-US/docs/Web/CSS/::-moz-placeholder",
+  "status":"unoff",
+  "links":[
+    {
+      "url":"http://msdn.microsoft.com/en-us/library/ie/hh772745(v=vs.85).aspx",
+      "title":"MSDN article"
+    },
+    {
+      "url":"http://css-tricks.com/snippets/css/style-placeholder-text/",
+      "title":"CSS-Tricks article with all prefixes"
+    },
+    {
+      "url":"http://wiki.csswg.org/ideas/placeholder-styling",
+      "title":"CSSWG discussion"
+    }
+  ],
+  "bugs":[
+  ],
+  "categories":[
+    "CSS"
+  ],
+  "stats":{
+    "ie":{
+      "5.5":"n",
+      "6":"n",
+      "7":"n",
+      "8":"n",
+      "9":"y",
+      "10":"y x",
+      "11":"y x"
+    },
+    "firefox":{
+      "2":"n",
+      "3":"n",
+      "3.5":"n",
+      "3.6":"n",
+      "4":"y x",
+      "5":"y x",
+      "6":"y x",
+      "7":"y x",
+      "8":"y x",
+      "9":"y x",
+      "10":"y x",
+      "11":"y x",
+      "12":"y x",
+      "13":"y x",
+      "14":"y x",
+      "15":"y x",
+      "16":"y x",
+      "17":"y x",
+      "18":"y x",
+      "19":"y x",
+      "20":"y x",
+      "21":"y x",
+      "22":"y x",
+      "23":"y x",
+      "24":"y x"
+    },
+    "chrome":{
+      "4":"y x",
+      "5":"y x",
+      "6":"y x",
+      "7":"y x",
+      "8":"y x",
+      "9":"y x",
+      "10":"y x",
+      "11":"y x",
+      "12":"y x",
+      "13":"y x",
+      "14":"y x",
+      "15":"y x",
+      "16":"y x",
+      "17":"y x",
+      "18":"y x",
+      "19":"y x",
+      "20":"y x",
+      "21":"y x",
+      "22":"y x",
+      "23":"y x",
+      "24":"y x",
+      "25":"y x",
+      "26":"y x",
+      "27":"y x",
+      "28":"y x",
+      "29":"y x",
+      "30":"y x"
+    },
+    "safari":{
+      "3.1":"n",
+      "3.2":"n",
+      "4":"n",
+      "5":"y x",
+      "5.1":"y x",
+      "6":"y x",
+      "7":"y x"
+    },
+    "opera":{
+      "9":"n",
+      "9.5-9.6":"n",
+      "10.0-10.1":"n",
+      "10.5":"n",
+      "10.6":"n",
+      "11":"n",
+      "11.1":"n",
+      "11.5":"n",
+      "11.6":"n",
+      "12":"n",
+      "12.1":"n",
+      "15":"y x"
+    },
+    "ios_saf":{
+      "3.2":"u",
+      "4.0-4.1":"u",
+      "4.2-4.3":"u",
+      "5.0-5.1":"u",
+      "6.0-6.1":"u",
+      "7.0":"u"
+    },
+    "op_mini":{
+      "5.0-7.0":"n"
+    },
+    "android":{
+      "2.1":"u",
+      "2.2":"u",
+      "2.3":"u",
+      "3":"u",
+      "4":"u",
+      "4.1":"u",
+      "4.2":"u"
+    },
+    "bb":{
+      "7":"u",
+      "10":"u"
+    },
+    "op_mob":{
+      "10":"n",
+      "11":"n",
+      "11.1":"n",
+      "11.5":"n",
+      "12":"n",
+      "12.1":"n",
+      "14":"y x"
+    },
+    "and_chr":{
+      "0":"y x"
+    },
+    "and_ff":{
+      "0":"n"
+    }
+  },
+  "notes":"",
+  "usage_perc_y":54.13,
+  "usage_perc_a":0.79,
+  "ucprefix":false,
+  "parent":"",
+  "keywords":"::placeholder,placeholder",
+  "shown":false
+}


### PR DESCRIPTION
Selector is a [candidate](http://wiki.csswg.org/spec/css4-ui#more-selectors) for CSS 4 selectors, is supported by all major browsers (Opera doesn’t support it until 15 version) and is very often used.

Filled the data accordingly to [post](http://blog.teamtreehouse.com/the-css3-placeholder-pseudo-element) and [stackoverflow](http://stackoverflow.com/questions/2610497/change-an-inputs-html5-placeholder-color-with-css).
