### PR TITLE
Use double-colon syntax for pseudo-elements

### DIFF
--- a/features-json/css-gencontent.json
+++ b/features-json/css-gencontent.json
@@ -1,6 +1,6 @@
 {
   "title":"CSS Generated content for pseudo-elements",
-  "description":"Method of displaying text or images before or after the given element's contents using the :before and :after pseudo-elements",
+  "description":"Method of displaying text or images before or after the given element's contents using the ::before and ::after pseudo-elements",
   "spec":"http://www.w3.org/TR/CSS21/generate.html",
   "status":"rec",
   "links":[


### PR DESCRIPTION
The fact that IE8 only recognizes `:before` and `:after` with a single colon is mentioned in the notes already.

http://www.w3.org/TR/css3-content/#pseudo-elements: “Authors are encouraged to use the new two-colon forms.”
