### PR TITLE
Hyphens property unprefixed in Firefox 43

### DIFF
--- a/features-json/css-hyphens.json
+++ b/features-json/css-hyphens.json
@@ -18,7 +18,7 @@
     }
   ],
   "bugs":[
-    
+
   ],
   "categories":[
     "CSS3"
@@ -81,7 +81,7 @@
       "40":"y x",
       "41":"y x",
       "42":"y x",
-      "43":"y x"
+      "43":"y"
     },
     "chrome":{
       "4":"n",
@@ -230,7 +230,7 @@
   },
   "notes":"Chrome and Android 4.0 Browser support \"-webkit-hyphens: none\", but not the \"auto\" property. It is [advisable to set the @lang attribute](http://blog.adrianroselli.com/2015/01/on-use-of-lang-attribute.html) on the HTML element to enable hyphenation support and improve accessibility.",
   "notes_by_num":{
-    
+
   },
   "usage_perc_y":27.11,
   "usage_perc_a":7.1,


### PR DESCRIPTION
https://www.fxsitecompat.com/en-US/docs/2015/hyphens-property-has-been-unprefixed/