### PR TITLE
css-clip-path: Removed fixed bug in chrome

### DIFF
--- a/features-json/css-clip-path.json
+++ b/features-json/css-clip-path.json
@@ -13,11 +13,7 @@
       "title":"Codepen Example Clipping an Image with a Polygon"
     }
   ],
-  "bugs":[
-    {
-      "description":"Chrome has an issue with [clip-paths and backface-visibility with 3D transforms](https://code.google.com/p/chromium/issues/detail?id=350724)"
-    }
-  ],
+  "bugs":[],
   "categories":[
     "CSS3"
   ],


### PR DESCRIPTION
It has been fixed 9 months ago https://code.google.com/p/chromium/issues/detail?id=350724