### PR TITLE
css-media-interaction: Update to correct Firefox bug tracking link

### DIFF
--- a/features-json/css-media-interaction.json
+++ b/features-json/css-media-interaction.json
@@ -19,7 +19,7 @@
   ],
   "bugs":[
     {
-      "description":"[Firefox tracking bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1171900)"
+      "description":"[Firefox tracking bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1035774)"
     }
   ],
   "categories":[


### PR DESCRIPTION
The old one was marked as a duplicate.