### PR TITLE
Mention Safari's lack of fullscreen stacking in Full Screen API known issues

### DIFF
--- a/features-json/fullscreen.json
+++ b/features-json/fullscreen.json
@@ -29,6 +29,9 @@
       "description":"Safari blocks access to keyboard events in fullscreen mode (as a security measure)."
     },
     {
+      "description":"Safari doesn't support stacking, meaning only one element can be set to full screen. `webkitRequestFullScreen()` is ignored for other elements and no error event is dispatched."
+    },
+    {
       "description":"IE 11 does not allow scrolling when document.documentElement is set to full screen."
     },
     {


### PR DESCRIPTION
Just ran into this today when trying to set a video full screen inside an already – fullscreen element.  God dammit, Safari, as if your full screen stretching animation isn't bad enough!

(╯°□°)╯︵ ┻━┻