### PR TITLE
Web Crypto API with Chrome only works over secure connections

### DIFF
--- a/features-json/cryptography.json
+++ b/features-json/cryptography.json
@@ -198,7 +198,7 @@
       "9.9":"p"
     }
   },
-  "notes":"Many browsers support the `[crypto.getRandomValues()](#feat=getrandomvalues)` method, but not actual cryptography functionality under `crypto.subtle`. \r\n\r\nAs the specification is currently still in development, users may be better off using polyfills or libraries like [PolyCrypt](http://polycrypt.net/). \r\n\r\nFirefox also has support for [unofficial features](https://developer.mozilla.org/en-US/docs/JavaScript_crypto).",
+  "notes":"Many browsers support the `[crypto.getRandomValues()](#feat=getrandomvalues)` method, but not actual cryptography functionality under `crypto.subtle`. \r\n\r\nAs the specification is currently still in development, users may be better off using polyfills or libraries like [PolyCrypt](http://polycrypt.net/). \r\n\r\nFirefox also has support for [unofficial features](https://developer.mozilla.org/en-US/docs/JavaScript_crypto). \r\n\r\nIn Chrome the API is only usable over secure connections. ([corresponding bug](https://code.google.com/p/chromium/issues/detail?id=373032))",
   "notes_by_num":{
     "1":"Support in IE11 is based an older version of the specification. ",
     "2":"Supported in Firefox behind the `dom.webcrypto.enabled` flag. ",


### PR DESCRIPTION
The Web Cryptography API functions throw an error in Google Chrome when called over insecure connections (plain http or ws). This should be added as a note because it limits the support in Chrome.
