### PR TITLE
Update calc.json

### DIFF
--- a/features-json/calc.json
+++ b/features-json/calc.json
@@ -22,7 +22,7 @@
       "description":"Internet Explorer (in accordance with the spec) does not accept calculations without spaces for additions/subtractions (ie. calc(100%-30px) is invalid, but calc(100% - 30px) works fine)."
     },
     {
-      "description":"Chrome and Safari do not support viewport units in calc() expressions."
+      "description":"Webkit doesn't support viewport units in calc() expressions."
     },
     {
       "description":"calc() does not work within translate/translateX on Internet Explorer 11: http://jsfiddle.net/Y5x93/\r\nIt does work in Firefox 25+ and Chrome 31+ with the -webkit- prefix."


### PR DESCRIPTION
Blink is now ok for mixing vh and calc (https://code.google.com/p/chromium/issues/detail?id=168840)
Webkit still can't (https://bugs.webkit.org/show_bug.cgi?id=94158)
