### PR TITLE
Firefox 39 and 42 don't prevent alpha chars input

### DIFF
--- a/features-json/input-number.json
+++ b/features-json/input-number.json
@@ -33,6 +33,9 @@
     },
     {
       "description":"Currently no mobile browsers and very few desktop browsers support using commas for languages where commas are used as decimal separators."
+    },
+    {
+      "description":"Firefox 39 in Mac OSX by default does not prevent alpha characters input and Firefox 42 validates only but It doesn't disable alpha keys input."
     }
   ],
   "categories":[


### PR DESCRIPTION
Firefox 39 in Mac OSX by default does not prevent input alpha characters and Firefox 42 validates only but It doesn't disable alpha keys input.

https://jsfiddle.net/fht19Loe/1/
