### PR TITLE
Edge 14 has added `none` back. cursor: url() never went away

### DIFF
--- a/features-json/css3-cursors.json
+++ b/features-json/css3-cursors.json
@@ -33,7 +33,7 @@
     "edge":{
       "12":"a #2",
       "13":"a #2",
-      "14":"a #2"
+      "14":"y"
     },
     "firefox":{
       "2":"a",
@@ -253,7 +253,7 @@
   "notes":"",
   "notes_by_num":{
     "1":"Partial support refers to no support for the alias, cell, copy, ew-resize, ns-resize, nesw-resize, nwse-resize or context-menu cursors.",
-    "2":"Partial support refers to not supporting 'none' nor a URI."
+    "2":"Partial support refers to not supporting 'none'."
   },
   "usage_perc_y":46.85,
   "usage_perc_a":2.3,


### PR DESCRIPTION
All versions of Edge support cursor: url() just like IE did http://samples.msdn.microsoft.com/workshop/samples/author/dhtml/refs/cursor_a.htm (second format has been dropped, presumably because other browsers don't support it.)