### PR TITLE
Updated webplatform drag event reference url

### DIFF
--- a/features-json/dragndrop.json
+++ b/features-json/dragndrop.json
@@ -9,7 +9,7 @@
       "title":"Demo with link blocks"
     },
     {
-      "url":"http://docs.webplatform.org/wiki/dom/events/drag",
+      "url":"http://docs.webplatform.org/wiki/dom/DragEvent",
       "title":"WebPlatform Docs"
     },
     {


### PR DESCRIPTION
URL for drag events has been updated on docs.webplatform.org and the old location is not redirecting.
