### PR TITLE
Added a list of unsupported `calc()` properties for Firefox

### DIFF
--- a/features-json/calc.json
+++ b/features-json/calc.json
@@ -32,6 +32,9 @@
     },
     {
       "description":"IE Edge is reported to not support calc inside a 'flex'. (Not tested on older versions)\r\nThis example does not work: `flex: 1 1 calc(50% - 20px);`"
+    },
+    {
+      "description":"Firefox does not support `calc()` inside the `line-height`, `stroke-width`, `stroke-dashoffset`, and `stroke-dasharray` properties. [Bug report](https://bugzilla.mozilla.org/show_bug.cgi?id=594933)"
     }
   ],
   "categories":[


### PR DESCRIPTION
A number of CSS properties in Firefox do not support using the CSS
`calc()` inside of them. This commit adds the exceptions to the list of
known bugs for `calc()`. The related bug report can be found
[here](https://bugzilla.mozilla.org/show_bug.cgi?id=594933).