### PR TITLE
Firefox workaround for no background-position-x/y

### DIFF
--- a/features-json/background-position-x-y.json
+++ b/features-json/background-position-x-y.json
@@ -243,7 +243,7 @@
       "9.9":"y"
     }
   },
-  "notes":"",
+  "notes":"A workaround for the lack of support in Firefox 31 and later is to use [CSS variables](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_variables). See [this Stack Overflow answer](http://stackoverflow.com/a/29282573/94197) for an example.",
   "notes_by_num":{
     
   },


### PR DESCRIPTION
Many people don't realise that background-position-x/y is achievable in Firefox, so I thought I'd add a note and some self-promotion by linking to one of my Stack Overflow answers from a while ago.  If that's an issue, feel free to remove it but I think it's helpful in any case.