### PR TITLE
Update the links for the matches() feature

### DIFF
--- a/features-json/matchesselector.json
+++ b/features-json/matchesselector.json
@@ -5,11 +5,11 @@
   "status":"ls",
   "links":[
     {
-      "url":"https://developer.mozilla.org/en/DOM/Element.mozMatchesSelector",
+      "url":"https://developer.mozilla.org/en/docs/Web/API/Element/matches",
       "title":"MDN article"
     },
     {
-      "url":"http://docs.webplatform.org/wiki/dom/HTMLElement/matchesSelector",
+      "url":"http://docs.webplatform.org/wiki/dom/HTMLElement/matches",
       "title":"WebPlatform Docs"
     },
     {


### PR DESCRIPTION
The links should point to the doc for the new feature.

The previous MDN link is redirecting to the new one, but the WebPlatform page shows a page describing the legacy feature.