### PR TITLE
Update eventsource.json

### DIFF
--- a/features-json/eventsource.json
+++ b/features-json/eventsource.json
@@ -30,6 +30,9 @@
     },
     {
       "description":"Firefox currently does not support [EventSource in web/shared workers](https://bugzilla.mozilla.org/show_bug.cgi?id=876498)"
+    },
+    {
+      "description": "Antivirus software may block the event streaming data chunks."
     }
   ],
   "categories":[


### PR DESCRIPTION
"Block malicious downloads" functionality of antivirus software buffers the download chunks until the whole file is not arrived. Once the file is downloaded completely, antivirus will scan the all the downloaded content and then allow further process with downloaded file.

Some antivirus software like SOPHOS (in my case), assumes event streaming of SSE as download started in the browser.  If your streaming API is never ending, then all data will be blocked all the time. SSE creates connection which is not about to close until the user closes the connection or closes the browser or switches to another page. I made a never ending API, ran for few minutes. Event streaming data was blocked under the protection of antivirus. When I closed the connection by stopping server, I was able to see all the data at once.