### PR TITLE
Update Mozilla Platform Status URLs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ Currently the following feature information can be modified:
 * **keywords** — Comma separated words that will match the feature in a search
 * **ie_id** — Comma separated IDs used by [status.modern.ie](http://status.modern.ie) - Each ID is the string in the feature's URL 
 * **chrome_id** — Comma separated IDs used by [chromestatus.com](http://chromestatus.com) - Each ID is the number in the feature's URL 
-* **firefox_id** - Comma separated IDs used by [mozilla.github.io/platatus](https://mozilla.github.io/platatus/) - Each ID is the filename (minus the `.md` extension suffix) of the relevant file in [the `/features/` directory of Mozilla's Platatus project on GitHub](https://github.com/mozilla/platatus/tree/master/features)
+* **firefox_id** - Comma separated IDs used by [platform-status.mozilla.org](https://platform-status.mozilla.org/) - Each ID is the filename (minus the `.md` extension suffix) of the relevant file in [the `/features/` directory of Mozilla's Platform Status project on GitHub](https://github.com/mozilla/platform-status/tree/master/features)
 * **webkit_id** - Comma separated IDs used by [webkit.org/status.html](http://www.webkit.org/status.html) - Each ID is the title of the feature's box on the status webpage
 * **shown** — Whether or not feature is ready to be shown on the site. This can be left as false if the support data or information for other fields is still being collected
 


### PR DESCRIPTION
The name of the repo has been changed to `platform-status` and the new home is https://platform-status.mozilla.org/.