### PR TITLE
Fix history API compatibility on Edge and IE

### DIFF
--- a/features-json/history.json
+++ b/features-json/history.json
@@ -47,14 +47,14 @@
       "7":"n",
       "8":"n",
       "9":"n",
-      "10":"y",
+      "10":"a #1",
       "11":"y"
     },
     "edge":{
-      "12":"y",
-      "13":"y",
-      "14":"y",
-      "15":"y"
+      "12":"a #1",
+      "13":"a #1",
+      "14":"a #1",
+      "15":"a #1"
     },
     "firefox":{
       "2":"n",
@@ -294,7 +294,7 @@
   },
   "notes":"Older iOS versions and Android 4.0.4 claim support, but implementation is too buggy to be useful.",
   "notes_by_num":{
-    
+    "1": "Partial support refers to not supporting scrollRestoration feature"
   },
   "usage_perc_y":84.73,
   "usage_perc_a":9.04,


### PR DESCRIPTION
Hi,

I've spotted that the provided info is not valid,
Seems that IE and Edge still doesn't support scroll restoration API.

Proof info could be found here:
https://developer.mozilla.org/en-US/docs/Web/API/History

We may also close this issue: #1889