### PR TITLE
bug report: linear-gradients in Chrome

### DIFF
--- a/features-json/background-img-opts.json
+++ b/features-json/background-img-opts.json
@@ -29,6 +29,9 @@
     },
     {
       "description":"Android 4.3 browser and below are reported to not support percentages in `background-size`"
+    },
+    {
+      "description":"Chrome does not support `to right` or `to left` in `linear-gradient` if the parent container is a list element and over 1025px wide."
     }
   ],
   "categories":[

--- a/features-json/background-img-opts.json
+++ b/features-json/background-img-opts.json
@@ -31,7 +31,7 @@
       "description":"Android 4.3 browser and below are reported to not support percentages in `background-size`"
     },
     {
-      "description":"Chrome does not support `to right` or `to left` in `linear-gradient` if the parent container is a list element and over 1025px wide."
+      "description":"Chrome 48 does not support `to right` or `to left` in `linear-gradient` if the parent container is a list element and over 1025px wide."
     }
   ],
   "categories":[


### PR DESCRIPTION
Obscure bug. Chrome does not support `to right` or `to left` in `linear-gradient` if the parent container is a list element and over 1000px wide.