### PR TITLE
document Firefox input placeholder style compat issue

### DIFF
--- a/features-json/input-placeholder.json
+++ b/features-json/input-placeholder.json
@@ -28,6 +28,9 @@
   "bugs":[
     {
       "description":"Android 4.0 and Android 4.1 Browser and WebView doesn't show up the placeholder for &lt;input type=\"number\"> field, link: https://code.google.com/p/android/issues/detail?id=24626"
+    },
+    {
+      "description":"Firefox 19+ applies a default style of <code>opacity: 0.4</code> to placeholder text."
     }
   ],
   "categories":[


### PR DESCRIPTION
More of a cross-browser compatibility issue than a bug per se, but I'm not sure where else to put this.

---

References:
https://developer.mozilla.org/en-US/docs/Web/CSS/::-moz-placeholder
https://bugzilla.mozilla.org/show_bug.cgi?id=556145
