### PR TITLE
Added bug description about selecting the text, styled with css ::first-letter pseudo-element

### DIFF
--- a/features-json/css-first-letter.json
+++ b/features-json/css-first-letter.json
@@ -10,7 +10,9 @@
     }
   ],
   "bugs":[
-    
+    {
+    	"description": "In webkit-based browsers first character of text inside elements, styled with `::first-letter`, is not highlighted while selecting the text. [See bug](https://bugs.webkit.org/show_bug.cgi?id=6185)"
+    }
   ],
   "categories":[
     "CSS"


### PR DESCRIPTION
Added this bug: [https://bugs.webkit.org/show_bug.cgi?id=6185](https://bugs.webkit.org/show_bug.cgi?id=6185)