### PR TITLE
Update css-clip-path.json

### DIFF
--- a/features-json/css-clip-path.json
+++ b/features-json/css-clip-path.json
@@ -7,6 +7,10 @@
     {
       "url":"http://css-tricks.com/almanac/properties/c/clip/",
       "title":"CSS Tricks article"
+    },
+    {
+      "url":"http://codepen.io/dubrod/details/myNNyW/",
+      "title":"Codepen Example Clipping an Image with a Polygon"
     }
   ],
   "bugs":[


### PR DESCRIPTION
Detailed Example of clipping an image using clip-path polygon css and svg coordinates url(#) style.