### PR TITLE
SVG-CSS on Firefox is fixed for 24 and above

### DIFF
--- a/features-json/svg-css.json
+++ b/features-json/svg-css.json
@@ -56,8 +56,8 @@
       "21":"a",
       "22":"a",
       "23":"a",
-      "24":"a",
-      "25":"a"
+      "24":"y",
+      "25":"y"
     },
     "chrome":{
       "4":"a",
@@ -152,7 +152,7 @@
       "0":"y"
     }
   },
-  "notes":"Partial support in Firefox refers to a known bug where SVG images are blurry when scaled. Partial support in iOS Safari and older Safari versions refers to failing to support tiling or the background-position property.",
+  "notes":"Partial support in Firefox refers to a known bug where SVG images are blurry when scaled, fixed in Firefox 24. Partial support in iOS Safari and older Safari versions refers to failing to support tiling or the background-position property.",
   "usage_perc_y":68.36,
   "usage_perc_a":16.26,
   "ucprefix":false,


### PR DESCRIPTION
Firefox version 24 and later already fixed the blurriness, see https://bugzilla.mozilla.org/show_bug.cgi?id=600207
