### PR TITLE
Use valid SPDX license identifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "svg"
   ],
   "author": "Alexis Deveria <adeveria@gmail.com>",
-  "license": "CC-BY",
+  "license": "CC-BY-4.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/Fyrd/caniuse.git"


### PR DESCRIPTION
This fixes toolchain warnings downstream.

Reference: http://spdx.org/licenses/