### PR TITLE
added iOS 8.* sibling selector bug

### DIFF
--- a/features-json/queryselector.json
+++ b/features-json/queryselector.json
@@ -22,7 +22,9 @@
     }
   ],
   "bugs":[
-    
+    {
+      "description":"iOS 8.* contains a [bug](https://github.com/jquery/sizzle/issues/290) where selecting siblings of filtered id selections are no longer working (for example #a + p)."
+    }
   ],
   "categories":[
     "DOM"


### PR DESCRIPTION
I'm not sure if it should be in, but I guess it could save people a lot of headache knowing about this bug.

jquery/sizzle#290
