### PR TITLE
cleaned up confusing wording for transition bugs

### DIFF
--- a/features-json/css-transitions.json
+++ b/features-json/css-transitions.json
@@ -27,7 +27,7 @@
   ],
   "bugs":[
     {
-      "description":"Only supported on ::before and ::after pseudo-elements for Firefox, Chrome 26+ and IE10+."
+      "description":"Not supported on any pseudo-elements besides ::before and ::after for Firefox, Chrome 26+ and IE10+."
     },
     {
       "description":"WebKit computes \"auto\" as 0 in transitions, so transitions of width between auto and 800px shrinks the element first and then widens it to 800px."


### PR DESCRIPTION
I first read this as if ::before and ::after pseudo-elements were the only elements you could use it on, which doesn't make sense.
