### PR TITLE
css-clip-path is a subfeature of css-masks

### DIFF
--- a/features-json/css-clip-path.json
+++ b/features-json/css-clip-path.json
@@ -223,7 +223,7 @@
   "usage_perc_y":0,
   "usage_perc_a":69.91,
   "ucprefix":false,
-  "parent":"",
+  "parent":"css-masks",
   "keywords":"",
   "ie_id":"",
   "chrome_id":"",


### PR DESCRIPTION
The `clip-path` property is part of the CSS Masking Module Level 1.