### PR TITLE
Added requestAnimationFrame Android Chrome data

### DIFF
--- a/features-json/requestanimationframe.json
+++ b/features-json/requestanimationframe.json
@@ -225,7 +225,33 @@
       "33":"y"
     },
     "and_chr":{
-      "47":"y"
+      "18":"a x #1",
+      "25":"y",
+      "26":"y",
+      "27":"y",
+      "28":"y",
+      "29":"y",
+      "30":"y",
+      "31":"y",
+      "32":"y",
+      "33":"y",
+      "34":"y",
+      "35":"y",
+      "36":"y",
+      "37":"y",
+      "38":"y",
+      "39":"y",
+      "40":"y",
+      "41":"y",
+      "42":"y",
+      "43":"y",
+      "44":"y",
+      "45":"y",
+      "46":"y",
+      "47":"y",
+      "48":"y",
+      "49":"y",
+      "50":"y"
     },
     "and_ff":{
       "42":"y"
@@ -241,7 +267,7 @@
   "notes":"",
   "notes_by_num":{
     "1":"Partial support refers to lacking `cancelAnimationFrame` support.",
-    "2":"Supports `webkitCancelRequestAnimationFrame` rather than `webkitCancelAnimationFrame."
+    "2":"Supports `webkitCancelRequestAnimationFrame` rather than `webkitCancelAnimationFrame`."
   },
   "usage_perc_y":87.96,
   "usage_perc_a":0.29,


### PR DESCRIPTION
The data was previously automated to always show the last Chrome for Android version (huh?), so I fixed it since Chrome for Android should have the same support for this as the desktop versions.
Also added a missing backtick in a note.