### PR TITLE
Add multiple Node versions to Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,7 @@ sudo: false
 language: node_js
 node_js:
   - 0.6
+  - 4
+  - 5
+  - 6
 script: node validator/validate-jsons.js


### PR DESCRIPTION
This is related to issue #2981 , I think it's good practice to test multiple Node versions, not just `0.6`. The issue could have been avoided. I've added Node versions 4, 5, and 6 to the Travis build file.