### PR TITLE
Fix typo in spec URL for eventsource

### DIFF
--- a/features-json/eventsource.json
+++ b/features-json/eventsource.json
@@ -1,7 +1,7 @@
 {
   "title":"Server-sent events",
   "description":"Method of continuously sending data from a server to the browser, rather than repeatedly requesting it (EventSource interface, used to fall under HTML5)",
-  "spec":"https://html.spec.whatwg.org/multipage/comms.html#server-sent-events/",
+  "spec":"https://html.spec.whatwg.org/multipage/comms.html#server-sent-events",
   "status":"rec",
   "links":[
     {


### PR DESCRIPTION
I accidentally left in a slash in https://github.com/Fyrd/caniuse/pull/2239/files 

Also see https://github.com/whatwg/wattsi/issues/14