### PR TITLE
Included reference to a WebP polyfill for browsers with or without WebM support 

### DIFF
--- a/features-json/webp.json
+++ b/features-json/webp.json
@@ -12,6 +12,10 @@
       "url":"http://antimatter15.github.io/weppy/demo.html",
       "title":"Polyfill for browsers with WebM support"
     },
+    { "url": "http://webpjs.appspot.com/",
+      "title": "Polyfill for browsers with or without WebM support (i.e. IE6-IE9, Safari/iOS version 6.1 and below; Firefox versions 24 and below; and so on)." 
+      
+    },
     {
       "url":"https://developers.google.com/speed/webp/",
       "title":"Official website"


### PR DESCRIPTION
Provided reference to a WebP polyfill that's more all-encompassing in function; this particular polyfill enables support of the image format for browsers that currently do not support WebP with or without WebM/VP8 support.
