### PR TITLE
Intial version of box-decoration-break JSON

### DIFF
--- a/features-json/css-boxdecorationbreak.json
+++ b/features-json/css-boxdecorationbreak.json
@@ -1,0 +1,213 @@
+{
+  "title":"CSS box-decoration-break",
+  "description":"Controls whether the box’s margins, borders, padding, and other decorations wrap the broken edges of the box fragments (when the box is split by a break (page/column/region/line).",
+  "spec":"http://www.w3.org/TR/css3-break/#break-decoration",
+  "status":"wd",
+  "links":[
+    {
+      "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/box-decoration-break",
+      "title":"MDN article"
+    },
+    {
+      "url":"http://jsbin.com/xojoro/edit?css,output",
+      "title":"Demo of effect on box border"
+    }
+  ],
+  "bugs":[
+
+  ],
+  "categories":[
+    "CSS3"
+  ],
+  "stats":{
+    "ie":{
+      "5.5":"n",
+      "6":"n",
+      "7":"n",
+      "8":"n",
+      "9":"n",
+      "10":"n",
+      "11":"n"
+    },
+    "firefox":{
+      "2":"n",
+      "3":"n",
+      "3.5":"n",
+      "3.6":"n",
+      "4":"n",
+      "5":"n",
+      "6":"n",
+      "7":"n",
+      "8":"n",
+      "9":"n",
+      "10":"n",
+      "11":"n",
+      "12":"n",
+      "13":"n",
+      "14":"n",
+      "15":"n",
+      "16":"n",
+      "17":"n",
+      "18":"n",
+      "19":"n",
+      "20":"n",
+      "21":"n",
+      "22":"n",
+      "23":"n",
+      "24":"n",
+      "25":"n",
+      "26":"n",
+      "27":"n",
+      "28":"n",
+      "29":"n",
+      "30":"n",
+      "31":"n",
+      "32":"y",
+      "33":"y",
+      "34":"y",
+      "35":"y",
+      "36":"y"
+    },
+    "chrome":{
+      "4":"u",
+      "5":"u",
+      "6":"u",
+      "7":"u",
+      "8":"u",
+      "9":"u",
+      "10":"u",
+      "11":"u",
+      "12":"u",
+      "13":"u",
+      "14":"u",
+      "15":"u",
+      "16":"u",
+      "17":"u",
+      "18":"u",
+      "19":"u",
+      "20":"u",
+      "21":"u",
+      "22":"u",
+      "23":"u",
+      "24":"y x",
+      "25":"y x",
+      "26":"y x",
+      "27":"y x",
+      "28":"y x",
+      "29":"y x",
+      "30":"y x",
+      "31":"y x",
+      "32":"y x",
+      "33":"y x",
+      "34":"y x",
+      "35":"y x",
+      "36":"y x",
+      "37":"y x",
+      "38":"y x",
+      "39":"y x",
+      "40":"y x",
+      "41":"y x"
+    },
+    "safari":{
+      "3.1":"u",
+      "3.2":"u",
+      "4":"u",
+      "5":"u",
+      "5.1":"u",
+      "6":"u",
+      "6.1":"u",
+      "7":"y x",
+      "7.1":"y x",
+      "8":"y x"
+    },
+    "opera":{
+      "9":"u",
+      "9.5-9.6":"u",
+      "10.0-10.1":"u",
+      "10.5":"u",
+      "10.6":"u",
+      "11":"u",
+      "11.1":"u",
+      "11.5":"u",
+      "11.6":"u",
+      "12":"u",
+      "12.1":"u",
+      "15":"y x",
+      "16":"y x",
+      "17":"y x",
+      "18":"y x",
+      "19":"y x",
+      "20":"y x",
+      "21":"y x",
+      "22":"y x",
+      "23":"y x",
+      "24":"y x",
+      "25":"y x",
+      "26":"y x",
+      "27":"y x"
+    },
+    "ios_saf":{
+      "3.2":"u",
+      "4.0-4.1":"u",
+      "4.2-4.3":"u",
+      "5.0-5.1":"u",
+      "6.0-6.1":"u",
+      "7.0-7.1":"y x",
+      "8":"y x",
+      "8.1":"y x"
+    },
+    "op_mini":{
+      "5.0-8.0":"y"
+    },
+    "android":{
+      "2.1":"u",
+      "2.2":"u",
+      "2.3":"u",
+      "3":"u",
+      "4":"u",
+      "4.1":"y x",
+      "4.2-4.3":"y x",
+      "4.4":"y x",
+      "4.4.3-4.4.4":"y x",
+      "37":"y x"
+    },
+    "bb":{
+      "7":"u",
+      "10":"u"
+    },
+    "op_mob":{
+      "10":"u",
+      "11":"u",
+      "11.1":"u",
+      "11.5":"u",
+      "12":"u",
+      "12.1":"u",
+      "24":"y x"
+    },
+    "and_chr":{
+      "38":"y x"
+    },
+    "and_ff":{
+      "32":"y"
+    },
+    "ie_mob":{
+      "10":"n",
+      "11":"n"
+    },
+    "and_uc":{
+      "9.9":"u"
+    }
+  },
+  "notes":"",
+  "notes_by_num":{
+
+  },
+  "usage_perc_y":0,
+  "usage_perc_a":0,
+  "ucprefix":false,
+  "parent":"",
+  "keywords":"box-decoration,box decoration,break",
+  "ie_id":"",
+  "chrome_id":"",
+  "shown":false
+}


### PR DESCRIPTION
A few notes:
1. Contrary to info on the web, IE does not seem to support this feature.
2. I wasn’t sure how far back support in WebKit-based browsers goes, so I took the year 2013 as a starting point for `"y x"` in Chrome/Safari/Android.

Related Autoprefixer issue: https://github.com/postcss/autoprefixer/issues/344
Demo of `box-decoration-break`: http://jsbin.com/xojoro/edit?css,output
