### PR TITLE
Adding data for WebVTT support

### DIFF
--- a/features-json/webvtt.json
+++ b/features-json/webvtt.json
@@ -10,7 +10,8 @@
     },
     {
       "url":"http://dev.opera.com/articles/view/an-introduction-to-webvtt-and-track/",
-      "title": "An Introduction to WebVTT and <track>"    
+      "title": "An Introduction to WebVTT and <track>"
+    }
   ],
   "bugs":[
 
@@ -25,7 +26,7 @@
       "7":"n",
       "8":"n",
       "9":"n",
-      "10":"y"
+      "10":"y",
       "11":"y"    
     },
     "firefox":{


### PR DESCRIPTION
Still needs data for Android's native browser, Blackberry browsers, and versions of Chrome for Android < 30.
