### PR TITLE
Add more keywords to SVG fragment data

### DIFF
--- a/features-json/svg-fragment.json
+++ b/features-json/svg-fragment.json
@@ -234,7 +234,7 @@
   "usage_perc_a":0.12,
   "ucprefix":false,
   "parent":"",
-  "keywords":"fragments,sprite",
+  "keywords":"fragments,sprite,svg,use",
   "ie_id":"",
   "chrome_id":"",
   "shown":true


### PR DESCRIPTION
Item could not be found by the terms `svg`, which is even in the title, or `use`, which is an important part of this functionality.
Added these terms in keywords.

Cheers!