### PR TITLE
Link platform status for CSP2.

### DIFF
--- a/features-json/contentsecuritypolicy2.json
+++ b/features-json/contentsecuritypolicy2.json
@@ -247,7 +247,7 @@
   "ucprefix":false,
   "parent":"",
   "keywords":"csp,header,nonce,hash",
-  "ie_id":"",
+  "ie_id":"contentsecuritypolicylevel2",
   "chrome_id":"4957003285790720",
   "firefox_id":"",
   "webkit_id":"",


### PR DESCRIPTION
This is on the IE roadmap now: https://dev.windows.com/en-us/microsoft-edge/platform/status/contentsecuritypolicylevel2

Thanks!