### PR TITLE
Update css-sticky with more correct Firefox bug

### DIFF
--- a/features-json/css-sticky.json
+++ b/features-json/css-sticky.json
@@ -27,7 +27,7 @@
   ],
   "bugs":[
     {
-      "description":"Firefox and Safari do not appear to support [sticky table headers](http://jsfiddle.net/Mf4YT/2/). (see also [Firefox bug](https://bugzilla.mozilla.org/show_bug.cgi?id=925259))"
+      "description":"Firefox and Safari do not appear to support [sticky table headers](http://jsfiddle.net/Mf4YT/2/). (see also [Firefox bug](https://bugzilla.mozilla.org/show_bug.cgi?id=975644))"
     }
   ],
   "categories":[


### PR DESCRIPTION
[925259](https://bugzilla.mozilla.org/show_bug.cgi?id=925259) was referring to buggy handling of position:sticky with &lt;thead>. This issue has since been fixed, but the functionality disabled until [35168](https://bugzilla.mozilla.org/show_bug.cgi?id=35168) is fixed. The new tracking bug for this (and other table parts) is [975644](https://bugzilla.mozilla.org/show_bug.cgi?id=975644).
