### PR TITLE
Misspelled name

### DIFF
--- a/features-json/pagevisibility.json
+++ b/features-json/pagevisibility.json
@@ -1,5 +1,5 @@
 {
-  "title":"PageVisibility",
+  "title":"Page Visibility",
   "description":"JavaScript API for determining whether a document is visible on the display",
   "spec":"http://www.w3.org/TR/page-visibility/",
   "status":"rec",


### PR DESCRIPTION
As the [specification](http://www.w3.org/TR/page-visibility/) confirms, the right name is with the whitespace.
