### PR TITLE
Change server-sent events spec URL to whatwg

### DIFF
--- a/features-json/eventsource.json
+++ b/features-json/eventsource.json
@@ -1,7 +1,7 @@
 {
   "title":"Server-sent events",
   "description":"Method of continuously sending data from a server to the browser, rather than repeatedly requesting it (EventSource interface, used to fall under HTML5)",
-  "spec":"http://www.w3.org/TR/eventsource/",
+  "spec":"https://html.spec.whatwg.org/multipage/comms.html#server-sent-events/",
   "status":"rec",
   "links":[
     {


### PR DESCRIPTION
> No one in the Web Platform Working Group is actively working on this specification. For the latest version of Server-sent Events use the WHATWG's Living Standard.

Also see https://github.com/whatwg/wattsi/issues/14