### PR TITLE
Fix mdn link in payment request api

### DIFF
--- a/features-json/payment-request.json
+++ b/features-json/payment-request.json
@@ -17,7 +17,7 @@
       "title":"Payment Request API Integration Guide"
     },
     {
-      "url":"https://developer.mozilla.org/en-US/docs/Web/API/Credential_Management_API",
+      "url":"https://developer.mozilla.org/en-US/docs/Web/API/Payment_Request_API",
       "title":"Mozilla Developer Network"
     },
     {


### PR DESCRIPTION
It currently links to the Credential Management API page