### PR TITLE
Normalize ECMAScript "spec" url

### DIFF
--- a/features-json/arrow-functions.json
+++ b/features-json/arrow-functions.json
@@ -1,7 +1,7 @@
 {
   "title":"Arrow functions",
   "description":"Function shorthand using `=>` syntax and lexical `this` binding.",
-  "spec":"http://www.ecma-international.org/ecma-262/6.0/index.html#sec-arrow-function-definitions",
+  "spec":"http://www.ecma-international.org/ecma-262/6.0/#sec-arrow-function-definitions",
   "status":"other",
   "links":[
     {

--- a/features-json/es5.json
+++ b/features-json/es5.json
@@ -1,7 +1,7 @@
 {
   "title":"ECMAScript 5",
   "description":"Full support for the ECMAScript 5 specification. Features include `Function.prototype.bind`, Array methods like `indexOf`, `forEach`, `map` & `filter`, Object methods like `defineProperty`, `create` & `keys`, the `trim` method on Strings and many more.",
-  "spec":"http://www.ecma-international.org/publications/standards/Ecma-262.htm",
+  "spec":"http://www.ecma-international.org/ecma-262/5.1/",
   "status":"other",
   "links":[
     {

--- a/features-json/es6-number.json
+++ b/features-json/es6-number.json
@@ -1,7 +1,7 @@
 {
   "title":"ES6 Number",
   "description":"Extensions to the `Number` built-in object in ES6, including constant properties `EPSILON`, `MIN_SAFE_INTEGER`, and `MAX_SAFE_INTEGER`, and methods ` isFinite`, `isInteger`, `isSafeInteger`, and `isNaN`.",
-  "spec":"http://ecma-international.org/ecma-262/6.0/index.html#sec-number-objects",
+  "spec":"http://www.ecma-international.org/ecma-262/6.0/#sec-number-objects",
   "status":"other",
   "links":[
     {

--- a/features-json/json.json
+++ b/features-json/json.json
@@ -1,7 +1,7 @@
 {
   "title":"JSON parsing",
   "description":"Method of converting JavaScript objects to JSON strings and JSON back to objects using JSON.stringify() and JSON.parse()",
-  "spec":"http://es5.github.com/#x15.12",
+  "spec":"http://www.ecma-international.org/ecma-262/5.1/#sec-15.12",
   "status":"other",
   "links":[
     {

--- a/features-json/promises.json
+++ b/features-json/promises.json
@@ -1,7 +1,7 @@
 {
   "title":"Promises",
   "description":"A promise represents the eventual result of an asynchronous operation.",
-  "spec":"https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-objects",
+  "spec":"http://www.ecma-international.org/ecma-262/6.0/#sec-promise-objects",
   "status":"other",
   "links":[
     {

--- a/features-json/use-strict.json
+++ b/features-json/use-strict.json
@@ -1,7 +1,7 @@
 {
   "title":"ECMAScript 5 Strict Mode",
   "description":"Method of placing code in a \"strict\" operating context.",
-  "spec":"http://ecma-international.org/ecma-262/5.1/#sec-14.1",
+  "spec":"http://www.ecma-international.org/ecma-262/5.1/#sec-14.1",
   "status":"other",
   "links":[
     {


### PR DESCRIPTION
Some of "spec" urls of ECMAScript entries are inconsistent or outdated.

This PR normalises "spec" urls of ECMAScript entries.
More specifically, it makes all "spec" urls reference official spec either

- http://www.ecma-international.org/ecma-262/5.1/
- http://www.ecma-international.org/ecma-262/6.0/