### PR TITLE
Ruby enabled in Firefox 38.0

### DIFF
--- a/features-json/ruby.json
+++ b/features-json/ruby.json
@@ -22,7 +22,7 @@
     }
   ],
   "bugs":[
-    
+
   ],
   "categories":[
     "HTML5"
@@ -77,7 +77,7 @@
       "35":"p",
       "36":"p",
       "37":"p",
-      "38":"p"
+      "38":"y"
     },
     "chrome":{
       "4":"p",
@@ -215,7 +215,7 @@
   },
   "notes":"Browsers without native support can still simulate support using CSS. Partial support refers to only supporting basic ruby, may still be missing writing-mode, Complex ruby and CSS3 Ruby.",
   "notes_by_num":{
-    
+
   },
   "usage_perc_y":0,
   "usage_perc_a":80.71,


### PR DESCRIPTION
Ruby is enabled by default in Firefox 38.0:

https://bugzilla.mozilla.org/show_bug.cgi?id=1039006