### PR TITLE
Change querySelector spec URL to whatwg

### DIFF
--- a/features-json/queryselector.json
+++ b/features-json/queryselector.json
@@ -1,7 +1,7 @@
 {
   "title":"querySelector/querySelectorAll",
   "description":"Method of accessing DOM elements using CSS selectors",
-  "spec":"http://www.w3.org/TR/selectors-api/",
+  "spec":"https://dom.spec.whatwg.org/#dom-parentnode-queryselector",
   "status":"rec",
   "links":[
     {


### PR DESCRIPTION
The W3C spec is not maintained.