### PR TITLE
Added IE11-related known issue.

### DIFF
--- a/features-json/transforms2d.json
+++ b/features-json/transforms2d.json
@@ -36,6 +36,9 @@
   "bugs":[
     {
       "description":"Scaling transforms in Android 2.3 fails to scale element background images."
+    },
+    {
+      "description":"IE doesn't support CSS transforms on SVG elements (version 11 or prior)."
     }
   ],
   "categories":[


### PR DESCRIPTION
Added known issue note re: IE's continuing lack of support for CSS transforms of SVG elements.
