### PR TITLE
Updated Firefox compatibility note

### DIFF
--- a/features-json/websockets.json
+++ b/features-json/websockets.json
@@ -27,7 +27,7 @@
   ],
   "bugs":[
     {
-      "description":"Firefox cannot host a WebSocket within a WebWorker context; see https://bugzilla.mozilla.org/show_bug.cgi?id=504553"
+      "description":"Firefox 36 and lower cannot host a WebSocket within a WebWorker context; see https://developer.mozilla.org/en-US/Firefox/Releases/37"
     }
   ],
   "categories":[


### PR DESCRIPTION
Firefox 37 beta can host WebSockets in a WebWorker context.