### PR TITLE
Flexbox: fixed spec definition of `flex` property

### DIFF
--- a/features-json/flexbox.json
+++ b/features-json/flexbox.json
@@ -43,7 +43,7 @@
   ],
   "bugs":[
     {
-      "description":"In IE10 the default value for `flex` is `0 0 auto` rather than `0 1 auto` as defined in the latest spec."
+      "description":"In IE10 the default value for `flex` is `0 0 auto` rather than `1 0 auto` as defined in the latest spec."
     },
     {
       "description":"In IE10 and IE11, containers with `display: flex` and `flex-direction: column` will not properly calculate their flexed childrens' sizes if the container has `min-height` but no explicit `height` property. [See bug](https://connect.microsoft.com/IE/feedback/details/802625/min-height-and-flexbox-flex-direction-column-dont-work-together-in-ie-10-11-preview)."


### PR DESCRIPTION
`Initial` value in the latest [spec definition](https://www.w3.org/TR/css-flexbox-1/#flex-property) for `flex` property is `1 0 auto` not `0 1 auto`.