### PR TITLE
Update the link to the Edge bug for currentColor

### DIFF
--- a/features-json/currentcolor.json
+++ b/features-json/currentcolor.json
@@ -18,7 +18,7 @@
       "description":"Safari and iOS Safari 8 (maybe earlier too) have [a bug with currentColor](http://stackoverflow.com/questions/29400291/currentcolor-seems-to-get-stuck-in-safari) in :after/:before pseudo-content"
     },
     {
-      "description":"IE10+ & Edge have an issue with `currentColor` in a linear gradient [see bug](https://connect.microsoft.com/IE/feedback/details/1040120/ie-11-the-color-keyword-currentcolor-doesnt-work-in-the-css-linear-gradient-function)"
+      "description":"IE10+ & Edge have an issue with `currentColor` in a linear gradient [see bug](https://developer.microsoft.com/microsoft-edge/platform/issues/1328019/)"
     }
   ],
   "categories":[


### PR DESCRIPTION
The previous link points to a page marking the bug as closed because of the migration of Edge issues to their new dedicated issue tracker. This updates the link to point to the new issue tracker instead.