### PR TITLE
Remove a link from webgl.json

### DIFF
--- a/features-json/webgl.json
+++ b/features-json/webgl.json
@@ -19,10 +19,6 @@
     {
       "url":"http://webkit.org/blog/603/webgl-now-available-in-webkit-nightlies/",
       "title":"Webkit blog post"
-    },
-    {
-      "url":"http://iewebgl.com/",
-      "title":"Polyfill for IE"
     }
   ],
   "bugs":[


### PR DESCRIPTION
http://iewebgl.com/ seems to have turned into a spam blog.
