### PR TITLE
Updated IE8 support

### DIFF
--- a/features-json/css-sel3.json
+++ b/features-json/css-sel3.json
@@ -32,7 +32,7 @@
       "5.5":"n",
       "6":"p",
       "7":"p",
-      "8":"p",
+      "8":"a",
       "9":"y",
       "10":"y",
       "11":"y"
@@ -179,7 +179,7 @@
       "10":"y"
     }
   },
-  "notes":"",
+  "notes":"IE8 supports the following CSS3 selectors, but only when a DOCTYPE is declared: General siblings (element1~element2) and Attribute selectors ([attr^=val], [attr$=val] and [attr*=val])",
   "usage_perc_y":87.13,
   "usage_perc_a":0,
   "ucprefix":false,


### PR DESCRIPTION
IE8 supports some CSS3 selectors when a DOCTYPE is declared.
