### PR TITLE
update CSS Filters implementation status

### DIFF
--- a/features-json/css-filters.json
+++ b/features-json/css-filters.json
@@ -74,7 +74,7 @@
       "32":"a",
       "33":"a",
       "34":"a",
-      "35":"a"
+      "35":"y"
     },
     "chrome":{
       "4":"n",
@@ -211,6 +211,6 @@
   "parent":"",
   "keywords":"sepia,hue-rotate,invert,saturate",
   "ie_id":"filters",
-  "chrome_id":"",
+  "chrome_id":"5822463824887808",
   "shown":true
 }


### PR DESCRIPTION
- [Support will be enabled by default in Firefox 35](https://hg.mozilla.org/mozilla-central/rev/697c4b245de0)
- add corresponding [Chromestatus.com entry](https://www.chromestatus.com/features/5822463824887808)
