### PR TITLE
input-minlength: Add link to Firefox bug

### DIFF
--- a/features-json/input-minlength.json
+++ b/features-json/input-minlength.json
@@ -11,6 +11,10 @@
     {
       "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6565212-minlength-attribute",
       "title":"Microsoft Edge feature request on UserVoice"
+    },
+    {
+      "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=932755",
+      "title":"Firefox tracking bug"
     }
   ],
   "bugs":[


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=932755