### PR TITLE
Add "custom properties" as keyword for CSS variables

### DIFF
--- a/features-json/css-variables.json
+++ b/features-json/css-variables.json
@@ -221,7 +221,7 @@
   "usage_perc_a":0,
   "ucprefix":false,
   "parent":"",
-  "keywords":"css variables",
+  "keywords":"css variables,custom properties",
   "ie_id":"cssvariables",
   "chrome_id":"6401356696911872",
   "shown":true


### PR DESCRIPTION
Hi!

I often looking for "custom properties" instead of "variables".
Perhaps we could add it to the keywords?

Cheers,
Thomas.