### PR TITLE
XHR2 - FormData corrupted IE10/11

### DIFF
--- a/features-json/xhr2.json
+++ b/features-json/xhr2.json
@@ -32,6 +32,9 @@
     },
     {
       "description":"In Internet Explorer the `timeout` property may only be set after calling `open` and before calling `send`."
+    },
+    {
+      "description":"IE10 and IE11, the request body will be corrupted, if the last checkable input is not checked. [More details](https://blog.yorkxin.org/2014/02/06/ajax-with-formdata-is-broken-on-ie10-ie11)."
     }
   ],
   "categories":[


### PR DESCRIPTION
`FormData` are not working properly on IE10/11, when there is unchecked
checkbox at the end of form.