### PR TITLE
Update xml-serializer.json

### DIFF
--- a/features-json/xml-serializer.json
+++ b/features-json/xml-serializer.json
@@ -268,7 +268,8 @@
   "notes":"",
   "notes_by_num":{
     "1":"Partial support refers to lacking support for `parseFromString` on the DOMParser.",
-    "2":"Partial support in older IE refers to only supporting `innerHTML`, nothing else."
+    "2":"Partial support refers to supporting only `innerHTML`.",
+    "3":"Partial support refers to supporting only `innerHTML` and `insertAdjacentHTML`."
   },
   "usage_perc_y":82.2,
   "usage_perc_a":15.84,


### PR DESCRIPTION
Note #3 (used by Firefox) was curiously missing, so I reconstructed it, based on https://developer.mozilla.org/en-US/docs/Web/API/Element/insertAdjacentHTML