### PR TITLE
Use canonical spec url for input[accept]

### DIFF
--- a/features-json/input-file-accept.json
+++ b/features-json/input-file-accept.json
@@ -1,7 +1,7 @@
 {
   "title":"accept attribute for file input",
   "description":"Allows a filter to be defined for what type of files a user may pick with from an `<input type=\"file\">` dialog",
-  "spec":"https://developers.whatwg.org/states-of-the-type-attribute.html#attr-input-accept",
+  "spec":"https://html.spec.whatwg.org/multipage/forms.html#attr-input-accept",
   "status":"ls",
   "links":[
     {


### PR DESCRIPTION
As developers.whatwg.org provides a subset of HTML Standard, caniuse should refer full version of HTML Standard.