### PR TITLE
Link to whatwg for the xhr spec

### DIFF
--- a/features-json/xhr2.json
+++ b/features-json/xhr2.json
@@ -1,8 +1,8 @@
 {
   "title":"XMLHttpRequest 2",
   "description":"Adds more functionality to AJAX requests like file uploads, transfer progress information and the ability to send form data.",
-  "spec":"http://www.w3.org/TR/XMLHttpRequest2/",
-  "status":"wd",
+  "spec":"https://xhr.spec.whatwg.org/",
+  "status":"ls",
   "links":[
     {
       "url":"https://developer.mozilla.org/en/XMLHttpRequest/FormData",


### PR DESCRIPTION
http://www.w3.org/TR/XMLHttpRequest2/:

>Work on this document has been discontinued and it should not be referenced or used as a basis for implementation. However, the Web Applications Working Group continues to work on XMLHttpRequest Level 1 and the WHATWG continues to work on XMLHttprequest.