### PR TITLE
Added 'Known Issue' to contentsecuritypolicy for Internet Explorer

### DIFF
--- a/features-json/contentsecuritypolicy.json
+++ b/features-json/contentsecuritypolicy.json
@@ -19,6 +19,9 @@
     },
     {
       "description":"Partially support in iOS Safari 5.0-5.1 refers to the browser recognizing the X-Webkit-CSP header but failing to handle complex cases correctly, often resulting in broken pages."
+    },
+    {
+      "description":"Partially support in Internet Explorer 10-11 refers to the browser only supporting the 'sandbox' directive by using the 'X-Content-Security-Policy' header."
     }
   ],
   "categories":[


### PR DESCRIPTION
Internet Explorer 10 & 11 only support the 'sandbox' directive.

https://en.wikipedia.org/wiki/Content_Security_Policy
"... Support for the **sandbox directive** is also available in Internet Explorer 10 and Internet Explorer 11 using the experimental X-Content-Security-Policy header. ..."

http://www.nokia.net.co/sec_rookie/?p=73
"... And yes, the very same MSDN article had the magic answer, IE10 supports “X-Content-Security-Policy: sandbox” directive, but **not the other ones** mentioned in the standard! ..."

https://www.isecpartners.com/media/106598/csp_best_practices.pdf
See "2.4 BROWSER SUPPORT" on page 6: "sandbox directive **only**"

Plus:
I testet it myself in IE 10 & IE11 and yes it's true - only the sandbox directive is supported!
