### PR TITLE
Update Safari 7 to reflect that it supports the standard CSP header

### DIFF
--- a/features-json/contentsecuritypolicy.json
+++ b/features-json/contentsecuritypolicy.json
@@ -105,7 +105,7 @@
       "5.1":"a x",
       "6":"y x",
       "6.1":"y x",
-      "7":"y x"
+      "7":"y"
     },
     "opera":{
       "9":"n",
@@ -130,7 +130,7 @@
       "4.2-4.3":"n",
       "5.0-5.1":"a x",
       "6.0-6.1":"y x",
-      "7.0":"y x"
+      "7.0":"y"
     },
     "op_mini":{
       "5.0-7.0":"n"
@@ -168,7 +168,7 @@
       "10":"a x"
     }
   },
-  "notes":"The HTTP header is 'X-Content-Security-Policy' for Firefox until version 23 and IE10&11, and 'X-Webkit-CSP' for Chrome until version 25 and Safari. 'Content-Security-Policy' is the official W3C defined header, used by Chrome version 25 and later, and Firefox version 23 and later.",
+  "notes":"The HTTP header is 'X-Content-Security-Policy' for Firefox until version 23 and IE10&11, and 'X-Webkit-CSP' for Chrome until version 25 and Safari until version 7. 'Content-Security-Policy' is the official W3C defined header, used by Chrome version 25 and later, Firefox version 23 and later, and Safari 7 and later.",
   "usage_perc_y":57,
   "usage_perc_a":12.52,
   "ucprefix":false,


### PR DESCRIPTION
Safari 7 supports the standard `Content-Security-Policy` header. This can be tested by visiting http://erlend.oftedal.no/blog/csp/readiness/version-1.0.php in Safari 7 and Mobile Safari 7.
