### PR TITLE
font-loading.json: removed webkit's "in progress"

### DIFF
--- a/features-json/font-loading.json
+++ b/features-json/font-loading.json
@@ -14,9 +14,7 @@
     }
   ],
   "bugs":[
-    {
-      "description":"WebKit [implementation](https://lists.webkit.org/pipermail/webkit-dev/2014-July/026741.html) is [in progress](https://bugs.webkit.org/show_bug.cgi?id=135390)."
-    }
+    
   ],
   "categories":[
     "CSS3",


### PR DESCRIPTION
Safari 10 reportedly shipped the feature