### PR TITLE
Change storage spec URL to whatwg

### DIFF
--- a/features-json/namevalue-storage.json
+++ b/features-json/namevalue-storage.json
@@ -1,7 +1,7 @@
 {
   "title":"Web Storage - name/value pairs",
   "description":"Method of storing data locally like cookies, but for larger amounts of data (sessionStorage and localStorage, used to fall under HTML5).",
-  "spec":"http://www.w3.org/TR/webstorage/#storage",
+  "spec":"https://html.spec.whatwg.org/multipage/webstorage.html#storage",
   "status":"rec",
   "links":[
     {


### PR DESCRIPTION
https://www.w3.org/TR/webstorage/

> Latest Editor's Draft:
> https://w3c.github.io/webstorage/

> The latest edits to Web Storage are maintained in https://html.spec.whatwg.org/multipage/webstorage.html.

Also see https://github.com/whatwg/wattsi/issues/14