### PR TITLE
Touch Events now supported IE11 mobile

### DIFF
--- a/features-json/touch.json
+++ b/features-json/touch.json
@@ -204,7 +204,7 @@
     },
     "ie_mob":{
       "10":"p",
-      "11":"y"http://blogs.msdn.com/b/ie/archive/2014/07/31/the-mobile-web-should-just-work-for-everyone.aspx
+      "11":"y"
     }
   },
   "notes":"Internet Explorer implements Pointer Events specification which supports more input devices than Touch Events one.\r\n\r\nRemoved support in Firefox refers to desktop Firefox only.",

--- a/features-json/touch.json
+++ b/features-json/touch.json
@@ -203,7 +203,8 @@
       "31":"y"
     },
     "ie_mob":{
-      "10":"p"
+      "10":"p",
+      "11":"y"http://blogs.msdn.com/b/ie/archive/2014/07/31/the-mobile-web-should-just-work-for-everyone.aspx
     }
   },
   "notes":"Internet Explorer implements Pointer Events specification which supports more input devices than Touch Events one.\r\n\r\nRemoved support in Firefox refers to desktop Firefox only.",


### PR DESCRIPTION
http://blogs.msdn.com/b/ie/archive/2014/07/31/the-mobile-web-should-just-work-for-everyone.aspx

Note that status.modern.IE reflects this as "In Development" at the moment. I'll be updating that soon, but just haven't yet figured out how to best differentiate in our site that this feature is currently only supported on mobile.