### PR TITLE
The Chrome 25+ date picker bug was probably fixed

### DIFF
--- a/features-json/input-datetime.json
+++ b/features-json/input-datetime.json
@@ -23,7 +23,7 @@
   ],
   "bugs":[
     {
-      "description":"There's a <a href=\"https://code.google.com/p/chromium/issues/detail?id=172029\">bug with Chrome 25+</a> on Windows:\r\n\r\nThe black triangle, to open the datePicker, will go outside the input field. The trick is that if you put an \"overflow: hidden\" or something like this, you'll see it disappear. It is the case with Twitter Bootstrap 2.3.0, and it's quite tricky.\r\n"
+      "description":"There's a <a href=\"https://code.google.com/p/chromium/issues/detail?id=172029\">bug with Chrome 25 - 35</a> on Windows:\r\n\r\nThe black triangle, to open the datePicker, will go outside the input field. The trick is that if you put an \"overflow: hidden\" or something like this, you'll see it disappear. It is the case with Twitter Bootstrap 2.3.0, and it's quite tricky.\r\n"
     }
   ],
   "categories":[


### PR DESCRIPTION
I tried data:text/html,<!doctype html><input type=date style="width: 4em;overflow:hidden"> and the triangle showed up and the date picker, too.
