### PR TITLE
form-validation: Firefox's form:valid bug is fixed in version 51

### DIFF
--- a/features-json/form-validation.json
+++ b/features-json/form-validation.json
@@ -17,7 +17,7 @@
       "description":"In Chrome (tested in 45) inputs marked as disabled or hidden while also marked as required are [incorrectly](https://html.spec.whatwg.org/multipage/forms.html#concept-fe-disabled) being considered for constraint validation. https://html.spec.whatwg.org/multipage/forms.html#concept-fe-disabled"
     },
     {
-      "description":"[IE & Edge do not support `:valid` on `form` elements.](https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/8114184/) Firefox seems to only apply it when child element values have changed from an invalid to valid state; see [bug #1285425](https://bugzilla.mozilla.org/show_bug.cgi?id=1285425)."
+      "description":"[IE & Edge do not support `:valid` on `form` elements.](https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/8114184/) Firefox<51 seemed to only match `:valid` on `form`s after child element values have changed from an invalid to valid state; see [bug #1285425](https://bugzilla.mozilla.org/show_bug.cgi?id=1285425)."
     }
   ],
   "categories":[


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1285425