### PR TITLE
Removed bug from web-audio

### DIFF
--- a/features-json/audio-api.json
+++ b/features-json/audio-api.json
@@ -22,9 +22,6 @@
     }
   ],
   "bugs":[
-    {
-      "description":"Chrome for Android does not support the Web Audio API in conjunction with getUserMedia."
-    }
   ],
   "categories":[
     "JS API"


### PR DESCRIPTION
Chrome on Android does support getUserMedia API bridge into WebAudio.

http://notthetup.github.io/auralizr/ uses that and works well on Chrome on Android.
