### PR TITLE
css-sticky.json: add examples & gotchas article

### DIFF
--- a/features-json/css-sticky.json
+++ b/features-json/css-sticky.json
@@ -23,6 +23,10 @@
     {
       "url":"https://github.com/wilddeer/stickyfill",
       "title":"Another polyfill"
+    },
+    {
+      "url":"http://gedd.ski/post/position-sticky/",
+      "title":"geddski article: Examples and Gotchas"
     }
   ],
   "bugs":[


### PR DESCRIPTION
adds a resource that shows examples of the kinds of things you can build with `position:sticky`, as well as gotchas you need to watch out for (like sticky sibling elements, `position: absolute` children, etc)