### PR TITLE
Update calc bug with IE10 with child inherit

### DIFF
--- a/features-json/calc.json
+++ b/features-json/calc.json
@@ -32,6 +32,9 @@
     },
     {
       "description":"IE11 and other browsers to a lesser extent have trouble supporting `calc()` inside [color or transform values](http://codepen.io/thebabydino/pen/wfraH)."
+    },
+    {
+     "description":"IE10 crashes when a div with a property using `calc()` has a child with [same property with `inherit`](http://stackoverflow.com/questions/19423384/css-less-calc-method-is-crashing-my-ie10)."
     }
   ],
   "categories":[


### PR DESCRIPTION
Add a bug to `calc` referring to stackoverflow question http://stackoverflow.com/questions/19423384/css-less-calc-method-is-crashing-my-ie10
