### PR TITLE
Update "known issue"

### DIFF
--- a/features-json/history.json
+++ b/features-json/history.json
@@ -31,7 +31,7 @@
   ],
   "bugs":[
     {
-      "description":"IE does not fire the `popstate` event when the URL's [hash value changes](http://codepen.io/Fyrd/pen/wBVGjK). See [IE bug report](https://connect.microsoft.com/IE/Feedback/Details/1528993)."
+      "description":"IE and Edge do not fire the `popstate` event when the URL's [hash value changes](http://codepen.io/Fyrd/pen/wBVGjK). See [MS bug report](https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/3740423/)."
     }
   ],
   "categories":[


### PR DESCRIPTION
The known issue with the popstate event not being fired when the hash changes affects Edge as well as IE. The official public-facing bug report has a new URL.