### PR TITLE
Update link to quirksmode.org selectors table.

### DIFF
--- a/features-json/css-sel3.json
+++ b/features-json/css-sel3.json
@@ -9,7 +9,7 @@
       "title":"Automated CSS3 selector test"
     },
     {
-      "url":"http://www.quirksmode.org/css/contents.html",
+      "url":"http://www.quirksmode.org/css/selectors/",
       "title":"Detailed support information"
     },
     {


### PR DESCRIPTION
Information browser support for selectors on quirksmode.org has been moved to a new page:

http://www.quirksmode.org/css/selectors/
