### PR TITLE
Flexbox bug in Firefox got fixed

### DIFF
--- a/features-json/flexbox.json
+++ b/features-json/flexbox.json
@@ -49,7 +49,7 @@
       "description":"In Safari, the height of (non flex) children are not recognized in percentages. However other browsers recognize and scale the children based on percentage heights. ([See bug](https://bugs.webkit.org/show_bug.cgi?id=137730)) The bug also appeared in Chrome but was fixed in [Chrome 51](http://crbug.com/341310)"
     },
     {
-      "description":"Firefox does not support [Flexbox in button elements](https://bugzilla.mozilla.org/show_bug.cgi?id=984869#c2)"
+      "description":"Firefox up to (and including) version 51 did not support [Flexbox in button elements](https://bugzilla.mozilla.org/show_bug.cgi?id=984869#c2). Fixed in version 52."
     },
     {
       "description":"[Flexbugs](https://github.com/philipwalton/flexbugs): community-curated list of flexbox issues and cross-browser workarounds for them"


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=984869 got fixed :smile: 

I checked with Firefox Aurora (v52) and the demo page http://codepen.io/philipwalton/pen/ByZgpW.
I can confirm this definitely got fixed.