### PR TITLE
Updated CSP header usage for different browsers

### DIFF
--- a/features-json/contentsecuritypolicy.json
+++ b/features-json/contentsecuritypolicy.json
@@ -167,7 +167,7 @@
       "10":"a x"
     }
   },
-  "notes":"The HTTP header is 'X-Content-Security-Policy' for Firefox and IE 10&11, and 'X-WebKit-CSP' for Safari and Chrome. IE 10&11's support is limited to the 'sandbox' directive.",
+  "notes":"The HTTP header is 'X-Content-Security-Policy' for Firefox until version 23 and IE10&11, and 'X-Webkit-CSP' for Chrome until version 25 and Safari. 'Content-Security-Policy' is the official W3C defined header, used by Chrome version 25 and later, and Firefox version 23 and later.",
   "usage_perc_y":55.74,
   "usage_perc_a":12.68,
   "ucprefix":false,


### PR DESCRIPTION
Make it consistent with https://www.owasp.org/index.php/Content_Security_Policy
