### PR TITLE
-ms- on IE6-8

### DIFF
--- a/features-json/text-overflow.json
+++ b/features-json/text-overflow.json
@@ -21,6 +21,10 @@
       "title":"MDN article"
     },
     {
+      "url":"http://msdn.microsoft.com/en-us/library/ie/ms531174%28v=vs.85%29.aspx",
+      "title":"MSDN article"
+    },
+    {
       "url":"http://www.css3files.com/text/",
       "title":"Information page"
     }
@@ -34,9 +38,9 @@
   "stats":{
     "ie":{
       "5.5":"n",
-      "6":"y",
-      "7":"y",
-      "8":"y",
+      "6":"y x",
+      "7":"y x",
+      "8":"y x",
       "9":"y",
       "10":"y",
       "11":"y"


### PR DESCRIPTION
MDN says IE6 supports text-overflow but IE8 uses -ms-
MSDN says IE6-8 use -ms-
