### PR TITLE
IE 10 & 11 don't support oninput for range

### DIFF
--- a/features-json/input-range.json
+++ b/features-json/input-range.json
@@ -31,7 +31,7 @@
   ],
   "bugs":[
     {
-      "description":"IE10 & 11 have a some <a href=\"http://stackoverflow.com/questions/20241415/html5-number-input-field-step-attribute-broken-in-internet-explorer-10-and-inter\">bugs related to the step value</a>."
+      "description":"IE10 & 11 have a some <a href=\"http://stackoverflow.com/questions/20241415/html5-number-input-field-step-attribute-broken-in-internet-explorer-10-and-inter\">bugs related to the step value</a> and do not support the oninput event handler."
     }
   ],
   "categories":[
@@ -44,8 +44,8 @@
       "7":"n",
       "8":"n",
       "9":"n",
-      "10":"y",
-      "11":"y"
+      "10":"a",
+      "11":"a"
     },
     "firefox":{
       "2":"n",


### PR DESCRIPTION
IE 10 & 11 don't support oninput events in the way that the value is being updated while moving the range slider (as is mandatory according to the spec). The onchange event does what the oninput event is supposed to do, however the onchange event should only trigger when the slider is released.

I think that should reduce the support to "partial/almost" until this is fixed.
