### PR TITLE
correct information about `font-rendering` in Firefox

### DIFF
--- a/features-json/css-font-rendering-controls.json
+++ b/features-json/css-font-rendering-controls.json
@@ -85,13 +85,13 @@
       "43":"n",
       "44":"n",
       "45":"n",
-      "46":"n",
-      "47":"n",
-      "48":"n",
-      "49":"n",
-      "50":"n",
-      "51":"n",
-      "52":"n"
+      "46":"n d #2",
+      "47":"n d #2",
+      "48":"n d #2",
+      "49":"n d #2",
+      "50":"n d #2",
+      "51":"n d #2",
+      "52":"n d #2"
     },
     "chrome":{
       "4":"n",
@@ -267,7 +267,8 @@
   },
   "notes":"",
   "notes_by_num":{
-    "1":"Can be enabled via the \"Experimental Web Platform features\" flag"
+    "1":"Can be enabled via the \"Experimental Web Platform features\" flag",
+    "2":"Can be enabled in Firefox through the `layout.css.grid.enabled` flag at about:config",
   },
   "usage_perc_y":0,
   "usage_perc_a":0,

--- a/features-json/css-font-rendering-controls.json
+++ b/features-json/css-font-rendering-controls.json
@@ -268,7 +268,7 @@
   "notes":"",
   "notes_by_num":{
     "1":"Can be enabled via the \"Experimental Web Platform features\" flag",
-    "2":"Can be enabled in Firefox through the `layout.css.font-display.enabled` flag at about:config",
+    "2":"Can be enabled in Firefox through the `layout.css.font-display.enabled` flag at about:config"
   },
   "usage_perc_y":0,
   "usage_perc_a":0,

--- a/features-json/css-font-rendering-controls.json
+++ b/features-json/css-font-rendering-controls.json
@@ -268,7 +268,7 @@
   "notes":"",
   "notes_by_num":{
     "1":"Can be enabled via the \"Experimental Web Platform features\" flag",
-    "2":"Can be enabled in Firefox through the `layout.css.grid.enabled` flag at about:config",
+    "2":"Can be enabled in Firefox through the `layout.css.font-display.enabled` flag at about:config",
   },
   "usage_perc_y":0,
   "usage_perc_a":0,


### PR DESCRIPTION
Support for `font-rendering` was added to Firefox 46, available by enabling a flag. See: https://bugzilla.mozilla.org/show_bug.cgi?id=1157064. 

(Future full support is being worked on at this ticket: https://bugzilla.mozilla.org/show_bug.cgi?id=1317445)