### PR TITLE
Firefox 25 supports `background-attachment: local`

### DIFF
--- a/features-json/background-img-opts.json
+++ b/features-json/background-img-opts.json
@@ -22,9 +22,6 @@
       "description":"Android 2.1-2.3 doesn't appear to honor background-size, only -webkit-background-size, which requires both width and height to be specified."
     },
     {
-      "description":"Firefox does not support \"local\" value for \r\nbackground-attachment."
-    },
-    {
       "description":"iOS Safari does not honor background-size: cover;"
     }
   ],


### PR DESCRIPTION
Firefox 25 supports `background-attachment: local`

See: https://developer.mozilla.org/en-US/docs/Web/CSS/background-attachment
