### PR TITLE
Updated background-size polyfill description

### DIFF
--- a/features-json/background-img-opts.json
+++ b/features-json/background-img-opts.json
@@ -14,7 +14,7 @@
     },
     {
       "url":"https://github.com/louisremi/background-size-polyfill",
-      "title":"jQuery polyfill for IE6-8"
+      "title":"Polyfill for IE7-8"
     }
   ],
   "bugs":[


### PR DESCRIPTION
Polyfill doesn't depend on jQuery, doesn't work in IE6
