### PR TITLE
 Noted lack of support for nested media queries

### DIFF
--- a/features-json/css-media-resolution.json
+++ b/features-json/css-media-resolution.json
@@ -28,9 +28,9 @@
       "6":"n",
       "7":"n",
       "8":"n",
-      "9":"a #1",
-      "10":"a #1",
-      "11":"a #1"
+      "9":"a #1 #4",
+      "10":"a #1 #4",
+      "11":"a #1 #4"
     },
     "edge":{
       "12":"y",
@@ -244,7 +244,8 @@
   "notes_by_num":{
     "1":"Supports the `dpi` unit, but does not support `dppx` or `dpcm` units.",
     "2":"Firefox before 16 supports only `dpi` unit, but you can set `2dppx` per `min--moz-device-pixel-ratio: 2`",
-    "3":"Supports the non-standard `min`/`max-device-pixel-ratio`"
+    "3":"Supports the non-standard `min`/`max-device-pixel-ratio`",
+    "4":"Does not support nested `@media` queries"
   },
   "usage_perc_y":61.93,
   "usage_perc_a":34.79,


### PR DESCRIPTION
Part of the official standard: https://www.w3.org/TR/css3-conditional/#processing
Works in Firefox and Chrome.
Does not work in IE11 and below.
Not sure if Edge and other browsers support this.