### PR TITLE
wasm is available behind a flag in Edge 15

### DIFF
--- a/features-json/wasm.json
+++ b/features-json/wasm.json
@@ -29,7 +29,7 @@
       "12":"n",
       "13":"n",
       "14":"n",
-      "15":"n"
+      "15":"n d #3"
     },
     "firefox":{
       "2":"n",
@@ -270,7 +270,8 @@
   "notes":"",
   "notes_by_num":{
     "1":"Can be enabled via the `javascript.options.wasm` in `about:config`",
-    "2":"Can be enabled via the `#enable-webassembly` flag"
+    "2":"Can be enabled via the `#enable-webassembly` flag",
+    "3":"Can be enabled via the Experimental JavaScript Features flag"
   },
   "usage_perc_y":0.07,
   "usage_perc_a":0,


### PR DESCRIPTION
https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/11423808-add-support-for-web-assembly-as-early-as-possible