### PR TITLE
Firefox for Android does not support internationalization yet.

### DIFF
--- a/features-json/internationalization.json
+++ b/features-json/internationalization.json
@@ -19,6 +19,10 @@
     {
       "url":"https://bugs.webkit.org/show_bug.cgi?id=90906",
       "title":"WebKit tracking bug"
+    },
+    {
+      "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=1215247",
+      "title":"Firefox for Android tracking bug"
     }
   ],
   "bugs":[
@@ -257,7 +261,7 @@
       "53":"y"
     },
     "and_ff":{
-      "49":"y"
+      "50":"n"
     },
     "ie_mob":{
       "10":"n",


### PR DESCRIPTION

Intl object. Because Firefox is one of the last major browsers without support, it
might be worth it to add the tracking bug as well.
https://bugzilla.mozilla.org/show_bug.cgi?id=1215247