### PR TITLE
Position:sticky is now "official", in WD

### DIFF
--- a/features-json/css-sticky.json
+++ b/features-json/css-sticky.json
@@ -1,8 +1,8 @@
 {
   "title":"CSS position:sticky",
   "description":"Keeps elements positioned as \"fixed\" or \"relative\" depending on how it appears in the viewport. As a result the element is \"stuck\" when necessary while scrolling.",
-  "spec":"http://dev.w3.org/csswg/css-position/#sticky-positioning",
-  "status":"unoff",
+  "spec":"http://www.w3.org/TR/2015/WD-css3-positioning-20150203/#sticky-pos",
+  "status":"wd",
   "links":[
     {
       "url":"http://updates.html5rocks.com/2012/08/Stick-your-landings-position-sticky-lands-in-WebKit",


### PR DESCRIPTION
Spec published yesterday: http://www.w3.org/TR/2015/WD-css3-positioning-20150203/