### PR TITLE
Fetch is enabled by default by Edge 14

### DIFF
--- a/features-json/fetch.json
+++ b/features-json/fetch.json
@@ -32,7 +32,7 @@
     "edge":{
       "12":"n",
       "13":"n",
-      "14":"n d #6"
+      "14":"y"
     },
     "firefox":{
       "2":"n",
@@ -251,8 +251,7 @@
     "2":"Only available in Chrome and Opera within ServiceWorkers.",
     "3":"Available in Chrome and Opera within Window and Workers by enabling the \"Experimental Web Platform Features\" flag in `chrome://flags`",
     "4":"Firefox <40 is not completely conforming to the specs and does not respect the <base> tag for relative URIs in fetch requests. https://bugzilla.mozilla.org/show_bug.cgi?id=1161625",
-    "5":"Appears to exist in Safari Technical Preview but does not work in current build. Should work in [next preview build](https://twitter.com/xeenon/status/715379838081576960)",
-    "6":"Can be enabled in `about:flags`"
+    "5":"Appears to exist in Safari Technical Preview but does not work in current build. Should work in [next preview build](https://twitter.com/xeenon/status/715379838081576960)"
   },
   "usage_perc_y":54.07,
   "usage_perc_a":0.24,


### PR DESCRIPTION
See https://developer.microsoft.com/en-us/microsoft-edge/platform/changelog/desktop/14342/