### PR TITLE
Correct spelling of "pseudo" in two features

### DIFF
--- a/features-json/css-placeholder.json
+++ b/features-json/css-placeholder.json
@@ -1,6 +1,6 @@
 {
-  "title":"::placeholder CSS psuedo-element",
-  "description":"The ::placeholder psuedo-element represents any form element displaying placeholder text.",
+  "title":"::placeholder CSS pseudo-element",
+  "description":"The ::placeholder pseudo-element represents any form element displaying placeholder text.",
   "spec":"https://developer.mozilla.org/en-US/docs/Web/CSS/::-moz-placeholder",
   "status":"unoff",
   "links":[

--- a/features-json/css-selection.json
+++ b/features-json/css-selection.json
@@ -1,5 +1,5 @@
 {
-  "title":"::selection CSS psuedo-element",
+  "title":"::selection CSS pseudo-element",
   "description":"The ::selection CSS pseudo-element applies rules to the portion of a document that has been highlighted (e.g., selected with the mouse or another pointing device) by the user.",
   "spec":"https://developer.mozilla.org/en-US/docs/Web/CSS/::selection",
   "status":"unoff",


### PR DESCRIPTION
A couple of features contain a typo "psuedo" in their titles and descriptions.
