### PR TITLE
css-placeholder-shown: Supported in OS X Safari 9

### DIFF
--- a/features-json/css-placeholder-shown.json
+++ b/features-json/css-placeholder-shown.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"http://trac.webkit.org/changeset/172826",
-      "title":"WebKit bug"
+      "title":"WebKit commit"
     },
     {
       "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=1069015",
@@ -145,8 +145,8 @@
       "7":"n",
       "7.1":"n",
       "8":"n",
-      "9":"n",
-      "9.1":"n"
+      "9":"y",
+      "9.1":"y"
     },
     "opera":{
       "9":"n",
@@ -237,7 +237,7 @@
       "9.9":"n"
     }
   },
-  "notes":"For support of styling the actual placeholder text itself, see [CSS ::placeholder](http://caniuse.com/#feat=css-placeholder)\r\n\r\nSupport currently exists in [WebKit Nightly](http://trac.webkit.org/changeset/172826)",
+  "notes":"For support of styling the actual placeholder text itself, see [CSS ::placeholder](http://caniuse.com/#feat=css-placeholder)",
   "notes_by_num":{
     
   },


### PR DESCRIPTION
Refs #2259.
Testcase: https://jsfiddle.net/38t99yg3/1/

<img width="990" alt="saf" src="https://cloud.githubusercontent.com/assets/419884/12694448/06a0a11c-c6e3-11e5-80a7-3def4d515bd9.png">

It seems likely that it should work in some version of iOS Safari too (probably 9.3), but I don't have the beta or time to test more.