### PR TITLE
Correct URL of `<input type=tel>`

### DIFF
--- a/features-json/input-email-tel-url.json
+++ b/features-json/input-email-tel-url.json
@@ -1,7 +1,7 @@
 {
   "title":"Email, telephone & URL input types",
   "description":"Text input fields intended for email addresses, telephone numbers or URLs. Particularly useful in combination with [form validation](http://caniuse.com/#feat=form-validation)",
-  "spec":"https://html.spec.whatwg.org/multipage/forms.html#telephone-state-%28type=tel%29",
+  "spec":"https://html.spec.whatwg.org/multipage/forms.html#telephone-state-(type=tel)",
   "status":"ls",
   "links":[
     {


### PR DESCRIPTION
Everywhere else the data files use "(type=...)" and using percent-encoding actually breaks the HTML Standard. See https://github.com/whatwg/html-build/issues/6.