### PR TITLE
Change DOM Range spec URL to whatwg

### DIFF
--- a/features-json/dom-range.json
+++ b/features-json/dom-range.json
@@ -1,7 +1,7 @@
 {
   "title":"Document Object Model Range",
   "description":"A contiguous range of content in a Document, DocumentFragment or Attr",
-  "spec":"http://www.w3.org/TR/DOM-Level-2-Traversal-Range/ranges.html",
+  "spec":"https://dom.spec.whatwg.org/#ranges",
   "status":"rec",
   "links":[
     {


### PR DESCRIPTION
Use a *somewhat* more up to date spec reference for DOM ranges.