### PR TITLE
text-size-adjust: More details on old desktop WebKit bug

### DIFF
--- a/features-json/text-size-adjust.json
+++ b/features-json/text-size-adjust.json
@@ -10,9 +10,6 @@
     }
   ],
   "bugs":[
-    {
-      "description":"There is a bug in Webkit-based desktop browsers. If -webkit-text-size-adjust is explicitly set to none, Webkit-based desktop browsers, like Chrome or Safari, instead of ignoring the property, will prevent the user to zoom in or out the Web page."
-    }
   ],
   "categories":[
     "CSS3"
@@ -103,7 +100,7 @@
       "23":"n",
       "24":"n",
       "25":"n",
-      "26":"n",
+      "26":"n #2",
       "27":"n",
       "28":"n",
       "29":"n",
@@ -134,7 +131,7 @@
       "3.2":"n",
       "4":"n",
       "5":"n",
-      "5.1":"n",
+      "5.1":"n #2",
       "6":"n",
       "6.1":"n",
       "7":"n",
@@ -231,7 +228,8 @@
   },
   "notes":"",
   "notes_by_num":{
-    "1":"If the viewport size is set using a `<meta>` element, the `-ms-text-size-adjust` property is ignored. See [MSDN](https://msdn.microsoft.com/en-us/library/ie/dn793579%28v=vs.85%29.aspx)"
+    "1":"If the viewport size is set using a `<meta>` element, the `-ms-text-size-adjust` property is ignored. See [MSDN](https://msdn.microsoft.com/en-us/library/ie/dn793579%28v=vs.85%29.aspx)",
+    "2":"Old versions of WebKit-based desktop browsers (Chrome<27, Safari<6) [suffer from a bug](https://bugs.webkit.org/show_bug.cgi?id=56543) where if `-webkit-text-size-adjust` is explicitly set to `none`, instead of ignoring the property, the browsers will prevent the user from zooming in or out on the webpage."
   },
   "usage_perc_y":15.83,
   "usage_perc_a":0,


### PR DESCRIPTION
The oldest Chrome I have access to is v26, which is affected by the bug. So I don't know how far further back the bug goes.
The bug was fixed in Chrome v27.

The oldest Safari I have access to is v5.1.7, which is affected by the bug. So I don't know how far further back the bug goes.
The bug is gone as of Safari v6.2.7. I don't have access to v6.0 or v6.1.

Testcase: https://bug-56543-attachments.webkit.org/attachment.cgi?id=86034
Bug: https://bugs.webkit.org/show_bug.cgi?id=56543