### PR TITLE
Promises: link to ES6 draft spec

### DIFF
--- a/features-json/promises.json
+++ b/features-json/promises.json
@@ -1,7 +1,7 @@
 {
   "title":"Promises",
   "description":"A promise represents the eventual result of an asynchronous operation.",
-  "spec":"https://github.com/domenic/promises-unwrapping",
+  "spec":"https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-objects",
   "status":"other",
   "links":[
     {


### PR DESCRIPTION
Now that promises have been included in the ES6 draft specification, it’s better to link there because that’s where spec bugs should be filed at this point.
