### PR TITLE
css-placeholder: Add link to Firefox unprefixing bug

### DIFF
--- a/features-json/css-placeholder.json
+++ b/features-json/css-placeholder.json
@@ -19,6 +19,10 @@
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/::-moz-placeholder",
       "title":"MDN article"
+    },
+    {
+      "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=1069012",
+      "title":"Mozilla Bug 1069012 - unprefix :placeholder-shown pseudo-class and ::placeholder pseudo-element"
     }
   ],
   "bugs":[


### PR DESCRIPTION
Refs https://bugzilla.mozilla.org/show_bug.cgi?id=1069012