### PR TITLE
Add IE11 on WP 8.1 WebGL support

### DIFF
--- a/features-json/webgl.json
+++ b/features-json/webgl.json
@@ -193,7 +193,8 @@
       "0":"a"
     },
     "ie_mob":{
-      "10":"p"
+      "10":"p",
+      "11":"y"
     }
   },
   "notes":"Support listed as \"partial\" refers to the fact that not all users with these browsers have WebGL access. This is due to the additional requirement for users to have <a href=\"http://www.khronos.org/webgl/wiki/BlacklistsAndWhitelists\">up to date video drivers</a>. This problem was <a href=\"http://blog.chromium.org/2012/02/gpu-accelerating-2d-canvas-and-enabling.html\">solved in Chrome</a> as of version 18.\r\n\r\nNote that WebGL is part of the <a href=\"http://www.khronos.org/webgl/\">Khronos Group</a>, not the W3C.",


### PR DESCRIPTION
Prooflink: http://msdn.microsoft.com/library/ie/bg182636(v=vs.85).aspx
