### PR TITLE
Adding bug/note for Chrome 55+ not fully working

### DIFF
--- a/features-json/speech-synthesis.json
+++ b/features-json/speech-synthesis.json
@@ -22,7 +22,9 @@
     }
   ],
   "bugs":[
-    
+    {
+      "description":"[Chrome issue 679437: Speech Synthesis stops abruptly after about 15 seconds](https://bugs.chromium.org/p/chromium/issues/detail?id=679437)"
+    }
   ],
   "categories":[
     "JS API"
@@ -152,11 +154,11 @@
       "52":"y",
       "53":"y",
       "54":"y",
-      "55":"y",
-      "56":"y",
-      "57":"y",
-      "58":"y",
-      "59":"y"
+      "55":"y #2",
+      "56":"y #2",
+      "57":"y #2",
+      "58":"y #2",
+      "59":"y #2"
     },
     "safari":{
       "3.1":"n",
@@ -282,7 +284,8 @@
   },
   "notes":"Samsung Internet for GearVR: In Development, release based on Chromium m53 due Q1/2017",
   "notes_by_num":{
-    "1":"Can be enabled in Firefox using the `media.webspeech.synth.enabled` about:config flag."
+    "1":"Can be enabled in Firefox using the `media.webspeech.synth.enabled` about:config flag.",
+    "2":"Speech Synthesis in Chrome since version 55 stops playback after about 15 seconds on Windows 7 & 10, and Ubuntu 14.04, possibly other platforms"
   },
   "usage_perc_y":72.3,
   "usage_perc_a":0,


### PR DESCRIPTION
Chrome stops playback after about 15 seconds since version 55 on some platforms, including at least: Windows 7 & 10, Ubuntu 14.04.