### PR TITLE
SVG: + IE warning & fix

### DIFF
--- a/features-json/svg.json
+++ b/features-json/svg.json
@@ -46,9 +46,9 @@
       "6":"p",
       "7":"p",
       "8":"p",
-      "9":"y",
-      "10":"y",
-      "11":"y"
+      "9":"y #2",
+      "10":"y #2",
+      "11":"y #2"
     },
     "firefox":{
       "2":"a",
@@ -184,10 +184,10 @@
       "2.1":"n",
       "2.2":"n",
       "2.3":"n",
-      "3":"a",
-      "4":"a",
-      "4.1":"a",
-      "4.2-4.3":"a",
+      "3":"a #1",
+      "4":"a #1",
+      "4.1":"a #1",
+      "4.2-4.3":"a #1",
       "4.4":"y",
       "4.4.3-4.4.4":"y",
       "37":"y"
@@ -212,16 +212,17 @@
       "32":"y"
     },
     "ie_mob":{
-      "10":"y",
-      "11":"y"
+      "10":"y #2",
+      "11":"y #2"
     },
     "and_uc":{
       "9.9":"y"
     }
   },
-  "notes":"Partial support in Android 4 refers to not supporting masking.",
+  "notes":"",
   "notes_by_num":{
-    
+    "1": "Partial support in Android 3 & 4 refers to not supporting masking.",
+    "2": "IE9-11 desktop & mobile don't properly scale SVG files.  [Adding height, width, viewport, and CSS rules](http://codepen.io/tomByrer/pen/qEBbzw?editors=110) seem to be the best workaround."
   },
   "usage_perc_y":89.77,
   "usage_perc_a":3.54,


### PR DESCRIPTION
IE's SVG resizing seems to be an [ongoing](http://stackoverflow.com/questions/9777143/svg-in-img-element-proportions-not-respected-in-ie9) [issue](http://stackoverflow.com/questions/7711641/why-doesnt-this-svg-graphic-scale-in-ie9-and-10-preview) including [mobile](https://github.com/twitter/twemoji/issues/27).

I don't want to be self-serving by pointing at my own CodePen fork, but the original didn't perform as well in IE10, so I fixed it.  The copy links to others' research, so only 1 link is needed here.

I did take some liberty expecting Android3 having the same issue as Adndroid4.  I don't have a WIndows Phone hardware to test on.
