### PR TITLE
Web notifications is enabled by default by Edge 14

### DIFF
--- a/features-json/notifications.json
+++ b/features-json/notifications.json
@@ -60,7 +60,7 @@
     "edge":{
       "12":"n",
       "13":"n",
-      "14":"n d #1"
+      "14":"y"
     },
     "firefox":{
       "2":"n",
@@ -275,7 +275,7 @@
   },
   "notes":"",
   "notes_by_num":{
-    "1":"Can be enabled in `about:flags`"
+    
   },
   "usage_perc_y":41.94,
   "usage_perc_a":2.81,


### PR DESCRIPTION
In Windows 10 Preview Build 14342, Web Notifications API is enabled by default in Edge 14.
https://developer.microsoft.com/en-us/microsoft-edge/platform/changelog/desktop/14342/