### PR TITLE
Safari <img> border-radius bug fixed as of v7.0

### DIFF
--- a/features-json/border-radius.json
+++ b/features-json/border-radius.json
@@ -27,9 +27,6 @@
   ],
   "bugs":[
     {
-      "description":"Safari does not apply `border-radius` correctly to image borders: http://stackoverflow.com/q/17202128"
-    },
-    {
       "description":"Android Browser 2.3 does not support % value for `border-radius`."
     },
     {
@@ -141,9 +138,9 @@
       "3.2":"y x",
       "4":"y x",
       "5":"y",
-      "5.1":"y",
-      "6":"y",
-      "6.1":"y",
+      "5.1":"y #1",
+      "6":"y #1",
+      "6.1":"y #1",
       "7":"y",
       "7.1":"y",
       "8":"y"
@@ -230,7 +227,7 @@
   },
   "notes":"",
   "notes_by_num":{
-    
+    "1":"Safari 6.1 and earlier did not apply `border-radius` correctly to image borders: http://stackoverflow.com/q/17202128"
   },
   "usage_perc_y":89.66,
   "usage_perc_a":0.01,


### PR DESCRIPTION
Prior to v5.1: Bug is probably present, but I don't have such old versions handy to test against.
Bug definitely present in: v5.1.9, v6.0.5
Bug probably present in v6.1, based on SO question's creation date.
Bug definitely absent as of: v7.0.6