### PR TITLE
fix webplatform history docs link

### DIFF
--- a/features-json/history.json
+++ b/features-json/history.json
@@ -25,7 +25,7 @@
       "title":"History.js polyfill "
     },
     {
-      "url":"http://docs.webplatform.org/wiki/dom/history",
+      "url":"http://docs.webplatform.org/wiki/dom/History",
       "title":"WebPlatform Docs"
     }
   ],


### PR DESCRIPTION
Fix link to History docs at webplatform site -- case sensitive, and the previous link doesn't work
