### PR TITLE
Corrected IE10 issue description

### DIFF
--- a/features-json/flexbox.json
+++ b/features-json/flexbox.json
@@ -43,7 +43,7 @@
   ],
   "bugs":[
     {
-      "description":"In IE10 the default value for `flex` is `0 0 auto` rather than `1 0 auto` as defined in the latest spec."
+      "description":"In IE10 the default value for `flex` is `0 0 auto` rather than `0 1 auto` as defined in the latest spec."
     },
     {
       "description":"In Safari, the height of (non flex) children are not recognized in percentages. However other browsers recognize and scale the children based on percentage heights. ([See bug](https://bugs.webkit.org/show_bug.cgi?id=137730)) The bug also appeared in Chrome but was fixed in [Chrome 51](http://crbug.com/341310)"


### PR DESCRIPTION
Initial value of `flex` is `0 1 auto` as per [Flexbox Spec](https://www.w3.org/TR/css-flexbox/#flex-initial).