### PR TITLE
Remove dead URL

### DIFF
--- a/features-json/canvas.json
+++ b/features-json/canvas.json
@@ -9,10 +9,6 @@
       "title":"Tutorial by Mozilla"
     },
     {
-      "url":"http://www.canvasdemos.com/",
-      "title":"Showcase site"
-    },
-    {
       "url":"http://glimr.rubyforge.org/cake/canvas.html",
       "title":"Animation kit"
     },


### PR DESCRIPTION
http://www.canvasdemos.com/ appears to be a dead URL, not sure if it has moved or not