### PR TITLE
Update CSS Grid with Safari TP support

### DIFF
--- a/features-json/css-grid.json
+++ b/features-json/css-grid.json
@@ -174,7 +174,7 @@
       "9":"p",
       "9.1":"p",
       "10":"p",
-      "TP":"n d #4"
+      "TP":"y d #4"
     },
     "opera":{
       "9":"n",
@@ -282,7 +282,7 @@
     "1":"Enabled in Chrome through the \"experimental Web Platform features\" flag in chrome://flags",
     "2":"Partial support in IE refers to supporting an [older version](http://www.w3.org/TR/2011/WD-css3-grid-layout-20110407/) of the specification.",
     "3":"Enabled in Firefox through the `layout.css.grid.enabled ` flag",
-    "4":"Can be enabled via the \"Experimental Features\" developer menu"
+    "4":"Can be disabled or enabled via the \"Experimental Features\" developer menu"
   },
   "usage_perc_y":0,
   "usage_perc_a":6,


### PR DESCRIPTION
Safari Technical Preview now ships with CSS Grid on by default. So the box should be green. I'm not sure whether you want to leave the note about how to toggle it on and off (since those folks who installed Safari TP in the past will need to toggle it on) or not. I've included two pull requests — commit both to keep the note. Or just the first to remove the note.