### PR TITLE
Update touch-action level 2 compatibility data for Chrome

### DIFF
--- a/features-json/css-touch-action-2.json
+++ b/features-json/css-touch-action-2.json
@@ -23,7 +23,7 @@
   ],
   "bugs":[
     {
-      "description":"Chrome treats two parallel finger swipes as `pan` instead of `pinch-zoom`."
+      "description":"Chrome 58 and below treats two parallel finger swipes as `pan` instead of `pinch-zoom`."
     }
   ],
   "categories":[
@@ -265,7 +265,7 @@
       "37":"n"
     },
     "and_chr":{
-      "56":"a #2"
+      "56":"y"
     },
     "and_ff":{
       "51":"n"


### PR DESCRIPTION
Two changes:
- Chrome 56 for Android has full support like Chrome 56 for desktop (see [chrome status](https://www.chromestatus.com/feature/5670200775016448))
- Chrome 59 dev resolves the outstanding bug for Chrome (see https://github.com/w3c/pointerevents/issues/166#issuecomment-286482230)
