### PR TITLE
Safari still does not support CORS for <video> in <canvas>

### DIFF
--- a/features-json/cors.json
+++ b/features-json/cors.json
@@ -138,15 +138,15 @@
     "safari":{
       "3.1":"n",
       "3.2":"n",
-      "4":"a #1",
-      "5":"a #1",
-      "5.1":"a #1",
-      "6":"y",
-      "6.1":"y",
-      "7":"y",
-      "7.1":"y",
-      "8":"y",
-      "9":"y"
+      "4":"a #1 #3",
+      "5":"a #1 #3",
+      "5.1":"a #1 #3",
+      "6":"a #3",
+      "6.1":"a #3",
+      "7":"a #3",
+      "7.1":"a #3",
+      "8":"a #3",
+      "9":"a #3"
     },
     "opera":{
       "9":"n",
@@ -179,15 +179,15 @@
       "31":"y"
     },
     "ios_saf":{
-      "3.2":"a #1",
-      "4.0-4.1":"a #1",
-      "4.2-4.3":"a #1",
-      "5.0-5.1":"a #1",
-      "6.0-6.1":"y",
-      "7.0-7.1":"y",
-      "8":"y",
-      "8.1-8.3":"y",
-      "9":"y"
+      "3.2":"a #1 #3",
+      "4.0-4.1":"a #1 #3",
+      "4.2-4.3":"a #1 #3",
+      "5.0-5.1":"a #1 #3",
+      "6.0-6.1":"a #3",
+      "7.0-7.1":"a #3",
+      "8":"a #3",
+      "8.1-8.3":"a #3",
+      "9":"a #3"
     },
     "op_mini":{
       "5.0-8.0":"n"
@@ -234,7 +234,8 @@
   "notes":"",
   "notes_by_num":{
     "1":"Does not support CORS for images in `<canvas>`",
-    "2":"Supported somewhat in IE8 and IE9 using the XDomainRequest object (but has [limitations]( http://blogs.msdn.com/b/ieinternals/archive/2010/05/13/xdomainrequest-restrictions-limitations-and-workarounds.aspx))"
+    "2":"Supported somewhat in IE8 and IE9 using the XDomainRequest object (but has [limitations]( http://blogs.msdn.com/b/ieinternals/archive/2010/05/13/xdomainrequest-restrictions-limitations-and-workarounds.aspx))",
+    "3": "Does not support CORS for `<video>` in `<canvas>`: https://bugs.webkit.org/show_bug.cgi?id=135379"
   },
   "usage_perc_y":84.43,
   "usage_perc_a":8.66,


### PR DESCRIPTION
Early testing of iOS 9 is not hopeful either:
https://bugs.webkit.org/show_bug.cgi?id=135379