### PR TITLE
Remove incorrect "DOM" suffix for CSS Supports API

### DIFF
--- a/features-json/css-supports-api.json
+++ b/features-json/css-supports-api.json
@@ -1,5 +1,5 @@
 {
-  "title":"CSS.supports() DOM API",
+  "title":"CSS.supports() API",
   "description":"The CSS.supports() static methods returns a Boolean value indicating if the browser supports a given CSS feature, or not.",
   "spec":"http://dev.w3.org/csswg/css-conditional/#the-css-interface",
   "status":"cr",


### PR DESCRIPTION
It is not related to the DOM.
