### PR TITLE
Firefox 49 supports background-position-x/y

### DIFF
--- a/features-json/background-position-x-y.json
+++ b/features-json/background-position-x-y.json
@@ -88,7 +88,7 @@
       "46":"n",
       "47":"n",
       "48":"n",
-      "49":"n"
+      "49":"y"
     },
     "chrome":{
       "4":"y",
@@ -248,7 +248,7 @@
       "9.9":"y"
     }
   },
-  "notes":"A workaround for the lack of support in Firefox 31 and later is to use [CSS variables](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_variables). See [this Stack Overflow answer](http://stackoverflow.com/a/29282573/94197) for an example.",
+  "notes":"A workaround for the lack of support in Firefox 31 - Firefox 48 is to use [CSS variables](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_variables). See [this Stack Overflow answer](http://stackoverflow.com/a/29282573/94197) for an example.",
   "notes_by_num":{
     
   },


### PR DESCRIPTION
The [issue on Firefox Bugzilla](https://bugzilla.mozilla.org/show_bug.cgi?id=550426) just got marked as resolved.