### PR TITLE
Update svg-html.json

### DIFF
--- a/features-json/svg-html.json
+++ b/features-json/svg-html.json
@@ -25,7 +25,7 @@
   "categories":[
     "SVG"
   ],
-  "stats":{
+  "stats":{part
     "ie":{
       "5.5":"n",
       "6":"n",
@@ -251,7 +251,7 @@
       "9.9":"n"
     }
   },
-  "notes":"Partial support refers to lack of filter support or buggy result from effects. A [CSS Filter Effects](http://www.w3.org/TR/filter-effects/) specification is in the works that would replace this method.",
+  "notes":"Partial support refers to lack of filter support or buggy result from effects. A [CSS Filter Effects](http://www.w3.org/TR/filter-effects/) specification is in the works that would replace this method.<br />Note that IE11 and below does not support foreignObject",
   "notes_by_num":{
     
   },


### PR DESCRIPTION
IE11 don't support `foreignObject` and the current json file does not reflect that fact.   This fixes that.