### PR TITLE
Remove note about Chrome for iOS bug now that it has been resolved.

### DIFF
--- a/features-json/contentsecuritypolicy.json
+++ b/features-json/contentsecuritypolicy.json
@@ -19,9 +19,6 @@
     },
     {
       "description":"Partial support in iOS Safari 5.0-5.1 refers to the browser recognizing the `X-Webkit-CSP` header but failing to handle complex cases correctly, often resulting in broken pages."
-    },
-    {
-      "description":"Chrome for iOS fails to render pages without a [connect-src 'self'](https://code.google.com/p/chromium/issues/detail?id=322497) policy."
     }
   ],
   "categories":[


### PR DESCRIPTION
Opposite of commit 861c59c11b95aac856f7, since this was a bug rather than a case of partial support it seems like it should be removed now.

See https://code.google.com/p/chromium/issues/detail?id=396076 for more information.