### PR TITLE
IE9, IE10, IE11 ignore CSS rem units in the line-height property

### DIFF
--- a/features-json/css-gencontent.json
+++ b/features-json/css-gencontent.json
@@ -20,6 +20,9 @@
   "bugs":[
     {
       "description":"Chrome supports CSS transitions on generated content as of v. 26. Safari v6 and below do not support transitions or animations on pseudo elements."
+    },
+    {
+      "description":"IE9, IE10, IE11 ignore CSS rem units in the line-height property. [Bug report](https://connect.microsoft.com/IE/feedback/details/776744/css3-using-rem-to-set-line-height-in-before-after-pseudo-elements-doesnt-work)."
     }
   ],
   "categories":[


### PR DESCRIPTION
https://connect.microsoft.com/IE/feedback/details/776744/css3-using-rem-to-set-line-height-in-before-after-pseudo-elements-doesnt-work
