### PR TITLE
css-read-only-write: Add link to relevant Firefox bug

### DIFF
--- a/features-json/css-read-only-write.json
+++ b/features-json/css-read-only-write.json
@@ -19,6 +19,10 @@
     {
       "url":"https://drafts.csswg.org/selectors-4/#rw-pseudos",
       "title":"Selectors Level 4 \u00a7 The Mutability Pseudo-classes: :read-only and :read-write"
+    },
+    {
+      "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=312971",
+      "title":"Firefox feature request bug"
     }
   ],
   "bugs":[


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=312971