### PR TITLE
Firefox does not support break-* for column layout

### DIFF
--- a/features-json/multicolumn.json
+++ b/features-json/multicolumn.json
@@ -262,7 +262,7 @@
       "9.9":"a x"
     }
   },
-  "notes":"Partial support refers to not supporting the `break-before`, `break-after`, `break-inside` properties. Webkit browsers do have equivalent support for the non-standard `-webkit-column-break-*` properties while Firefox supports `page-break-*` to accomplish the same result (but only the `auto` and `always` values).",
+  "notes":"Partial support refers to not supporting the `break-before`, `break-after`, `break-inside` properties. Webkit browsers do have equivalent support for the non-standard `-webkit-column-break-*` properties to accomplish the same result (but only the `auto` and `always` values). Firefox does not support `break-*`.",
   "notes_by_num":{
     
   },


### PR DESCRIPTION
``` html
<!doctype html>
<html lang="en">
<head>
    <meta charset="UTF-8">
    <style>
        .wrap {
            -webkit-column-count: 4;
            -moz-column-count: 4;
            column-count: 4;
            width: 1000px;
        }

        .col {
            break-inside: avoid;
            page-break-inside: avoid;
            -webkit-column-break-inside: avoid;
          
            break-after: always;
            page-break-after: always;
            -webkit-column-break-after: always;
        }
    </style>
    <title></title>
</head>
<body>
<div class="wrap">
    <div class="col">
        <p>aaa aaa aaa</p>
        <p>aaa aaa aaa</p>
        <p>aaa aaa aaa</p>
        <p>aaa aaa aaa</p>
        <p>aaa aaa aaa</p>
        <p>aaa aaa aaa</p>
        <p>aaa aaa aaa</p>
        <p>aaa aaa aaa</p>
        <p>aaa aaa aaa</p>
        <p>aaa aaa aaa</p>
        <p>aaa aaa aaa</p>
        <p>aaa aaa aaa</p>
        <p>aaa aaa aaa</p>
        <p>aaa aaa aaa</p>
        <p>aaa aaa aaa</p>
        <p>aaa aaa aaa</p>
        <p>aaa aaa aaa</p>
        <p>aaa aaa aaa</p>
        <p>aaa aaa aaa</p>
        <p>aaa aaa aaa</p>
        <p>aaa aaa aaa</p>
        <p>aaa aaa aaa</p>
        <p>aaa aaa aaa</p>
    </div>
    <div class="col">
        <p>bbb bbb bbb</p>
        <p>bbb bbb bbb</p>
    </div>
    <div class="col">
        <p>ccc ccc ccc</p>
        <p>ccc ccc ccc</p>
        <p>ccc ccc ccc</p>
        <p>ccc ccc ccc</p>
    </div>
    <div class="col">
        <p>ddd ddd ddd</p>
        <p>ddd ddd ddd</p>
        <p>ddd ddd ddd</p>
        <p>ddd ddd ddd</p>
    </div>
</div>
</body>
</html>
```

Does not work in Firefox 42