### PR TITLE
child-src support was added in FF 45

### DIFF
--- a/features-json/contentsecuritypolicy2.json
+++ b/features-json/contentsecuritypolicy2.json
@@ -76,11 +76,11 @@
       "42":"a #3",
       "43":"a #3",
       "44":"a #3",
-      "45":"a #3",
-      "46":"a #3",
-      "47":"a #3",
-      "48":"a #3",
-      "49":"a #3"
+      "45":"a #7",
+      "46":"a #7",
+      "47":"a #7",
+      "48":"a #7",
+      "49":"a #7"
     },
     "chrome":{
       "4":"n",
@@ -245,10 +245,11 @@
   "notes_by_num":{
     "1":"Firefox 31-34 is missing the plugin-types, child-src, frame-ancestors, base-uri, and form-action directives.",
     "2":"Firefox 35 is missing the plugin-types, child-src, frame-ancestors, and form-action directives.",
-    "3":"Firefox 36+ is missing the plugin-types and child-src directives.",
+    "3":"Firefox 36-44 is missing the plugin-types and child-src directives.",
     "4":"Chrome 36-38 & Opera 23-25 are missing the plugin-types, child-src, frame-ancestors, base-uri, and form-action directives.",
     "5":"Chrome 39 and Opera 26 are missing the plugin-types, child-src, base-uri, and form-action directives.",
-    "6":"Firefox 38 on Android is missing the child-src directive."
+    "6":"Firefox 38 on Android is missing the child-src directive.",
+    "7":"Firefox 45+ is missing the plugin-types directive."
   },
   "usage_perc_y":52.3,
   "usage_perc_a":8.13,


### PR DESCRIPTION
taken from here: https://developer.mozilla.org/en-US/docs/Web/Security/CSP/CSP_policy_directives#Browser_compatibility