### PR TITLE
custom-elementsv1: Remove duplicate Edge status link

### DIFF
--- a/features-json/custom-elementsv1.json
+++ b/features-json/custom-elementsv1.json
@@ -9,10 +9,6 @@
       "title":"Firefox tracking bug: Implement Custom Elements (from Web Components)"
     },
     {
-      "url":"http://status.modern.ie/customelements",
-      "title":"IE Web Platform Status and Roadmap: Custom Elements"
-    },
-    {
       "url":"https://developers.google.com/web/fundamentals/primers/customelements/",
       "title":"Google Developers - Custom elements v1: reusable web components"
     },


### PR DESCRIPTION
The ie_id already generates the same link, just with a different title.