### PR TITLE
Fixed link for customElements github polyfill

### DIFF
--- a/features-json/custom-elements.json
+++ b/features-json/custom-elements.json
@@ -37,7 +37,7 @@
       "title":"Google Developers - Custom elements v1: reusable web components"
     },
     {
-      "url":"https://github.com/webcomponents/webcomponentsjs/tree/v1/src/CustomElements/v1",
+      "url":"https://github.com/webcomponents/webcomponentsjs/tree/v1/src/WebComponents",
       "title":"customElements.define polyfill (supersedes document.registerElement)"
     }
   ],

--- a/features-json/custom-elementsv1.json
+++ b/features-json/custom-elementsv1.json
@@ -17,7 +17,7 @@
       "title":"Google Developers - Custom elements v1: reusable web components"
     },
     {
-      "url":"https://github.com/webcomponents/webcomponentsjs/tree/v1/src/CustomElements/v1",
+      "url":"https://github.com/webcomponents/webcomponentsjs/tree/v1/src/WebComponents",
       "title":"customElements.define polyfill"
     }
   ],


### PR DESCRIPTION
The following link is currently broken: https://github.com/webcomponents/webcomponentsjs/tree/v1/src/CustomElements/v1

I found it when searching for Custom elements on [CanIUse](http://caniuse.com/#search=custom%20elements) (`Resources`: "customElements.define polyfill (supersedes document.registerElement)")

I replaced it with a new link to the current folder of the polyfill: https://github.com/webcomponents/webcomponentsjs/tree/v1/src/WebComponents

It might be a good idea to remove this link altogether though or just link to the Github repository itself instead of a folder in the tree (or a branch) as this is most likely going to break again in the future.

Let me know if I should remove the link from the list