### PR TITLE
Removing link to SVG classlist polyfill

### DIFF
--- a/features-json/classlist.json
+++ b/features-json/classlist.json
@@ -9,10 +9,6 @@
       "title":"Mozilla Hacks article"
     },
     {
-      "url":"https://github.com/eligrey/classList.js/pull/12",
-      "title":"Polyfill script for classList on SVG elements on WebKit"
-    },
-    {
       "url":"https://github.com/eligrey/classList.js",
       "title":"Polyfill script"
     },


### PR DESCRIPTION
The SVG classList polyfill script has been merged into the classList script.
https://github.com/eligrey/classList.js/commit/0e3f8635bbc034e2f47c0abcb512d1072d69a79b
https://github.com/eligrey/classList.js/pull/15
