### PR TITLE
IE & Edge don't fully implement old snappoints spec

### DIFF
--- a/features-json/css-snappoints.json
+++ b/features-json/css-snappoints.json
@@ -30,14 +30,14 @@
       "7":"n",
       "8":"n",
       "9":"n",
-      "10":"a x #1 #5",
-      "11":"a x #2 #5"
+      "10":"a x #1 #5 #6",
+      "11":"a x #2 #5 #6"
     },
     "edge":{
-      "12":"a x #2 #5",
-      "13":"a x #2 #5",
-      "14":"a x #2 #5",
-      "15":"a x #2 #5"
+      "12":"a x #2 #5 #6",
+      "13":"a x #2 #5 #6",
+      "14":"a x #2 #5 #6",
+      "15":"a x #2 #5 #6"
     },
     "firefox":{
       "2":"n",
@@ -281,7 +281,8 @@
     "1":"Partial support in IE10 refers to support limited to touch screens.",
     "2":"Partial support in IE11 [documented here](https://dl.dropboxusercontent.com/u/444684/openwebref/CSS/scroll-snap-points/support.html)",
     "4":"Partial support in Safari refers to not supporting the `none` keyword in `scroll-snap-points-x`, `scroll-snap-points-y` and `scroll-snap-coordinate`, and length keywords (`top`, `right`, etc.) in `scroll-snap-destination` and `scroll-snap-coordinate`.",
-    "5":"Supports properties from an [older version](https://www.w3.org/TR/2015/WD-css-snappoints-1-20150326/) of the spec."
+    "5":"Supports properties from an [older version](https://www.w3.org/TR/2015/WD-css-snappoints-1-20150326/) of the spec.",
+    "6":"Partial support in IE & Edge refers to not supporting `scroll-snap-coordinate` and `scroll-snap-destination`."
   },
   "usage_perc_y":0.01,
   "usage_perc_a":22.94,


### PR DESCRIPTION
Document IE & Edge versions not supporting the `scroll-snap-coordinate` and `scroll-snap-destination` from the old spec.