### PR TITLE
Remove confusing bug text from nav-timing.json

### DIFF
--- a/features-json/nav-timing.json
+++ b/features-json/nav-timing.json
@@ -18,9 +18,7 @@
     }
   ],
   "bugs":[
-    {
-      "description":"Chrome on Windows - window.performance timing is millisecond resolution."
-    }
+    
   ],
   "categories":[
     "DOM",


### PR DESCRIPTION
According to https://www.w3.org/TR/navigation-timing/#sec-navigation-timing the NavigationTiming values are all longs -- MDN says these are "number of milliseconds since the Unix epoch." So unlike the High Resolution Time API (`window.performance.now()`), these are _supposed_ to be integer numbers of milliseconds. This bug description implies that Chrome on Windows is not following the spec, but millisecond resolution would seem to be correct.