### PR TITLE
Update strict transport security

### DIFF
--- a/features-json/stricttransportsecurity.json
+++ b/features-json/stricttransportsecurity.json
@@ -11,6 +11,10 @@
     {
       "url":"https://developer.mozilla.org/en-US/docs/Security/HTTP_Strict_Transport_Security",
       "title":"Strict Transport Security @ Mozilla Developer Network"
+    },
+    {
+      "url":"https://www.owasp.org/index.php/HTTP_Strict_Transport_Security",
+      "title":"Strict Transport Security @ The Open Web Application Security Project"
     }
   ],
   "bugs":[


### PR DESCRIPTION
- IE12 support
- Link to OWASP
