### PR TITLE
Add text-align-last feature

### DIFF
--- a/features-json/css-text-align-last.json
+++ b/features-json/css-text-align-last.json
@@ -1,0 +1,220 @@
+{
+  "title":"CSS3 text-align-last",
+  "description":"CSS property to describe how the last line of a block or a line right before a forced line break",
+  "spec":"http://www.w3.org/TR/css3-text/#text-align-last-property",
+  "status":"wd",
+  "links":[
+    {
+      "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/text-align-last",
+      "title":"MDN text-align-last"
+    },
+    {
+      "url":"http://blogs.adobe.com/webplatform/2014/02/25/improving-your-sites-visual-details-css3-text-align-last/",
+      "title":"Adobe Web Platform Article"
+    }
+  ],
+  "bugs":[
+  ],
+  "categories":[
+    "CSS3"
+  ],
+  "stats":{
+    "ie":{
+      "5.5":"a #1",
+      "6":"a #1",
+      "7":"a #1",
+      "8":"a #1",
+      "9":"a #1",
+      "10":"a #1",
+      "11":"a #1",
+      "TP":"a #1"
+    },
+    "firefox":{
+      "2":"n",
+      "3":"n",
+      "3.5":"n",
+      "3.6":"n",
+      "4":"n",
+      "5":"n",
+      "6":"n",
+      "7":"n",
+      "8":"n",
+      "9":"n",
+      "10":"n",
+      "11":"n",
+      "12":"y x",
+      "13":"y x",
+      "14":"y x",
+      "15":"y x",
+      "16":"y x",
+      "17":"y x",
+      "18":"y x",
+      "19":"y x",
+      "20":"y x",
+      "21":"y x",
+      "22":"y x",
+      "23":"y x",
+      "24":"y x",
+      "25":"y x",
+      "26":"y x",
+      "27":"y x",
+      "28":"y x",
+      "29":"y x",
+      "30":"y x",
+      "31":"y x",
+      "32":"y x",
+      "33":"y x",
+      "34":"y x",
+      "35":"y x",
+      "36":"y x",
+      "37":"y x",
+      "38":"y x"
+    },
+    "chrome":{
+      "4":"n",
+      "5":"n",
+      "6":"n",
+      "7":"n",
+      "8":"n",
+      "9":"n",
+      "10":"n",
+      "11":"n",
+      "12":"n",
+      "13":"n",
+      "14":"n",
+      "15":"n",
+      "16":"n",
+      "17":"n",
+      "18":"n",
+      "19":"n",
+      "20":"n",
+      "21":"n",
+      "22":"n",
+      "23":"n",
+      "24":"n",
+      "25":"n",
+      "26":"n",
+      "27":"n",
+      "28":"n",
+      "29":"n",
+      "30":"n",
+      "31":"n",
+      "32":"n",
+      "33":"n",
+      "34":"n",
+      "35":"y d #2",
+      "36":"y d #2",
+      "37":"y d #2",
+      "38":"y d #2",
+      "39":"y d #2",
+      "40":"y d #2",
+      "41":"y d #2",
+      "42":"y d #2",
+      "43":"y d #2"
+    },
+    "safari":{
+      "3.1":"n",
+      "3.2":"n",
+      "4":"n",
+      "5":"n",
+      "5.1":"n",
+      "6":"n",
+      "6.1":"n",
+      "7":"n",
+      "7.1":"n",
+      "8":"n"
+    },
+    "opera":{
+      "9":"n",
+      "9.5-9.6":"n",
+      "10.0-10.1":"n",
+      "10.5":"n",
+      "10.6":"n",
+      "11":"n",
+      "11.1":"n",
+      "11.5":"n",
+      "11.6":"n",
+      "12":"n",
+      "12.1":"n",
+      "15":"n",
+      "16":"n",
+      "17":"n",
+      "18":"n",
+      "19":"n",
+      "20":"n",
+      "21":"n",
+      "22":"y d #3",
+      "23":"y d #3",
+      "24":"y d #3",
+      "25":"y d #3",
+      "26":"y d #3",
+      "27":"y d #3",
+      "28":"y d #3"
+    },
+    "ios_saf":{
+      "3.2":"n",
+      "4.0-4.1":"n",
+      "4.2-4.3":"n",
+      "5.0-5.1":"n",
+      "6.0-6.1":"n",
+      "7.0-7.1":"n",
+      "8":"n",
+      "8.1":"n"
+    },
+    "op_mini":{
+      "5.0-8.0":"n"
+    },
+    "android":{
+      "2.1":"n",
+      "2.2":"n",
+      "2.3":"n",
+      "3":"n",
+      "4":"n",
+      "4.1":"n",
+      "4.2-4.3":"n",
+      "4.4":"n",
+      "4.4.3-4.4.4":"n",
+      "37":"y d #2"
+    },
+    "bb":{
+      "7":"n",
+      "10":"n"
+    },
+    "op_mob":{
+      "10":"n",
+      "11":"n",
+      "11.1":"n",
+      "11.5":"n",
+      "12":"n",
+      "12.1":"n",
+      "24":"y d #3"
+    },
+    "and_chr":{
+      "39":"y d #2"
+    },
+    "and_ff":{
+      "33":"y x"
+    },
+    "ie_mob":{
+      "10":"a #1",
+      "11":"a #1"
+    },
+    "and_uc":{
+      "9.9":"u"
+    }
+  },
+  "notes":"",
+  "notes_by_num":{
+    "1":"In Internet Explorer, the start and end values are not supported.",
+    "2":"Enabled through the \"Enable Experimental Web Platform Features\" flag in chrome://flags",
+    "3":"Enabled through the \"Enable Experimental Web Platform Features\" flag in opera://flags"
+  },
+  "usage_perc_y":87.42,
+  "usage_perc_a":3.18,
+  "ucprefix":false,
+  "parent":"",
+  "keywords":"text align last",
+  "ie_id":"",
+  "chrome_id":"",
+  "shown":true
+}


### PR DESCRIPTION
By [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-align-last) data and @yisibl 
[investigation](https://github.com/postcss/autoprefixer/issues/372#issue-53359465).