### PR TITLE
Firefox doesn't support the multi-line attributes, flex-wrap & align-con...

### DIFF
--- a/features-json/flexbox.json
+++ b/features-json/flexbox.json
@@ -23,7 +23,8 @@
   ],
   "bugs":[
     {
-      "description":"Firefox does not support specifying widths in percentages. <a href=\"https://bugzilla.mozilla.org/show_bug.cgi?id=529761\">See bug</a>."
+      "description":"Firefox does not support specifying widths in percentages. <a href=\"https://bugzilla.mozilla.org/show_bug.cgi?id=529761\">See bug</a>.",
+      "description":"Firefox does not support flex-wrap, align-content properties. <a href=\"https://bugzilla.mozilla.org/show_bug.cgi?id=702508\">See bug</a>."
     }
   ],
   "categories":[


### PR DESCRIPTION
The multi-line support (or lack of) in Firefox really caught me out, lots of the demos fall apart in Firefox due to this, so I think it's worth including as a bug. I included the bug tracker link.
