### PR TITLE
IE & Edge do not support region-fragment

### DIFF
--- a/features-json/css-regions.json
+++ b/features-json/css-regions.json
@@ -34,14 +34,14 @@
       "7":"n",
       "8":"n",
       "9":"n",
-      "10":"a x #1",
-      "11":"a x #1"
+      "10":"a x #1 #2",
+      "11":"a x #1 #2"
     },
     "edge":{
-      "12":"a x #1",
-      "13":"a x #1",
-      "14":"a x #1",
-      "15":"a x #1"
+      "12":"a x #1 #2",
+      "13":"a x #1 #2",
+      "14":"a x #1 #2",
+      "15":"a x #1 #2"
     },
     "firefox":{
       "2":"n",
@@ -267,8 +267,8 @@
       "51":"n"
     },
     "ie_mob":{
-      "10":"a x #1",
-      "11":"a x #1"
+      "10":"a x #1 #2",
+      "11":"a x #1 #2"
     },
     "and_uc":{
       "11":"y x"
@@ -282,7 +282,8 @@
   },
   "notes":"",
   "notes_by_num":{
-    "1":"Support is limited to using an iframe as a content source with the `-ms-flow-into: flow_name;` and `-ms-flow-from: flow_name;` syntax."
+    "1":"Support is limited to using an iframe as a content source with the `-ms-flow-into: flow_name;` and `-ms-flow-from: flow_name;` syntax.",
+    "2":"Partial support refers to not supporting the `region-fragment` property."
   },
   "usage_perc_y":21.24,
   "usage_perc_a":5.99,


### PR DESCRIPTION
Document the fact that IE & Edge do not support `region-fragment`.