### PR TITLE
Firefox 41 supports SVG favicons better

### DIFF
--- a/features-json/link-icon-svg.json
+++ b/features-json/link-icon-svg.json
@@ -73,7 +73,7 @@
       "38":"a #2",
       "39":"a #2",
       "40":"a #2",
-      "41":"a #2"
+      "41":"y #4"
     },
     "chrome":{
       "4":"n",
@@ -219,8 +219,9 @@
   "notes":"See also [PNG favicons](#feat=link-icon-png).",
   "notes_by_num":{
     "1":"Does not use favicons at all",
-    "2":"Partial support in Firefox refers to only loading the SVG favicon the first time, but not [on subsequent loads](https://bugzilla.mozilla.org/show_bug.cgi?id=366324#c14).",
-    "3":"Safari 9 has support for \"[pinned tab](https://developer.apple.com/library/prerelease/mac/releasenotes/General/WhatsNewInSafari/Articles/Safari_9.html)\" SVG icons, but this requires an unofficial `mask` attribute to be set and only works for all-black icons."
+    "2":"Partial support in Firefox before version 41 refers to only loading the SVG favicon the first time, but not [on subsequent loads](https://bugzilla.mozilla.org/show_bug.cgi?id=366324#c14).",
+    "3":"Safari 9 has support for \"[pinned tab](https://developer.apple.com/library/prerelease/mac/releasenotes/General/WhatsNewInSafari/Articles/Safari_9.html)\" SVG icons, but this requires an unofficial `mask` attribute to be set and only works for all-black icons.",
+    "4":"Firefox [requires](https://bugzilla.mozilla.org/show_bug.cgi?id=366324#c50) the served mime-type to be 'image/svg+xml'."
   },
   "usage_perc_y":0,
   "usage_perc_a":10.82,


### PR DESCRIPTION
(as long as the mime-type is correct)

[Bug 366324 - Resolved Fixed](https://bugzilla.mozilla.org/show_bug.cgi?id=366324)

[HG Changeset](https://hg.mozilla.org/mozilla-central/rev/ed791601d8e7)