### PR TITLE
Added bug notes regarding incompatibilities between the Web Audio API and getUserMedia

### DIFF
--- a/features-json/audio-api.json
+++ b/features-json/audio-api.json
@@ -22,7 +22,9 @@
     }
   ],
   "bugs":[
-    
+    {
+      "description":"Chrome for Android does not support the Web Audio API in conjunction with getUserMedia."
+    }
   ],
   "categories":[
     "JS API"
@@ -175,6 +177,6 @@
   "usage_perc_a":0,
   "ucprefix":false,
   "parent":"",
-  "keywords":"web-audio",
+  "keywords":"web-audio,webaudio",
   "shown":true
 }

--- a/features-json/stream.json
+++ b/features-json/stream.json
@@ -14,7 +14,9 @@
     }
   ],
   "bugs":[
-    
+    {
+      "description":"Chrome for Android does not support getUserMedia in conjunction with the Web Audio API."
+    }
   ],
   "categories":[
     "HTML5",


### PR DESCRIPTION
Added bug notes regarding incompatibilities between the Web Audio API and getUserMedia.  Added `webaudio` as a keyword for the Web Audio API.
