### PR TITLE
#801 Updated status of HTML5 features to 'rec' in features-json files...

### DIFF
--- a/features-json/audio.json
+++ b/features-json/audio.json
@@ -1,8 +1,8 @@
 {
   "title":"Audio element",
-  "description":"Method of playing sound on webpages (without requiring a plug-in)",
+  "description":"Method of playing sound on webpages (without requiring a plug-in).",
   "spec":"https://html.spec.whatwg.org/multipage/embedded-content.html#the-audio-element",
-  "status":"cr",
+  "status":"rec",
   "links":[
     {
       "url":"http://html5doctor.com/native-audio-in-the-browser/",
@@ -42,16 +42,16 @@
       "description":"Audio played from the element in iOS always plays in a full screen player."
     },
     {
-      "description":"Playback rate not supported on the stock android browser"
+      "description":"Playback rate not supported on the stock Android browser."
     },
     {
-      "description":"Only one Audio file can be played at one time in iOS and Android browsers which forces you to use sprites for multiple audios"
+      "description":"Only one Audio file can be played at one time in iOS and Android browsers which forces you to use sprites for multiple audios."
     },
     {
-      "description":"Audio in iOS can not be auto played. It even starts downloading after a user triggered event"
+      "description":"Audio in iOS cannot be auto played. It even starts downloading after a user triggered event."
     },
     {
-      "description":"Volume is read-only on iOS"
+      "description":"Volume is read-only on iOS."
     }
   ],
   "categories":[

--- a/features-json/autofocus.json
+++ b/features-json/autofocus.json
@@ -2,7 +2,7 @@
   "title":"Autofocus attribute",
   "description":"Allows a form field to be immediately focused on page load.",
   "spec":"https://html.spec.whatwg.org/multipage/forms.html#autofocusing-a-form-control:-the-autofocus-attribute",
-  "status":"wd",
+  "status":"rec",
   "links":[
     {
       "url":"http://davidwalsh.name/autofocus",

--- a/features-json/canvas.json
+++ b/features-json/canvas.json
@@ -1,8 +1,8 @@
 {
   "title":"Canvas (basic support)",
-  "description":"Method of generating fast, dynamic graphics using JavaScript",
+  "description":"Method of generating fast, dynamic graphics using JavaScript.",
   "spec":"https://html.spec.whatwg.org/multipage/scripting.html#the-canvas-element",
-  "status":"cr",
+  "status":"rec",
   "links":[
     {
       "url":"https://developer.mozilla.org/en/Canvas_tutorial",

--- a/features-json/contenteditable.json
+++ b/features-json/contenteditable.json
@@ -1,8 +1,8 @@
 {
   "title":"contenteditable attribute (basic support)",
-  "description":"Method of making any HTML element editable",
+  "description":"Method of making any HTML element editable.",
   "spec":"http://www.w3.org/TR/html/editing.html#contenteditable",
-  "status":"cr",
+  "status":"rec",
   "links":[
     {
       "url":"http://html5demos.com/contenteditable",

--- a/features-json/datalist.json
+++ b/features-json/datalist.json
@@ -2,7 +2,7 @@
   "title":"Datalist element",
   "description":"Method of setting a list of options for a user to select in a text field, while leaving the ability to enter a custom value.",
   "spec":"https://html.spec.whatwg.org/multipage/forms.html#the-datalist-element",
-  "status":"wd",
+  "status":"rec",
   "links":[
     {
       "url":"http://hacks.mozilla.org/2010/11/firefox-4-html5-forms/",

--- a/features-json/dataset.json
+++ b/features-json/dataset.json
@@ -2,7 +2,7 @@
   "title":"dataset & data-* attributes",
   "description":"Method of applying and accessing custom data to elements.",
   "spec":"https://html.spec.whatwg.org/multipage/dom.html#embedding-custom-non-visible-data-with-the-data-*-attributes",
-  "status":"wd",
+  "status":"rec",
   "links":[
     {
       "url":"http://html5doctor.com/html5-custom-data-attributes/",

--- a/features-json/download.json
+++ b/features-json/download.json
@@ -1,8 +1,8 @@
 {
   "title":"Download attribute",
-  "description":"When used on an anchor, this attribute signifies that the resource it points to should be downloaded by the browser rather than navigate to it.",
+  "description":"When used on an anchor, this attribute signifies that the browser should download the resource the anchor points to rather than navigate to it.",
   "spec":"https://html.spec.whatwg.org/multipage/semantics.html#downloading-resources",
-  "status":"wd",
+  "status":"rec",
   "links":[
     {
       "url":"http://updates.html5rocks.com/2011/08/Downloading-resources-in-HTML5-a-download",

--- a/features-json/form-validation.json
+++ b/features-json/form-validation.json
@@ -1,8 +1,8 @@
 {
   "title":"Form validation",
-  "description":"Method of setting required fields and field types without requiring JavaScript",
+  "description":"Method of setting required fields and field types without requiring JavaScript.",
   "spec":"https://html.spec.whatwg.org/multipage/forms.html#client-side-form-validation",
-  "status":"wd",
+  "status":"rec",
   "links":[
     {
       "url":"http://docs.webplatform.org/wiki/html/attributes/required",
@@ -11,7 +11,7 @@
   ],
   "bugs":[
     {
-      "description":"Support for using differently colored borders is not complete in Firefox or Opera (did not test others yet) - using a seperate class for styling works well in both."
+      "description":"Support for using differently colored borders is not complete in Firefox or Opera (did not test others yet) - using a separate class for styling works well in both."
     },
     {
       "description":"In Chrome the attribute \"formnovalidate\" doesn't work on <input type=\"submit\"> elements but does on <button type=\"submit\"> elements."

--- a/features-json/forms.json
+++ b/features-json/forms.json
@@ -2,7 +2,7 @@
   "title":"HTML5 form features",
   "description":"Expanded form options, including things like date pickers, sliders, validation, placeholders and multiple file uploads. Previously known as \"Web forms 2.0\".",
   "spec":"https://html.spec.whatwg.org/multipage/forms.html#forms",
-  "status":"wd",
+  "status":"rec",
   "links":[
     {
       "url":"https://miketaylr.com/code/input-type-attr.html",

--- a/features-json/hidden.json
+++ b/features-json/hidden.json
@@ -2,7 +2,7 @@
   "title":"hidden attribute",
   "description":"The `hidden` attribute may be applied to any element, and effectively hides elements similar to `display: none` in CSS.",
   "spec":"http://www.w3.org/TR/html5/editing.html#the-hidden-attribute",
-  "status":"pr",
+  "status":"rec",
   "links":[
     {
       "url":"http://davidwalsh.name/html5-hidden",

--- a/features-json/history.json
+++ b/features-json/history.json
@@ -1,8 +1,8 @@
 {
   "title":"Session history management",
-  "description":"Method of manipulating the user's browser's session history in JavaScript using history.pushState, history.replaceState and the popstate event",
+  "description":"Method of manipulating the user's browser's session history in JavaScript using history.pushState, history.replaceState and the popstate event.",
   "spec":"https://html.spec.whatwg.org/multipage/browsers.html#dom-history-pushstate",
-  "status":"cr",
+  "status":"rec",
   "links":[
     {
       "url":"http://www.adequatelygood.com/2010/7/Saner-HTML5-History-Management",

--- a/features-json/html5semantic.json
+++ b/features-json/html5semantic.json
@@ -2,7 +2,7 @@
   "title":"New semantic elements",
   "description":"HTML5 offers some new elements, primarily for semantic purposes. The elements include: section, article, aside, header, footer, nav, figure, figcaption, time, mark, main.",
   "spec":"https://html.spec.whatwg.org/multipage/semantics.html#sections",
-  "status":"wd",
+  "status":"rec",
   "links":[
     {
       "url":"https://blog.whatwg.org/supporting-new-elements-in-ie",

--- a/features-json/iframe-sandbox.json
+++ b/features-json/iframe-sandbox.json
@@ -1,8 +1,8 @@
 {
   "title":"sandbox attribute for iframes",
-  "description":"Method of running external site pages with reduced privileges (e.g. no JavaScript) in iframes",
+  "description":"Method of running external site pages with reduced privileges (e.g. no JavaScript) in iframes.",
   "spec":"https://html.spec.whatwg.org/multipage/embedded-content.html#attr-iframe-sandbox",
-  "status":"cr",
+  "status":"rec",
   "links":[
     {
       "url":"http://blog.chromium.org/2010/05/security-in-depth-html5s-sandbox.html",

--- a/features-json/input-color.json
+++ b/features-json/input-color.json
@@ -2,7 +2,7 @@
   "title":"Color input type",
   "description":"Form field allowing the user to select a color.",
   "spec":"https://html.spec.whatwg.org/multipage/forms.html#color-state-(type=color)",
-  "status":"wd",
+  "status":"rec",
   "links":[
     {
       "url":"http://www.html5tutorial.info/html5-color.php",

--- a/features-json/input-datetime.json
+++ b/features-json/input-datetime.json
@@ -2,7 +2,7 @@
   "title":"Date and time input types",
   "description":"Form field widget to easily allow users to enter a date or a time, generally by using a calendar/time input widget. Previously there was also a single field for both date & time, but this has been deprecated.",
   "spec":"https://html.spec.whatwg.org/multipage/forms.html#date-state-(type=date)",
-  "status":"cr",
+  "status":"rec",
   "links":[
     {
       "url":"http://net.tutsplus.com/tutorials/javascript-ajax/quick-tip-cross-browser-datepickers-within-minutes/",

--- a/features-json/input-file-multiple.json
+++ b/features-json/input-file-multiple.json
@@ -2,7 +2,7 @@
   "title":"Multiple file selection",
   "description":"Allows users to select multiple files in the file picker.",
   "spec":"https://html.spec.whatwg.org/multipage/forms.html#attr-input-multiple",
-  "status":"wd",
+  "status":"rec",
   "links":[
     {
       "url":"https://code.google.com/p/chromium/issues/detail?id=348912",

--- a/features-json/input-number.json
+++ b/features-json/input-number.json
@@ -2,7 +2,7 @@
   "title":"Number input type",
   "description":"Form field type for numbers.",
   "spec":"https://html.spec.whatwg.org/multipage/forms.html#number-state-(type=number)",
-  "status":"wd",
+  "status":"rec",
   "links":[
     {
       "url":"http://www.html5tutorial.info/html5-number.php",

--- a/features-json/input-placeholder.json
+++ b/features-json/input-placeholder.json
@@ -2,7 +2,7 @@
   "title":"input placeholder attribute",
   "description":"Method of setting placeholder text for text-like input fields, to suggest the expected inserted information.",
   "spec":"https://html.spec.whatwg.org/multipage/forms.html#attr-input-placeholder",
-  "status":"cr",
+  "status":"rec",
   "links":[
     {
       "url":"http://www.zachleat.com/web/placeholder/",

--- a/features-json/input-range.json
+++ b/features-json/input-range.json
@@ -2,7 +2,7 @@
   "title":"Range input type",
   "description":"Form field type that allows the user to select a value using a slider widget.",
   "spec":"https://html.spec.whatwg.org/multipage/forms.html#range-state-(type=range)",
-  "status":"wd",
+  "status":"rec",
   "links":[
     {
       "url":"https://github.com/fryn/html5slider",

--- a/features-json/link-icon-png.json
+++ b/features-json/link-icon-png.json
@@ -2,7 +2,7 @@
   "title":"PNG favicons",
   "description":"Icon used by browsers to identify a webpage or site. While all browsers support the `.ico` format, the PNG format can be preferable.",
   "spec":"https://html.spec.whatwg.org/multipage/semantics.html#rel-icon",
-  "status":"pr",
+  "status":"rec",
   "links":[
     {
       "url":"http://css-tricks.com/favicon-quiz/",
@@ -202,7 +202,7 @@
     "1":"If both ICO and PNG are available, will use ICO over PNG if ICO has better matching sizes set.",
     "2":"If both ICO and PNG are available, will ALWAYS use ICO file, regardless of sizes set.",
     "3":"If multiple formats are available, will use the last one loaded, regardless of sizes (effectively picks at random).",
-    "4":"Does not use favicons at all (but may have alternative for bookmarks, etc)"
+    "4":"Does not use favicons at all (but may have alternative for bookmarks, etc.)."
   },
   "usage_perc_y":77.82,
   "usage_perc_a":0,

--- a/features-json/link-icon-svg.json
+++ b/features-json/link-icon-svg.json
@@ -2,7 +2,7 @@
   "title":"SVG favicons",
   "description":"Icon used by browsers to identify a webpage or site. While all browsers support the `.ico` format, the SVG format can be preferable to more easily support higher resolutions or larger icons.",
   "spec":"https://html.spec.whatwg.org/multipage/semantics.html#rel-icon",
-  "status":"pr",
+  "status":"rec",
   "links":[
     {
       "url":"http://crbug.com/294179",

--- a/features-json/menu.json
+++ b/features-json/menu.json
@@ -2,7 +2,7 @@
   "title":"Toolbar/context menu",
   "description":"Method of defining a toolbar menu, a context menu or a list of (interactive) options using the <menu> element.",
   "spec":"https://html.spec.whatwg.org/multipage/forms.html#the-menu-element",
-  "status":"cr",
+  "status":"wd",
   "links":[
     {
       "url":"https://bug617528.bugzilla.mozilla.org/attachment.cgi?id=554309",

--- a/features-json/offline-apps.json
+++ b/features-json/offline-apps.json
@@ -2,7 +2,7 @@
   "title":"Offline web applications",
   "description":"Method of defining web page files to be cached using a cache manifest file, allowing them to work offline on subsequent visits to the page",
   "spec":"https://html.spec.whatwg.org/multipage/browsers.html#offline",
-  "status":"wd",
+  "status":"rec",
   "links":[
     {
       "url":"http://www.sitepoint.com/offline-web-application-tutorial/",

--- a/features-json/progressmeter.json
+++ b/features-json/progressmeter.json
@@ -2,7 +2,7 @@
   "title":"Progress & Meter",
   "description":"Method of indicating a progress state (progress element) or the current level of a gauge (meter element).\r\n",
   "spec":"https://html.spec.whatwg.org/multipage/forms.html#the-progress-element",
-  "status":"wd",
+  "status":"rec",
   "links":[
     {
       "url":"https://dev.opera.com/articles/new-form-features-in-html5/#newoutput",
@@ -10,7 +10,7 @@
     },
     {
       "url":"http://html5doctor.com/measure-up-with-the-meter-tag/",
-      "title":"HTML5 Doctor on meter element "
+      "title":"HTML5 Doctor on meter element"
     },
     {
       "url":"http://peter.sh/examples/?/html/meter-progress.html",

--- a/features-json/ruby.json
+++ b/features-json/ruby.json
@@ -1,8 +1,8 @@
 {
   "title":"Ruby annotation",
-  "description":"Method of adding pronunciation or other annotations using ruby elements (primarily used in East Asian typography)",
+  "description":"Method of adding pronunciation or other annotations using ruby elements (primarily used in East Asian typography).",
   "spec":"http://www.w3.org/TR/html-markup/ruby.html",
-  "status":"wd",
+  "status":"rec",
   "links":[
     {
       "url":"http://html5doctor.com/ruby-rt-rp-element/",
@@ -207,7 +207,7 @@
       "9.9":"a"
     }
   },
-  "notes":"Browsers without native support can still simulate support using CSS. Partial support refers to only supporting basic ruby, may still be missing writing-mode, Complex ruby and CSS3 Ruby",
+  "notes":"Browsers without native support can still simulate support using CSS. Partial support refers to only supporting basic ruby, may still be missing writing-mode, Complex ruby and CSS3 Ruby.",
   "notes_by_num":{
     
   },

--- a/features-json/script-async.json
+++ b/features-json/script-async.json
@@ -2,7 +2,7 @@
   "title":"async attribute for external scripts",
   "description":"The boolean async attribute on script elements allows the external JavaScript file to run when it's available, without delaying page load first.",
   "spec":"https://html.spec.whatwg.org/multipage/scripting.html#attr-script-async",
-  "status":"cr",
+  "status":"rec",
   "links":[
     {
       "url":"https://developer.mozilla.org/en/HTML/Element/script#Attributes",

--- a/features-json/script-defer.json
+++ b/features-json/script-defer.json
@@ -2,7 +2,7 @@
   "title":"defer attribute for external scripts",
   "description":"The boolean defer attribute on script elements allows the external JavaScript file to run when the DOM is loaded, without delaying page load first.",
   "spec":"https://html.spec.whatwg.org/multipage/scripting.html#attr-script-defer",
-  "status":"cr",
+  "status":"rec",
   "links":[
     {
       "url":"https://developer.mozilla.org/en/HTML/Element/script#Attributes",
@@ -206,7 +206,7 @@
       "9.9":"y"
     }
   },
-  "notes":"Partial support in older IE refers to a buggy implementation (see issue)",
+  "notes":"Partial support in older IE refers to a buggy implementation (see issue).",
   "notes_by_num":{
     
   },

--- a/features-json/spellcheck-attribute.json
+++ b/features-json/spellcheck-attribute.json
@@ -2,7 +2,7 @@
   "title":"Spellcheck attribute",
   "description":"Attribute for `input`/`textarea` fields to enable/disable the browser's spellchecker.",
   "spec":"https://html.spec.whatwg.org/multipage/interaction.html#spelling-and-grammar-checking",
-  "status":"cr",
+  "status":"rec",
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/HTML/Controlling_spell_checking_in_HTML_formsControlling_spell_checking_in_HTML_forms",

--- a/features-json/svg-html5.json
+++ b/features-json/svg-html5.json
@@ -2,7 +2,7 @@
   "title":"Inline SVG in HTML5",
   "description":"Method of using SVG tags directly in HTML documents. Requires HTML5 parser.",
   "spec":"https://html.spec.whatwg.org/multipage/embedded-content.html#svg-0",
-  "status":"cr",
+  "status":"rec",
   "links":[
     {
       "url":"http://hacks.mozilla.org/2010/05/firefox-4-the-html5-parser-inline-svg-speed-and-more/",

--- a/features-json/svg-img.json
+++ b/features-json/svg-img.json
@@ -1,8 +1,8 @@
 {
   "title":"SVG in HTML img element",
-  "description":"Method of displaying SVG images in HTML using <img>",
+  "description":"Method of displaying SVG images in HTML using <img>.",
   "spec":"https://html.spec.whatwg.org/multipage/embedded-content.html",
-  "status":"cr",
+  "status":"rec",
   "links":[
     {
       "url":"http://blog.dholbert.org/2010/10/svg-as-image.html",

--- a/features-json/video.json
+++ b/features-json/video.json
@@ -1,8 +1,8 @@
 {
   "title":"Video element",
-  "description":"Method of playing videos on webpages (without requiring a plug-in)",
+  "description":"Method of playing videos on webpages (without requiring a plug-in).",
   "spec":"https://html.spec.whatwg.org/multipage/embedded-content.html#the-video-element",
-  "status":"cr",
+  "status":"rec",
   "links":[
     {
       "url":"https://dev.opera.com/articles/view/everything-you-need-to-know-about-html5-video-and-audio/",


### PR DESCRIPTION
Also, changed the `menu` element to `wd` to reflect that it is part of 5.1. Made a few minor changes to descriptions, mostly involving adding periods at end for consistency.

Please note that I did _not_ change any of the URLs that point to the specs. Please see my question in #801 about whether they should be updated to point to the W3C Recommendation instead of WHATWG.

Thanks for providing caniuse to the community. Hope this update helps some.
