### PR TITLE
XHR: add issue about setting timeout in IE

### DIFF
--- a/features-json/xhr2.json
+++ b/features-json/xhr2.json
@@ -29,6 +29,9 @@
     },
     {
       "description":"The \"progress\" event is reported to not work in Chrome for iOS "
+    },
+    {
+      "description":"In Internet Explorer the `timeout` property may only be set after calling `open` and before calling `send`."
     }
   ],
   "categories":[


### PR DESCRIPTION
In Internet Explorer the `timeout` property may only be set after calling `open` and before calling `send`. Chrome and Firefox each support setting `timeout` before `open` and after `send`.