### PR TITLE
Removed dead link on CSS Table display

### DIFF
--- a/features-json/css-table.json
+++ b/features-json/css-table.json
@@ -5,10 +5,6 @@
   "status":"rec",
   "links":[
     {
-      "url":"http://blog.12spokes.com/web-design-development/when-to-choose-between-the-html-table-element-and-css-displaytable-property/",
-      "title":"Deciding on HTML or CSS tables"
-    },
-    {
       "url":"http://www.onenaught.com/posts/201/use-css-displaytable-for-layout",
       "title":"Blog post on usage"
     }


### PR DESCRIPTION
"Deciding on HTML or CSS tables [blog.12spokes.com]" is a dead link, so I removed it.
