### PR TITLE
History.js has moved to a community repository

### DIFF
--- a/features-json/history.json
+++ b/features-json/history.json
@@ -25,7 +25,7 @@
       "title":"MDN article"
     },
     {
-      "url":"https://github.com/balupton/history.js",
+      "url":"https://github.com/browserstate/history.js",
       "title":"History.js polyfill "
     }
   ],


### PR DESCRIPTION
https://github.com/balupton/History.js moved to https://github.com/browserstate/history.js about 7 months ago.

see: https://github.com/balupton/history.js/commit/3731c74129821181d6760948e00c4853c83b2ba4
