### PR TITLE
css-shapes: Add link to Firefox tracking bug

### DIFF
--- a/features-json/css-shapes.json
+++ b/features-json/css-shapes.json
@@ -15,6 +15,10 @@
     {
       "url":"http://alistapart.com/article/css-shapes-101",
       "title":"A List Apart article"
+    },
+    {
+      "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=1040714",
+      "title":"Firefox tracking bug"
     }
   ],
   "bugs":[


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1040714