### PR TITLE
Removed partial support for Android 4.0 and 4.1

### DIFF
--- a/features-json/input-placeholder.json
+++ b/features-json/input-placeholder.json
@@ -27,7 +27,7 @@
   ],
   "bugs":[
     {
-      "description":"Android 4.0 and Android 4.1 Browser and WebView doesn't show up the placeholder for &lt;input type=\"number\"> field, link: https://code.google.com/p/android/issues/detail?id=24626"
+      "description":""
     }
   ],
   "categories":[
@@ -160,8 +160,8 @@
       "2.2":"y",
       "2.3":"y",
       "3":"y",
-      "4":"a",
-      "4.1":"a",
+      "4":"y",
+      "4.1":"y",
       "4.2-4.3":"y",
       "4.4":"y"
     },


### PR DESCRIPTION
As per the spec, http://www.w3.org/TR/2011/WD-html5-20110525/number-state.html, The placeholder attribute must not be specified and do not apply to the number input type. So, although Chrome did "fix" this quirk, it doesn't not make 4.0, 4.1 and webview buggy.
