### PR TITLE
Update css-boxshadow.json

### DIFF
--- a/features-json/css-boxshadow.json
+++ b/features-json/css-boxshadow.json
@@ -27,7 +27,7 @@
   ],
   "bugs":[
     {
-      "description":"Safari 6, iOS 6 and Android 2.3 default browser don't work with a 0px value for \"spread\".\r\ne.g. -webkit-box-shadow: 5px 1px 0px #f04e29;\r\ndoesn't work, but\r\n-webkit-box-shadow: 5px 1px 1px #f04e29\r\ndoes."
+      "description":"Safari 6, iOS 6 and Android 2.3 default browser don't work with a 0px value for \"blur-radius\".\r\ne.g. -webkit-box-shadow: 5px 1px 0px 1px #f04e29;\r\ndoesn't work, but\r\n-webkit-box-shadow: 5px 1px 1px 1px #f04e29\r\ndoes."
     }
   ],
   "categories":[


### PR DESCRIPTION
Bug description stated that a 0-value for "spread" for some browsers doesn't work, but it's a 0-value for "blur-radius" (optional third parameter in spec) that causes the issue, "spread-radius", the optional fourth parameter, may be 0. Confirmed on emulated version of Android 2.3.
