### PR TITLE
Added note about IE11 flex-basis bug.

### DIFF
--- a/features-json/flexbox.json
+++ b/features-json/flexbox.json
@@ -71,6 +71,9 @@
     },
     {
       "description":"IE 11 does not vertically align items correctly when `min-height` is used [see bug](https://connect.microsoft.com/IE/feedback/details/816293/ie11-flexbox-with-min-height-not-vertically-aligning-with-align-items-center)"
+    },
+    {
+      "description":"IE 11 requires a unit to be added to the third argument, the flex-basis property [see MSFT documentation](https://msdn.microsoft.com/en-us/library/dn254946(v=vs.85).aspx)"
     }
   ],
   "categories":[


### PR DESCRIPTION
IE11 requires a unit to be added to the 'flex-basis' attribute and to the third argument to the 'flex' attribute.