### PR TITLE
Added 'title argument not working' as a bug

### DIFF
--- a/features-json/history.json
+++ b/features-json/history.json
@@ -35,6 +35,9 @@
     },
     {
       "description":"Safari 5 and older iOS Safari have a broken implementation, when the page is within an iframe, the back button will not take you to the correct state. When under heavy load, the `onpopstate` event fails to fire."
+    },
+    {
+      "description":"The title argument is not applied in the history list of major browsers; they will display the page's title instead."
     }
   ],
   "categories":[


### PR DESCRIPTION
Most browsers don't display the title argument in their history list, but will show the page's title. More browsers need to be determined, but tested on Windows 7 with IE11.0.9600.17358, Chrome 38.0.2125.104 m, FF 31.1.1 and Opera 24.0.1558.64
It does work on Safari 5.1.2 (7534.52.7)
