### PR TITLE
Move eventsource to PR

### DIFF
--- a/features-json/eventsource.json
+++ b/features-json/eventsource.json
@@ -2,7 +2,7 @@
   "title":"Server-sent events",
   "description":"Method of continuously sending data from a server to the browser, rather than repeatedly requesting it (EventSource interface, used to fall under HTML5)",
   "spec":"http://www.w3.org/TR/eventsource/",
-  "status":"cr",
+  "status":"pr",
   "links":[
     {
       "url":"http://www.html5rocks.com/tutorials/eventsource/basics/",


### PR DESCRIPTION
The "Server-Sent Events" spec was moved to PR on December 9: http://www.w3.org/TR/2014/PR-eventsource-20141209/
