### PR TITLE
inline-block: Remove bunk Safari bug note

### DIFF
--- a/features-json/inline-block.json
+++ b/features-json/inline-block.json
@@ -20,9 +20,6 @@
   "bugs":[
     {
       "description":"IE 8 has a [resize issue with display-inline block](http://blog.caplin.com/2013/06/07/developing-for-ie8-inline-block-resize-bug/)."
-    },
-    {
-      "description":"inline-block shows elements in one line overflowing the parent (container) in Safari, while all other browsers center the overflowing element below them no matter what. And that is without overflowing the container."
     }
   ],
   "categories":[


### PR DESCRIPTION
I tried both of the obvious ways to interpret the note (http://jsfiddle.net/cvrebert/s4r6wo46/, http://jsfiddle.net/cvrebert/zps0oov9/), but neither of the testcases rendered unusually in OS X Safari 8.0.7. Otherwise, the note seems too unclear to be understood.