### PR TITLE
Node.innerText has been standardized in HTML

### DIFF
--- a/features-json/innertext.json
+++ b/features-json/innertext.json
@@ -1,8 +1,8 @@
 {
   "title":"Node.innerText",
-  "description":"A currently-nonstandard property representing the text within a DOM element and its descendants. As a getter, it approximates the text the user would get if they highlighted the contents of the element with the cursor and then copied to the clipboard.",
-  "spec":"http://rocallahan.github.io/innerText-spec/",
-  "status":"unoff",
+  "description":"A property representing the text within a DOM element and its descendants. As a getter, it approximates the text the user would get if they highlighted the contents of the element with the cursor and then copied to the clipboard.",
+  "spec":"https://html.spec.whatwg.org/multipage/dom.html#the-innertext-idl-attribute",
+  "status":"ls",
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/Node/innerText",

--- a/features-json/textcontent.json
+++ b/features-json/textcontent.json
@@ -251,7 +251,7 @@
       "4":"y"
     }
   },
-  "notes":"`Node.textContent` is somewhat similar to, but has important differences from, the proprietary [`Node.innerText`](http://caniuse.com/#feat=innertext) property.",
+  "notes":"`Node.textContent` is somewhat similar to, but has important differences from, [`Node.innerText`](http://caniuse.com/#feat=innertext).",
   "notes_by_num":{
     
   },


### PR DESCRIPTION
See https://html.spec.whatwg.org/multipage/dom.html#the-innertext-idl-attribute