### PR TITLE
Update background-img-opts.json

### DIFF
--- a/features-json/background-img-opts.json
+++ b/features-json/background-img-opts.json
@@ -20,6 +20,9 @@
   "bugs":[
     {
       "description":"iOS Safari has buggy behavior with `background-size: cover;` on a page's body."
+    },
+    {
+      "description":"iOS Safari has buggy behavior with `background-size: cover;` + `background-attachment: fixed;`"
     }
   ],
   "categories":[


### PR DESCRIPTION
Addet iOS Safari Bug "iOS Safari has buggy behavior with `background-size: cover;` + `background-attachment: fixed;`"