### PR TITLE
Added an .editorconfig file for consistent code style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*.json]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = false


### PR DESCRIPTION
Added an .editorconfig file to ensure editors adhere to the standards
used for JSON files. This is mostly to prevent contributors from
accidentally adding JSON indented with tabs or adding newlines to the
end of a file.