### PR TITLE
Remove redundancy in viewport units notes

### DIFF
--- a/features-json/viewport-units.json
+++ b/features-json/viewport-units.json
@@ -223,7 +223,7 @@
       "9.9":"n"
     }
   },
-  "notes":"Partial support in IE9 refers to supporting \"vm\" instead of \"vmin\".\r\n\r\nPartial support in IE10 refers to lack of \"vmax\" support.\r\n\r\nPartial support in iOS7 is due to buggy behavior of the \"vh\" unit (see [workaround](https://gist.github.com/pburtchaell/e702f441ba9b3f76f587)).\r\n\r\nAll other partial support refers to not supporting the \"vmax\" unit. ",
+  "notes":"Partial support in IE9 refers to supporting \"vm\" instead of \"vmin\".\r\n\r\nPartial support in iOS7 is due to buggy behavior of the \"vh\" unit (see [workaround](https://gist.github.com/pburtchaell/e702f441ba9b3f76f587)).\r\n\r\nAll other partial support refers to not supporting the \"vmax\" unit. ",
   "notes_by_num":{
     
   },


### PR DESCRIPTION
> Partial support in IE10 refers to lack of "vmax" support.
> [...]
> All other partial support refers to not supporting the "vmax" unit.

The IE10-specific note can be removed since it already falls under the general "all other" note.
