### PR TITLE
Change websockets spec URL to whatwg

### DIFF
--- a/features-json/websockets.json
+++ b/features-json/websockets.json
@@ -1,7 +1,7 @@
 {
   "title":"Web Sockets",
   "description":"Bidirectional communication technology for web apps",
-  "spec":"http://www.w3.org/TR/websockets/",
+  "spec":"https://html.spec.whatwg.org/multipage/comms.html#network",
   "status":"cr",
   "links":[
     {


### PR DESCRIPTION
> No one in the Web Platform Working Group is actively working on this specification. For the latest version of The WebSocket API use the WHATWG Living Standard.

Also see https://github.com/whatwg/wattsi/issues/14