### PR TITLE
add link, update Firefox 32+ and Opera 24+

### DIFF
--- a/features-json/cryptography.json
+++ b/features-json/cryptography.json
@@ -67,8 +67,8 @@
       "29":"p",
       "30":"p",
       "31":"p",
-      "32":"d",
-      "33":"d",
+      "32":"n d #2",
+      "33":"n d #2",
       "34":"y",
       "35":"y"
     },
@@ -195,7 +195,8 @@
   },
   "notes":"Many browsers support the `[crypto.getRandomValues()](#feat=getrandomvalues)` method, but not actual cryptography functionality under `crypto.subtle`. \r\n\r\nAs the specification is currently still in development, users may be better off using polyfills or libraries like [PolyCrypt](http://polycrypt.net/). \r\n\r\nFirefox also has support for [unofficial features](https://developer.mozilla.org/en-US/docs/JavaScript_crypto).",
   "notes_by_num":{
-    "1":"Support in IE11 is based an older version of the specification. "
+    "1":"Support in IE11 is based an older version of the specification. ",
+    "2":"Supported in Firefox behind the `dom.webcrypto.enabled` flag. "
   },
   "usage_perc_y":8.05,
   "usage_perc_a":7.23,


### PR DESCRIPTION
Opera data from http://www.chromestatus.com/feature/5030265697075200
Firefox data from https://bugzilla.mozilla.org/show_bug.cgi?id=865789 and https://docs.google.com/spreadsheet/ccc?key=0AiAcidBZRLxndE9LWEs2R1oxZ0xidUVoU3FQbFFobkE&usp=sharing#gid=1
