### PR TITLE
object-observe: Add link to relevant Firefox bug

### DIFF
--- a/features-json/object-observe.json
+++ b/features-json/object-observe.json
@@ -11,6 +11,10 @@
     {
       "url":"https://github.com/MaxArt2501/object-observe",
       "title":"Polyfill"
+    },
+    {
+      "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=800355",
+      "title":"Firefox tracking bug"
     }
   ],
   "bugs":[


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=800355