### PR TITLE
v0 -> v1 update

### DIFF
--- a/features-json/custom-elements.json
+++ b/features-json/custom-elements.json
@@ -13,12 +13,8 @@
       "title":"Polymer project (polyfill & web components framework)"
     },
     {
-      "url":"http://www.html5rocks.com/tutorials/webcomponents/customelements/",
-      "title":"HTML5Rocks - Custom Elements: defining new elements in HTML"
-    },
-    {
-      "url":"https://code.google.com/p/chromium/issues/detail?id=234509",
-      "title":"Chromium tracking bug: Implement Custom Elements"
+      "url":"https://developers.google.com/web/fundamentals/primers/customelements/",
+      "title":"Google Developers - Custom elements v1: reusable web components"
     },
     {
       "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=889230",
@@ -29,8 +25,8 @@
       "title":"IE Web Platform Status and Roadmap: Custom Elements"
     },
     {
-      "url":"https://github.com/WebReflection/document-register-element",
-      "title":"document.registerElement polyfill in 3KB minified & gzipped"
+      "url":"https://github.com/webcomponents/webcomponentsjs/tree/v1/src/CustomElements/v1",
+      "title":"customElements.define polyfill (supersedes document.registerElement)"
     }
   ],
   "bugs":[


### PR DESCRIPTION
Custom Elements v0 [was](https://github.com/w3c/webcomponents/pull/405#issuecomment-191698136) superseded by [Custom Elements v1](https://developers.google.com/web/fundamentals/primers/customelements/#historysupport).