### PR TITLE
Added bug with details element and box-sizing in Chrome

### DIFF
--- a/features-json/details.json
+++ b/features-json/details.json
@@ -32,6 +32,9 @@
   "bugs":[
     {
       "description":"`<select>` within `<details>` elements won't have their value changed on the Android browser shipped with most of Samsung's devices (i.e. Note 3, Galaxy 5)\r\nThe picker will appear, but attempting to select any option won't update the `<select>` or trigger any event."
+    },
+    {
+      "description":"In Chrome, when using the common inherit box-sizing fix (http://www.paulirish.com/2012/box-sizing-border-box-ftw/) in combination with a `<details>` element, the children of the `<details>` element get rendered as if they were `box-sizing: content-box;`. See: http://codepen.io/jochemnabuurs/pen/yYzYqM"
     }
   ],
   "categories":[


### PR DESCRIPTION
When using the common box-sizing fix using "box-sizing: inherit;" on
details elements, children of the details element inherit a value of
"box-sizing: content-box;" even if the box-sizing value is explicitly
set to "box-sizing: border-box"