### PR TITLE
upgrade insecure requests status to cr

### DIFF
--- a/features-json/upgradeinsecurerequests.json
+++ b/features-json/upgradeinsecurerequests.json
@@ -2,7 +2,7 @@
   "title":"Upgrade Insecure Requests",
   "description":"Declare that browsers should transparently upgrade HTTP resources on a website to HTTPS.",
   "spec":"http://www.w3.org/TR/upgrade-insecure-requests/",
-  "status":"wd",
+  "status":"cr",
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/Security/CSP/CSP_policy_directives#upgrade-insecure-requests",


### PR DESCRIPTION
Upgrade Insecure Requests is now a W3C Candidate Recommendation.
https://www.w3.org/TR/upgrade-insecure-requests/