### PR TITLE
Add files for npm release

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,8 @@
+.gitignore
+.gitattributes
+
+.travis.yml
+validator/
+
+Contributing.md
+sample-data.json

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "caniuse-db",
+  "version": "1.0.20140126",
+  "description": "Raw browser/feature support data from caniuse.com",
+  "keywords": ["support", "css", "js", "html5", "svg"],
+  "author": "Alexis Deveria <adeveria@gmail.com>",
+  "license": "CC-BY-NC",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Fyrd/caniuse.git"
+  }
+}


### PR DESCRIPTION
I use `caniuse-db` name, because [cabniuse](https://npmjs.org/package/caniuse) is already used.

I use `1.0.x` API version, because Can I Use is old site and API is already stabilazied :).

Please, check tags and description.
