### PR TITLE
position:fixed partially supported in Android 4.0-4.3

### DIFF
--- a/features-json/css-fixed.json
+++ b/features-json/css-fixed.json
@@ -230,9 +230,9 @@
       "2.2":"a #2",
       "2.3":"a #2",
       "3":"y",
-      "4":"y",
-      "4.1":"y",
-      "4.2-4.3":"y",
+      "4":"y #3",
+      "4.1":"y #3",
+      "4.2-4.3":"y #3",
       "4.4":"y",
       "4.4.3-4.4.4":"y",
       "52":"y"
@@ -270,7 +270,8 @@
   "notes":"",
   "notes_by_num":{
     "1":"Partial support in older iOS Safari refers to [buggy behavior](http://remysharp.com/2012/05/24/issues-with-position-fixed-scrolling-on-ios/).",
-    "2":"Only works in Android 2.1 thru 2.3 by using the following meta tag: <meta name=\"viewport\" content=\"width=device-width, user-scalable=no\">."
+    "2":"Only works in Android 2.1 thru 2.3 by using the following meta tag: <meta name=\"viewport\" content=\"width=device-width, user-scalable=no\">.",
+    "3":"Android 4.0-4.3 [ignore transforms and margin:auto on position:fixed elements](https://codepen.io/mattiacci/pen/mPRKZY)."
   },
   "usage_perc_y":92.92,
   "usage_perc_a":0.16,


### PR DESCRIPTION
CSS transforms and margin:auto are ignored on position:fixed elements in Android 4.0-4.3.
Example: https://codepen.io/mattiacci/pen/mPRKZY

Note: Couldn't find a way to test Android 3, so not sure about compatibility there.