### PR TITLE
upgradeinsecurerequests: add upgrade-insecure-requests alias

### DIFF
--- a/features-json/upgradeinsecurerequests.json
+++ b/features-json/upgradeinsecurerequests.json
@@ -270,7 +270,7 @@
   "usage_perc_a":0,
   "ucprefix":false,
   "parent":"",
-  "keywords":"security,header,uir",
+  "keywords":"security,header,uir,upgrade-insecure-requests",
   "ie_id":"upgradeinsecureresourcerequests",
   "chrome_id":"6534575509471232",
   "firefox_id":"",


### PR DESCRIPTION
Allow searching for `upgradeinsecurerequests` as `upgrade-insecure-requests` since that's the name that's actually used in the CSP header.