### PR TITLE
Fixed Safari support, added article on MDN

### DIFF
--- a/features-json/notifications.json
+++ b/features-json/notifications.json
@@ -15,6 +15,10 @@
     {
       "url":"http://www.chromium.org/developers/design-documents/desktop-notifications/api-specification",
       "title":"Chromium API"
+    },
+    {
+      "url":"https://developer.mozilla.org/en-US/docs/Web/API/notification",
+      "title":"MDN Notifications"
     }
   ],
   "bugs":[
@@ -107,8 +111,8 @@
       "4":"n",
       "5":"n",
       "5.1":"n",
-      "6":"n",
-      "6.1":"n",
+      "6":"y",
+      "6.1":"y",
       "7":"y"
     },
     "opera":{


### PR DESCRIPTION
Safari 6 supports notifications according 
https://developer.mozilla.org/en-US/docs/Web/API/notification#Browser_compatibility
