### PR TITLE
Adds a known IE9 issue to css3-boxsizing.json

### DIFF
--- a/features-json/css3-boxsizing.json
+++ b/features-json/css3-boxsizing.json
@@ -31,6 +31,12 @@
     },
     {
       "description":"Safari 6.0.x does not use box-sizing on elements with display: table;"
+    },
+    {
+      "description":"Safari 6.0.x does not use box-sizing on elements with display: table;"
+    },
+    {
+      "description":"IE9 will subtract the with of the scrollbar to the with of the element when set to position: absolute, overflow: auto / overflow-y: scroll"
     }
   ],
   "categories":[


### PR DESCRIPTION
IE9 will subtract the with of the scrollbar to the with of the element when set to position: absolute, overflow: auto / overflow-y: scroll
