### PR TITLE
add hint about missing datalist support for input type number in FF

### DIFF
--- a/features-json/datalist.json
+++ b/features-json/datalist.json
@@ -221,7 +221,7 @@
       "9.9":"y"
     }
   },
-  "notes":"Partial support in IE10 refers to [significantly buggy behavior](http://playground.onereason.eu/2013/04/ie10s-lousy-support-for-datalists/).",
+  "notes":"Partial support in IE10 refers to [significantly buggy behavior](http://playground.onereason.eu/2013/04/ie10s-lousy-support-for-datalists/). Firefox doesn't support [datalist association with inputs of type `number`](http://codepen.io/graste/pen/bNoVKW).",
   "notes_by_num":{
     
   },

--- a/features-json/input-number.json
+++ b/features-json/input-number.json
@@ -221,7 +221,7 @@
       "9.9":"a"
     }
   },
-  "notes":"iOS Safari, Android 4, Chrome for Android show number input, but do not use \"step\", \"min\" or \"max\" attributes or show increment/decrement buttons. Internet Explorer 10 and 11 do not show increment/decrement buttons.",
+  "notes":"iOS Safari, Android 4, Chrome for Android show number input, but do not use \"step\", \"min\" or \"max\" attributes or show increment/decrement buttons. Internet Explorer 10 and 11 do not show increment/decrement buttons. Firefox doesn't support [autocomplete content via datalist](http://codepen.io/graste/pen/bNoVKW) elements.",
   "notes_by_num":{
     
   },


### PR DESCRIPTION
See [demo on codepen](http://codepen.io/graste/pen/bNoVKW) in Firefox and latest Opera/Chrome to see the difference. Firefox is missing autocomplete support or a dropdown select list.