### PR TITLE
Added animation event bug for IE10/IE11

### DIFF
--- a/features-json/css-animation.json
+++ b/features-json/css-animation.json
@@ -35,6 +35,9 @@
     },
     {
       "description":"IE10 and IE11 on Windows 7 have a bug where translate transform values are always interpreted as pixels when used in animations [test case](http://codepen.io/flxsource/pen/jPYWoE)"
+    },
+    {
+      "description":"IE10 and IE11 will not fire Animation events for pseudo element animations. See [example here](http://codepen.io/dogoku/pen/JRwbmL)"
     }
   ],
   "categories":[


### PR DESCRIPTION
When animating a pseudo element, IE10 and IE11 will not fire the relevant Animation Events