### PR TITLE
Normalise IETF "spec" url 

### DIFF
--- a/features-json/client-hints-dpr-width-viewport.json
+++ b/features-json/client-hints-dpr-width-viewport.json
@@ -1,7 +1,7 @@
 {
   "title":"Client Hints: DPR, Width, Viewport-Width",
   "description":"DPR, Width, and Viewport-Width hints enable proactive content negotiation between client and server, enabling automated delivery of optimized assets - e.g. auto-negotiating image DPR resolution.",
-  "spec":"http://tools.ietf.org/html/draft-grigorik-http-client-hints",
+  "spec":"https://tools.ietf.org/html/draft-grigorik-http-client-hints",
   "status":"other",
   "links":[
     {

--- a/features-json/datauri.json
+++ b/features-json/datauri.json
@@ -1,7 +1,7 @@
 {
   "title":"Data URIs",
   "description":"Method of embedding images and other files in webpages as a string of text, generally using base64 encoding.",
-  "spec":"http://www.ietf.org/rfc/rfc2397.txt",
+  "spec":"https://tools.ietf.org/html/rfc2397",
   "status":"other",
   "links":[
     {

--- a/features-json/opus.json
+++ b/features-json/opus.json
@@ -1,7 +1,7 @@
 {
   "title":"Opus",
   "description":"Royalty-free open audio codec by IETF, which incorporated SILK from Skype and CELT from Xiph.org, to serve higher sound quality and lower latency at the same bitrate.",
-  "spec":"http://tools.ietf.org/html/rfc6716",
+  "spec":"https://tools.ietf.org/html/rfc6716",
   "status":"other",
   "links":[
     {

--- a/features-json/sni.json
+++ b/features-json/sni.json
@@ -1,7 +1,7 @@
 {
   "title":"Server Name Indication",
   "description":"An extension to the TLS computer networking protocol by which a client indicates which hostname it is attempting to connect to at the start of the handshaking process.",
-  "spec":"http://www.rfc-editor.org/rfc/rfc6066.txt",
+  "spec":"https://tools.ietf.org/html/rfc6066",
   "status":"other",
   "links":[
     {

--- a/features-json/stricttransportsecurity.json
+++ b/features-json/stricttransportsecurity.json
@@ -1,7 +1,7 @@
 {
   "title":"Strict Transport Security",
   "description":"Declare that a website is only accessible over a secure connection (HTTPS).",
-  "spec":"http://tools.ietf.org/html/rfc6797",
+  "spec":"https://tools.ietf.org/html/rfc6797",
   "status":"other",
   "links":[
     {


### PR DESCRIPTION
Some of "spec" urls of IETF entries are inconsistent.

This PR normalises "spec" urls of IETF entries.
More specifically, it makes all "spec" urls reference html version

- https://tools.ietf.org/html/