### PR TITLE
firefox border-image bug

### DIFF
--- a/features-json/border-image.json
+++ b/features-json/border-image.json
@@ -14,7 +14,9 @@
     }
   ],
   "bugs":[
-    
+    {
+      "description": "Firefox is not able to stretch svg images across an element - [bug report](https://bugzilla.mozilla.org/show_bug.cgi?id=619500)."
+    }
   ],
   "categories":[
     "CSS3"


### PR DESCRIPTION
bug report - https://bugzilla.mozilla.org/show_bug.cgi?id=619500