### PR TITLE
Fixed iframe seamless attribute's status and link

### DIFF
--- a/features-json/iframe-seamless.json
+++ b/features-json/iframe-seamless.json
@@ -1,8 +1,8 @@
 {
   "title":"seamless attribute for iframes",
   "description":"The seamless attribute makes an iframe's contents actually part of a page, and adopts the styles from its hosting page. ",
-  "spec":"http://whatwg.org/html#attr-iframe-seamless",
-  "status":"cr",
+  "spec":"http://www.w3.org/html/wg/drafts/html/master/single-page.html#attr-iframe-seamless",
+  "status":"wd",
   "links":[
     {
       "url":"https://github.com/ornj/seamless-polyfill",


### PR DESCRIPTION
Changed the status to WD because it is not a part of the HTML5 spec, it appears in the HTML5.1 spec. Also updated the link to reflect that
