### PR TITLE
Safari TP 12 has Fetch API enabled by default

### DIFF
--- a/features-json/fetch.json
+++ b/features-json/fetch.json
@@ -156,7 +156,7 @@
       "9":"n",
       "9.1":"n",
       "10":"n #5",
-      "TP":"n #5"
+      "TP":"y #7"
     },
     "opera":{
       "9":"n",
@@ -263,6 +263,7 @@
     "4":"Firefox <40 is not completely conforming to the specs and does not respect the <base> tag for relative URIs in fetch requests. https://bugzilla.mozilla.org/show_bug.cgi?id=1161625",
     "5":"Appears to exist in Safari Technical Preview but does not work in current build. Should work in [next preview build](https://twitter.com/xeenon/status/715379838081576960)",
     "6":"Can be enabled in `about:flags`"
+    "7":"Fetch API enabled by default since [Safari TP release 12](https://webkit.org/blog/6928/release-notes-for-safari-technology-preview-release-12/)"
   },
   "usage_perc_y":59.77,
   "usage_perc_a":0.15,


### PR DESCRIPTION
Safari just released a new TP version which has the Fetch API.

> Fetch API is enabled by default ([r204705](https://trac.webkit.org/changeset/204705/))

Source: 
- https://webkit.org/blog/6928/release-notes-for-safari-technology-preview-release-12/
- https://twitter.com/rmondello/status/771031234986127360