### PR TITLE
upgradeinsecurerequests: Add link to WebKit bug

### DIFF
--- a/features-json/upgradeinsecurerequests.json
+++ b/features-json/upgradeinsecurerequests.json
@@ -11,6 +11,10 @@
     {
       "url":"https://googlechrome.github.io/samples/csp-upgrade-insecure-requests/index.html",
       "title":"Demo Website"
+    },
+    {
+      "url":"https://bugs.webkit.org/show_bug.cgi?id=143653",
+      "title":"WebKit feature request bug"
     }
   ],
   "bugs":[


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=143653