### PR TITLE
Make WebP unofficial

### DIFF
--- a/features-json/webp.json
+++ b/features-json/webp.json
@@ -2,7 +2,7 @@
   "title":"WebP image format",
   "description":"Image format that supports lossy and lossless compression, as well as animation and alpha transparency.",
   "spec":"https://developers.google.com/speed/webp/",
-  "status":"other",
+  "status":"unoff",
   "links":[
     {
       "url":"https://developers.google.com/speed/webp/",


### PR DESCRIPTION
WebP is unofficial and not on any standards track. It is controlled by Google.