### PR TITLE
Fix spec link

### DIFF
--- a/features-json/matchesselector.json
+++ b/features-json/matchesselector.json
@@ -1,7 +1,7 @@
 {
   "title":"matches() DOM method",
   "description":"Method of testing whether or not a DOM element matches a given selector. Formerly known (and largely supported with prefix) as matchesSelector.",
-  "spec":"http://www.w3.org/TR/selectors-api2/",
+  "spec":"https://dom.spec.whatwg.org/#dom-element-matches",
   "status":"wd",
   "links":[
     {


### PR DESCRIPTION
CSS Selectors 2 is not maintained; DOM is where the method lives
