### PR TITLE
Use correct Firefox bug for CSS masks

### DIFF
--- a/features-json/css-masks.json
+++ b/features-json/css-masks.json
@@ -17,7 +17,7 @@
       "title":"Detailed blog post"
     },
     {
-      "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=686281",
+      "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=1224422",
       "title":"Firefox implementation bug"
     }
   ],


### PR DESCRIPTION
The current one is about implementing only, the new one about implementing and shipping (Meta bug)