### PR TITLE
Scroll Snap Points enabled by default in Fx39+

### DIFF
--- a/features-json/css-snappoints.json
+++ b/features-json/css-snappoints.json
@@ -10,7 +10,7 @@
     }
   ],
   "bugs":[
-    
+
   ],
   "categories":[
     "CSS"
@@ -66,9 +66,9 @@
       "36":"n",
       "37":"n",
       "38":"n",
-      "39":"n d #3",
-      "40":"n d #3",
-      "41":"n d #3"
+      "39":"y",
+      "40":"y",
+      "41":"y"
     },
     "chrome":{
       "4":"n",
@@ -212,8 +212,7 @@
   "notes":"Currently in development in WebKit with partial support in nightly builds.",
   "notes_by_num":{
     "1":"Partial support in IE10 refers to support limited to touch screens.",
-    "2":"Partial support in IE11 [documented here](https://dl.dropboxusercontent.com/u/444684/openwebref/CSS/scroll-snap-points/support.html)",
-    "3":"Can be enabled in Firefox using the `layout.css.scroll-snap.enabled` flag in `about:config`"
+    "2":"Partial support in IE11 [documented here](https://dl.dropboxusercontent.com/u/444684/openwebref/CSS/scroll-snap-points/support.html)"
   },
   "usage_perc_y":0,
   "usage_perc_a":8.86,


### PR DESCRIPTION
In Firefox 39+, CSS Scroll Snap Points are enabled by default.