### PR TITLE
Workaround for className on SVG elements on WebKit.

### DIFF
--- a/features-json/svg-html5.json
+++ b/features-json/svg-html5.json
@@ -15,7 +15,7 @@
   ],
   "bugs":[
     {
-      "description":"Inline SVG in HTML works in Android 4+, but is reported to have bugs when manipulating the elements using JS, e.g. setting className does not work."
+      "description":"Inline SVG in HTML works in Android 4+, but is reported to have bugs when manipulating the elements using JS, e.g. setting className does not work. Using getAttribute('class') and setAttribute('class', 'foobar') works."
     }
   ],
   "categories":[


### PR DESCRIPTION
See this commit for details:
https://github.com/denilsonsa/classList.js/commit/87e93c2178563d840554a42113dedafb567df838
