### PR TITLE
Add bug to css animation bugs list

### DIFF
--- a/features-json/css-animation.json
+++ b/features-json/css-animation.json
@@ -23,6 +23,9 @@
     },
     {
       "description":"iOS 6.1 and below do not support animation on pseudo-elements."
+    },
+    {
+      "description":"@keyframes not supported in an inline or scoped stylesheet in Firefox (bug 830056)"
     }
   ],
   "categories":[


### PR DESCRIPTION
@keyframes are not supported in Firefox in inline or scoped stylesheets, which is against spec, but a known will-not-fix bug. See https://bugzilla.mozilla.org/show_bug.cgi?id=830056 and http://css-tricks.com/animate-to-an-inline-style/
