### PR TITLE
Update flexbox.json

### DIFF
--- a/features-json/flexbox.json
+++ b/features-json/flexbox.json
@@ -209,7 +209,7 @@
       "10":"a x #2"
     }
   },
-  "notes":"Most partial support refers to supporting an <a href=\"http://www.w3.org/TR/2009/WD-css3-flexbox-20090723/\">older version</a> of the specification or an <a href=\"http://www.w3.org/TR/2012/WD-css3-flexbox-20120322/\">older syntax</a>. For Firefox 28- it refers to lack of flex-wrap & flex-flow support.",
+  "notes":"Most partial support refers to supporting an <a href=\"http://www.w3.org/TR/2009/WD-css3-flexbox-20090723/\">older version</a> of the specification or an <a href=\"http://www.w3.org/TR/2012/WD-css3-flexbox-20120322/\">older syntax</a>.",
   "usage_perc_y":67.8,
   "usage_perc_a":14.91,
   "ucprefix":false,


### PR DESCRIPTION
Either remove the partial support warning for Firefox 28, or mark it as "a x" (partial support) in the statuses section.

I think it fully supports flex-wrap and flex-flow though
