### PR TITLE
Update css-gencontent.json

### DIFF
--- a/features-json/css-gencontent.json
+++ b/features-json/css-gencontent.json
@@ -19,7 +19,7 @@
   ],
   "bugs":[
     {
-      "description":"Chrome supports CSS transitions on generated content as of v. 26. Safari does not support transitions or animations on pseudo elements as of v. 6."
+      "description":"Chrome supports CSS transitions on generated content as of v. 26. Safari v6 and below do not support transitions or animations on pseudo elements."
     }
   ],
   "categories":[


### PR DESCRIPTION
Safari added support for pseudo element transitions/animations starting with v7 and iOS 7.
