### PR TITLE
Note about the need for the lang attribute to make CSS hyphenation work

### DIFF
--- a/features-json/css-hyphens.json
+++ b/features-json/css-hyphens.json
@@ -209,7 +209,7 @@
       "9.9":"a x"
     }
   },
-  "notes":"Chrome 29- and Android 4.0 Browser support \"-webkit-hyphens: none\", but not the \"auto\" property. Chrome 30+ doesn't support it either.",
+  "notes":"Chrome 29- and Android 4.0 Browser support \"-webkit-hyphens: none\", but not the \"auto\" property. Chrome 30+ doesn't support it either. It is [advisable to set the @lang attribute](http://blog.adrianroselli.com/2015/01/on-use-of-lang-attribute.html) on the HTML element to enable hyphenation support and improve accessibility.",
   "notes_by_num":{
     
   },

--- a/features-json/datalist.json
+++ b/features-json/datalist.json
@@ -221,7 +221,7 @@
       "9.9":"y"
     }
   },
-  "notes":"Partial support in IE10 refers to [significantly buggy behavior](http://playground.onereason.eu/2013/04/ie10s-lousy-support-for-datalists/).",
+  "notes":"Partial support in IE10 refers to [significantly buggy behavior](http://playground.onereason.eu/2013/04/ie10s-lousy-support-for-datalists/). Firefox doesn't support [datalist association with inputs of type `number`](http://codepen.io/graste/pen/bNoVKW).",
   "notes_by_num":{
     
   },

--- a/features-json/input-number.json
+++ b/features-json/input-number.json
@@ -221,7 +221,7 @@
       "9.9":"a"
     }
   },
-  "notes":"iOS Safari, Android 4, Chrome for Android show number input, but do not use \"step\", \"min\" or \"max\" attributes or show increment/decrement buttons. Internet Explorer 10 and 11 do not show increment/decrement buttons.",
+  "notes":"iOS Safari, Android 4, Chrome for Android show number input, but do not use \"step\", \"min\" or \"max\" attributes or show increment/decrement buttons. Internet Explorer 10 and 11 do not show increment/decrement buttons. Firefox doesn't support [autocomplete content via datalist](http://codepen.io/graste/pen/bNoVKW) elements.",
   "notes_by_num":{
     
   },


### PR DESCRIPTION
To make hyphenation work it is advisable to set the `lang` attribute on the HTML element as suggested [on quirksmode.org](http://www.quirksmode.org/blog/archives/2012/11/hyphenation_wor.html) and [adrianroselli.com](http://blog.adrianroselli.com/2015/01/on-use-of-lang-attribute.html).

```html
<html lang="en">
…
</html>
```