### PR TITLE
Change xhtml spec URL to whatwg

### DIFF
--- a/features-json/xhtml.json
+++ b/features-json/xhtml.json
@@ -1,7 +1,7 @@
 {
   "title":"XHTML served as application/xhtml+xml",
   "description":"A strict form of HTML, and allows embedding of other XML languages",
-  "spec":"http://www.w3.org/TR/xhtml1/",
+  "spec":"https://html.spec.whatwg.org/multipage/xhtml.html#parsing-xhtml-documents",
   "status":"rec",
   "links":[
     {


### PR DESCRIPTION
Use a *somewhat* more up to date spec reference for XHTML.

Also see https://github.com/whatwg/wattsi/issues/14