### PR TITLE
Remove unreferenced note.

### DIFF
--- a/features-json/css-grid.json
+++ b/features-json/css-grid.json
@@ -157,7 +157,6 @@
       "0":"n"
     }
   },
-  "notes":"Reported to be supported in Chrome 27.",
   "usage_perc_y":9.19,
   "usage_perc_a":0,
   "ucprefix":false,


### PR DESCRIPTION
Webkit still hasn't implemented the feature, so chrome can't have either.
