### PR TITLE
Update cryptography.json

### DIFF
--- a/features-json/cryptography.json
+++ b/features-json/cryptography.json
@@ -31,6 +31,10 @@
     {
       "url":"https://diafygi.github.io/webcrypto-examples/",
       "title":"Test suite for various algorithms/methods"
+    },
+    {
+      "url":"https://github.com/vibornoff/webcrypto-shim",
+      "title":"Web Cryptography API shim for IE11 and Safari - set of bugfixes and workarounds of prefixed api implementations"
     }
   ],
   "bugs":[


### PR DESCRIPTION
Add link to [_webcrypto-shim.js_](https://github.com/vibornoff/webcrypto-shim) — project aiming to fix bugs in prefixed webcrypto implementations in IE11 and Safari.