### PR TITLE
Change requestAnimationFrame spec URL to whatwg

### DIFF
--- a/features-json/requestanimationframe.json
+++ b/features-json/requestanimationframe.json
@@ -1,7 +1,7 @@
 {
   "title":"requestAnimationFrame",
   "description":"API allowing a more efficient way of running script-based animation, compared to traditional methods using timeouts. Also covers support for `cancelAnimationFrame`",
-  "spec":"http://www.w3.org/TR/animation-timing/#requestAnimationFrame",
+  "spec":"https://html.spec.whatwg.org/multipage/webappapis.html#animation-frames",
   "status":"cr",
   "links":[
     {


### PR DESCRIPTION
> Beware. This specification is no longer in active maintenance and the Web Performance Working Group does not intend to maintain it further. See HTML instead.

Also see https://github.com/whatwg/wattsi/issues/14