### PR TITLE
Added IE bug #781303

### DIFF
--- a/features-json/cors.json
+++ b/features-json/cors.json
@@ -28,6 +28,9 @@
   "bugs":[
     {
       "description":"IE10 does not send cookies when withCredential=true (<a href=\"https://connect.microsoft.com/IE/feedback/details/759587/ie10-doesnt-support-cookies-on-cross-origin-xmlhttprequest-withcredentials-true\">IE Bug #759587</a>)"
+    },
+    {
+      "description":"IE10+ does not make a CORS request if port is the only difference (<a href=\"http://connect.microsoft.com/IE/feedback/details/781303\">IE Bug #781303</a>)"
     }
   ],
   "categories":[


### PR DESCRIPTION
IE10+ will consider two resources to be of the same origin and not make a CORS request with an Origin header added to the request if port is the only difference of the resources. This behavior goes against the specification and the behavior of all other modern browsers.
