### PR TITLE
css-media-interaction: Reinstate WebKit platform status ID

### DIFF
--- a/features-json/css-media-interaction.json
+++ b/features-json/css-media-interaction.json
@@ -276,6 +276,6 @@
   "ie_id":"mediaquerieslevel4pointerandhover",
   "chrome_id":"6460705494532096",
   "firefox_id":"",
-  "webkit_id":"",
+  "webkit_id":"feature-interaction-media-features-(pointer,-hover,-any-pointer,-any-hover)",
   "shown":true
 }


### PR DESCRIPTION
Seems to have been accidentally removed in 7dfd31d319b21ec4e787ec63aaa7b4f7368db221 ?
Reapplies #2440.

https://webkit.org/status/#feature-interaction-media-features-(pointer,-hover,-any-pointer,-any-hover)
