### PR TITLE
Update canvas.json

### DIFF
--- a/features-json/canvas.json
+++ b/features-json/canvas.json
@@ -144,9 +144,9 @@
       "5.0-7.0":"a"
     },
     "android":{
-      "2.1":"y",
-      "2.2":"y",
-      "2.3":"y",
+      "2.1":"a",
+      "2.2":"a",
+      "2.3":"a",
       "3":"y",
       "4":"y",
       "4.1":"y",
@@ -175,7 +175,7 @@
       "10":"y"
     }
   },
-  "notes":"Opera Mini supports the canvas element, but is unable to play animations or run other more complex applications.",
+  "notes":"Opera Mini supports the canvas element, but is unable to play animations or run other more complex applications. Android 2.x supports canvas except the toDataURL() function. See http://code.google.com/p/android/issues/detail?id=7901 Some (slow) workarounds are described here: http://stackoverflow.com/q/10488033/841830",
   "usage_perc_y":83.87,
   "usage_perc_a":2.81,
   "ucprefix":false,


### PR DESCRIPTION
Android 2.x doesn't support toDataURL(), so I've downgraded it to partial support. (This is a critical function for some categories of canvas applications.)
