### PR TITLE
Update bugs section of high-resolution-time.json

### DIFF
--- a/features-json/high-resolution-time.json
+++ b/features-json/high-resolution-time.json
@@ -22,7 +22,10 @@
     }
   ],
   "bugs":[
-    
+    {
+      "description":"The Spy in the Sandbox vulnerability is a class of JavaScript-based exploits that leverage the High Resolution Time API to detect CPU cache hit/miss on chosen plaintext data placed into cache by an attacker. [Full security research paper is here](http://arxiv.org/abs/1502.07373)",
+      "description":"Some versions of Chrome and Opera on Windows have only millisecond precision. The fractional part is always near the very start or the very end of a millisecond. (<a href=\"https://code.google.com/p/chromium/issues/detail?id=158234\">issue #158234</a>)."
+    }
   ],
   "categories":[
     "JS API"


### PR DESCRIPTION
The High Resolution Time API has been found to enable a "Spy in the Sandbox" class of security vulnerability. Full PDF of security research paper is at http://arxiv.org/pdf/1502.07373v2.pdf
Also found an old Temp2 fork created last year by Fyrd containing Chrome and Opera about older versions of Chrome and Opera on Windows. Copied and pasted into this proposed update, then revised to "Some versions of ..."