### PR TITLE
Firefox 54+ supports ES6 Modules behind a flag

### DIFF
--- a/features-json/es6-module.json
+++ b/features-json/es6-module.json
@@ -98,8 +98,8 @@
       "51":"n",
       "52":"n",
       "53":"n",
-      "54":"n",
-      "55":"n"
+      "54":"n d #2",
+      "55":"n d #2"
     },
     "chrome":{
       "4":"n",
@@ -283,7 +283,8 @@
   },
   "notes":"",
   "notes_by_num":{
-    "1":"Support can be enabled via `about:flags`"
+    "1":"Support can be enabled via `about:flags`",
+    "2":"Support can be enabled via `about:config`"
   },
   "usage_perc_y":0.01,
   "usage_perc_a":0,


### PR DESCRIPTION
Ref: https://blog.hospodarets.com/native-ecmascript-modules-the-first-overview#enabling-es-modules-in-firefox