### PR TITLE
Update fetch.json

### DIFF
--- a/features-json/fetch.json
+++ b/features-json/fetch.json
@@ -209,7 +209,7 @@
   "notes_by_num":{
     "1":"Partial support can be enabled in Firefox with the `dom.fetch.enabled` flag.",
     "2":"Only available in Chrome and Opera within ServiceWorkers.",
-    "3":"Available in Chrome and Opera within Window by enabling the \"Experimental Web Platform Features\" flag in `chrome://flags`"
+    "3":"Available in Chrome and Opera within Window and Workers by enabling the \"Experimental Web Platform Features\" flag in `chrome://flags`"
   },
   "usage_perc_y":0,
   "usage_perc_a":16.84,

--- a/features-json/fetch.json
+++ b/features-json/fetch.json
@@ -109,9 +109,9 @@
       "38":"n",
       "39":"n",
       "40":"a #2",
-      "41":"a #2",
-      "42":"a d #2 #3",
-      "43":"a d #2 #3"
+      "41":"a #2 #3",
+      "42":"y",
+      "43":"y"
     },
     "safari":{
       "3.1":"n",
@@ -149,9 +149,9 @@
       "24":"n",
       "25":"n",
       "26":"n",
-      "27":"n",
-      "28":"n",
-      "29":"n"
+      "27":"a #2",
+      "28":"a #2 #3",
+      "29":"y"
     },
     "ios_saf":{
       "3.2":"n",
@@ -208,8 +208,8 @@
   "notes":"",
   "notes_by_num":{
     "1":"Partial support can be enabled in Firefox with the `dom.fetch.enabled` flag.",
-    "2":"Only available in Chrome within ServiceWorkers.",
-    "3":"Available in Chrome within Window by enabling the \"Experimental Web Platform Features\" flag in `chrome://flags`"
+    "2":"Only available in Chrome and Opera within ServiceWorkers.",
+    "3":"Available in Chrome and Opera within Window by enabling the \"Experimental Web Platform Features\" flag in `chrome://flags`"
   },
   "usage_perc_y":0,
   "usage_perc_a":16.84,


### PR DESCRIPTION
Fetch shipped in Chrome canary 42 in the window context by default:
https://code.google.com/p/chromium/issues/detail?id=436770#c24
Also matched the support in Opera.