### PR TITLE
Update svg-css.json

### DIFF
--- a/features-json/svg-css.json
+++ b/features-json/svg-css.json
@@ -11,7 +11,7 @@
   ],
   "bugs":[
     {
-      "description":"Opera messes background repeat when changing zoom level: [known issue in Opera's private bug tracker (CORE-33071)](http://stackoverflow.com/questions/15220910/svg-as-css-background-problems-with-zoom-level-in-opera#comment21458317_15220910)"
+      "description":"Opera messes background repeat when changing zoom level: [known issue in Opera's private bug tracker (CORE-33071)](http://stackoverflow.com/questions/15220910/svg-as-css-background-problems-with-zoom-level-in-opera#comment21458317_15220910)",
       "description":"Android 2.x will not display the fallback background-image in addition to not displaying the SVG if it is implemented using multiple background-image properties on the same element. (e.g. PNG background-image fallback + SVG background-image)"
     }
   ],


### PR DESCRIPTION
Bug regarding Android 2.x not only not supporting SVG but if attempting to use with a fallback, it will not render the fallback either.
