### PR TITLE
Change channel messaging to spec URL to whatwg

### DIFF
--- a/features-json/channel-messaging.json
+++ b/features-json/channel-messaging.json
@@ -1,7 +1,7 @@
 {
   "title":"Channel messaging",
   "description":"Method for having two-way communication between browsing contexts (using MessageChannel)",
-  "spec":"http://www.w3.org/TR/webmessaging/#channel-messaging",
+  "spec":"https://html.spec.whatwg.org/multipage/comms.html#channel-messaging",
   "status":"rec",
   "links":[
     {


### PR DESCRIPTION
https://www.w3.org/TR/webmessaging/ says

> Please look at http://w3c.github.io/webmessaging/ for the latest changes.

...which says

> No one in the Web Platform Working Group is actively working on the Web Messaging specification. For the latest version of the specification use the WHATWG Living Standard: Cross-document messaging and Channel messaging.

Also see https://github.com/whatwg/wattsi/issues/14