### PR TITLE
Mark svg-html as partially supported on IE and Edge.

### DIFF
--- a/features-json/svg-html.json
+++ b/features-json/svg-html.json
@@ -31,14 +31,14 @@
       "6":"n",
       "7":"n",
       "8":"n",
-      "9":"a #1",
-      "10":"a #1",
-      "11":"a #1"
+      "9":"a #1 #2",
+      "10":"a #1 #2",
+      "11":"a #1 #2"
     },
     "edge":{
-      "12":"y",
-      "13":"y",
-      "14":"y"
+      "12":"a #2",
+      "13":"a #2",
+      "14":"a #2"
     },
     "firefox":{
       "2":"n",
@@ -267,7 +267,8 @@
   },
   "notes":"Partial support refers to lack of filter support or buggy result from effects. A [CSS Filter Effects](http://www.w3.org/TR/filter-effects/) specification is in the works that would replace this method.",
   "notes_by_num":{
-    "1":"IE11 and below do not support `<foreignObject>`."
+    "1":"IE11 and below do not support `<foreignObject>`.",
+    "2":"IE and Edge do not support applying SVG filter effects to HTML elements using CSS. [Bug Report](https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/6618695/)"
   },
   "usage_perc_y":9.02,
   "usage_perc_a":74.01,


### PR DESCRIPTION
Due to https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/6618695/

Fixes #2333