### PR TITLE
Chrome on iOS does not support  webRTC

### DIFF
--- a/features-json/rtcpeerconnection.json
+++ b/features-json/rtcpeerconnection.json
@@ -193,7 +193,7 @@
       "9.9":"n"
     }
   },
-  "notes":"BlackBerry 10 recognizes RTCPeerConnection but real support is unconfirmed.",
+  "notes":"BlackBerry 10 recognizes RTCPeerConnection but real support is unconfirmed.\r\n\r\nChrome on iOS (iphone and ipads) does not support webRTC.",
   "notes_by_num":{
     
   },


### PR DESCRIPTION
chrome does not support webRTC on iphone and ipad because of apple policy on those type of devices about their own p2p protocol used in facetime app , it is supported in chrome on mac os x as expected.
