### PR TITLE
Update font-loading.json

### DIFF
--- a/features-json/font-loading.json
+++ b/features-json/font-loading.json
@@ -77,9 +77,9 @@
       "38":"n d #1",
       "39":"n d #1",
       "40":"n d #1",
-      "41":"n d #1",
-      "42":"n d #1",
-      "43":"n d #1"
+      "41":"y",
+      "42":"y",
+      "43":"y"
     },
     "chrome":{
       "4":"n",
@@ -226,7 +226,7 @@
   },
   "notes":"",
   "notes_by_num":{
-    "1":"Can be enabled in Firefox using the `layout.css.font-loading-api.enabled` flag. See [this bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1149381) for information on when it will be enabled by default."
+    "1":"Can be enabled in Firefox using the `layout.css.font-loading-api.enabled` flag. Enabled by default in Firefox 41. See [this bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1149381)"
   },
   "usage_perc_y":45.33,
   "usage_perc_a":0,


### PR DESCRIPTION
Font-loading events are enabled by default in Firefox starting with version 41
See: https://bugzilla.mozilla.org/show_bug.cgi?id=1149381