### PR TITLE
Add note for Safari bug to multicolumn.json

### DIFF
--- a/features-json/multicolumn.json
+++ b/features-json/multicolumn.json
@@ -49,6 +49,9 @@
     },
     {
       "description":"Safari 5-8 is known to render columns [less evenly](http://stackoverflow.com/questions/14148078/safari-column-count-differs-from-firefox-and-chrome) than other browsers"
+    },
+    {
+      "description":"Safari 5.1-10+ does not work as expected with `min-height` [see testcase](https://codepen.io/herrschuessler/pen/LNVWJE) [see bug](https://bugs.webkit.org/show_bug.cgi?id=65691)"
     }
   ],
   "categories":[


### PR DESCRIPTION
Safari 5.1-10+ has a bug where setting `min-height` on an element with css columns will clip the contents to that min-height.

[test case](https://codepen.io/herrschuessler/pen/LNVWJE)

[bug report](https://bugs.webkit.org/show_bug.cgi?id=65691)