### PR TITLE
touch-action property support is limited in Safari

### DIFF
--- a/features-json/css-touch-action.json
+++ b/features-json/css-touch-action.json
@@ -174,9 +174,9 @@
       "7.1":"n",
       "8":"n",
       "9":"n",
-      "9.1":"y",
-      "10":"y",
-      "TP":"y"
+      "9.1":"a #3",
+      "10":"a #3",
+      "TP":"a #3"
     },
     "opera":{
       "9":"n",
@@ -228,7 +228,7 @@
       "8":"n",
       "8.1-8.4":"n",
       "9.0-9.2":"n",
-      "9.3":"y"
+      "9.3":"a #3"
     },
     "op_mini":{
       "all":"n"
@@ -275,10 +275,11 @@
       "4":"y"
     }
   },
-  "notes":"Safari supports only `manipulation`, Chrome - `manipulation`, `pan-x`, `pan-y` and `none`.",
+  "notes":"",
   "notes_by_num":{
     "1":"Supported in Firefox behind the `layout.css.touch_action.enabled` flag, Firefox for Windows 8 Touch ('Metro') enabled by default.",
-    "2":"IE10+ has already supported these property which are not in standard at present such as'pinch-zoom','double-tap-zoom','cross-slide-x','cross-slide-y'."
+    "2":"IE10+ has already supported these property which are not in standard at present such as `pinch-zoom`, `double-tap-zoom`, `cross-slide-x`, `cross-slide-y`.",
+    "3":"Safari only supports `auto` and `manipulation`."
   },
   "usage_perc_y":69.39,
   "usage_perc_a":0,


### PR DESCRIPTION
The `touch-action` support in Safari is limited to one out of four properties (not counting the default `auto`). The other properties are just as relevant such that I would recommend treating the support for touch-action as partial.