### PR TITLE
http2: Add Firefox platform status ID

### DIFF
--- a/features-json/http2.json
+++ b/features-json/http2.json
@@ -256,7 +256,7 @@
   "keywords":"",
   "ie_id":"http2",
   "chrome_id":"5152586365665280",
-  "firefox_id":"",
+  "firefox_id":"http2",
   "webkit_id":"",
   "shown":true
 }


### PR DESCRIPTION
https://platform-status.mozilla.org/#http2