### PR TITLE
Update deviceorientation's notes about chrome 31

### DIFF
--- a/features-json/deviceorientation.json
+++ b/features-json/deviceorientation.json
@@ -167,7 +167,7 @@
       "10":"n"
     }
   },
-  "notes":"Partial support refers to the lack of compassneedscalibration event. Partial support also refers to the lack of devicemotion event support for Chrome and Opera. Opera Mobile 14 lost the ondevicemotion event support. Firefox 3.6, 4 and 5 support the non-standard <a href=\"https://developer.mozilla.org/en/DOM/MozOrientation\">MozOrientation</a> event.",
+  "notes":"Partial support refers to the lack of compassneedscalibration event. Partial support also refers to the lack of devicemotion event support for Chrome 30- and Opera. Opera Mobile 14 lost the ondevicemotion event support. Firefox 3.6, 4 and 5 support the non-standard <a href=\"https://developer.mozilla.org/en/DOM/MozOrientation\">MozOrientation</a> event.",
   "usage_perc_y":0.08,
   "usage_perc_a":62.33,
   "ucprefix":false,


### PR DESCRIPTION
Chromium/Blink supports the devicemotion event. It's available in Chromium 31.0.1639.0 (224567).
https://src.chromium.org/viewvc/blink?revision=158031&view=revision
https://src.chromium.org/viewvc/chrome?revision=224164&view=revision
