### PR TITLE
Add SCSS workaround for iOS issue in viewport-units

### DIFF
--- a/features-json/viewport-units.json
+++ b/features-json/viewport-units.json
@@ -269,7 +269,7 @@
   "notes_by_num":{
     "1":"Partial support in IE9 refers to supporting \"vm\" instead of \"vmin\".",
     "2":"Partial support refers to not supporting the \"vmax\" unit. ",
-    "3":"Partial support in iOS7 is due to buggy behavior of the \"vh\" unit (see [workaround](https://gist.github.com/pburtchaell/e702f441ba9b3f76f587))."
+    "3":"Partial support in iOS7 is due to buggy behavior of the \"vh\" unit (see workarounds: [1](https://gist.github.com/pburtchaell/e702f441ba9b3f76f587), [2](https://gist.github.com/BenMorel/e9e34c08360ebbbd0634))."
   },
   "usage_perc_y":67.51,
   "usage_perc_a":10.6,


### PR DESCRIPTION
The [viewport-units](http://caniuse.com/#feat=viewport-units) page links to a [workaround](https://gist.github.com/pburtchaell/e702f441ba9b3f76f587) by Patrick Burtchaell for iOS issues.

I've created SCSS [mixins](https://gist.github.com/BenMorel/e9e34c08360ebbbd0634) based on his idea, that include a comprehensive list of iOS devices.

This basically allow you to support iOS 7 devices by just replacing:

    height: 50vh;

with:

    @include vh(50);

I thought it could be useful to link it on caniuse!