### PR TITLE
Initial Letter page — Fixing broken link to Bugzilla

### DIFF
--- a/features-json/css-initial-letter.json
+++ b/features-json/css-initial-letter.json
@@ -274,7 +274,7 @@
       "4":"n"
     }
   },
-  "notes":"Firefox status: [in-development](https://bugzilla.mozilla.org/show_bug.cgi?id=1040714)",
+  "notes":"Firefox status: [in-development](https://bugzilla.mozilla.org/show_bug.cgi?id=1223880)",
   "notes_by_num":{
     "1":"Safari implementation is incomplete. Does not allow applying web fonts to the initial letter."
   },


### PR DESCRIPTION
I included two links to the Bugzilla ticket for implementing Initial Letter in Firefox — only one of them points to CSS Shapes. Wooops! This commit should fix that.