### PR TITLE
Clarify and update Web Audio API note regarding Firefox.

### DIFF
--- a/features-json/audio-api.json
+++ b/features-json/audio-api.json
@@ -161,7 +161,7 @@
       "10":"n"
     }
   },
-  "notes":"Currently Firefox supports an alternative, deprecated audio API, with support for the Web Audio API <a href=\"https://wiki.mozilla.org/Web_Audio_API\">being planned</a>.",
+  "notes":"Older Firefox versions support an alternative, deprecated audio API, with support for the cross browser Web Audio API available from version 25 on.",
   "usage_perc_y":0,
   "usage_perc_a":43.25,
   "ucprefix":false,


### PR DESCRIPTION
The wording is a bit outdated and may confuse users when they look at the table (with the "correct" support coming up in the next release within the next month). 
