### PR TITLE
css function attr() support - Updated supported browsers with issues

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/features-json/css3-attr.json
+++ b/features-json/css3-attr.json
@@ -26,7 +26,7 @@
     }
   ],
   "bugs":[
-    
+    "description":"Works only for content property. Content property can be used only for before and after pseudo elements"
   ],
   "categories":[
     "CSS"
@@ -39,7 +39,7 @@
       "8":"n",
       "9":"n",
       "10":"n",
-      "11":"n"
+      "11":"a #1"
     },
     "edge":{
       "12":"n",
@@ -94,11 +94,11 @@
       "44":"n",
       "45":"n",
       "46":"n",
-      "47":"n",
-      "48":"n",
-      "49":"n",
-      "50":"n",
-      "51":"n"
+      "47":"a #1",
+      "48":"a #1",
+      "49":"a #1",
+      "50":"a #1",
+      "51":"a #1"
     },
     "chrome":{
       "4":"n",
@@ -149,10 +149,10 @@
       "49":"n",
       "50":"n",
       "51":"n",
-      "52":"n",
-      "53":"n",
-      "54":"n",
-      "55":"n"
+      "52":"a #1",
+      "53":"a #1",
+      "54":"a #1",
+      "55":"a #1"
     },
     "safari":{
       "3.1":"n",
@@ -166,8 +166,8 @@
       "7.1":"n",
       "8":"n",
       "9":"n",
-      "9.1":"n",
-      "10":"n",
+      "9.1":"a #1",
+      "10":"a #1",
       "TP":"n"
     },
     "opera":{
@@ -258,7 +258,7 @@
     },
     "ie_mob":{
       "10":"n",
-      "11":"n"
+      "11":"y"
     },
     "and_uc":{
       "9.9":"n"
@@ -269,7 +269,7 @@
   },
   "notes":"",
   "notes_by_num":{
-    
+    "1":"Partial support in browsers refers to a buggy implementation (see issue)."
   },
   "usage_perc_y":0,
   "usage_perc_a":0,


### PR DESCRIPTION
Updated css attr function support information.

Partially supported browsers: IE11, chrome, firefox, safari.

Why no full support? : attr works only with content property in above browsers. As per specifications, it should work with any property like font-size, color etc.