### PR TITLE
Safari Custom Push notification support

### DIFF
--- a/features-json/push-api.json
+++ b/features-json/push-api.json
@@ -164,10 +164,10 @@
       "7.1":"n",
       "8":"n",
       "9":"n",
-      "9.1":"n",
-      "10":"n",
-      "10.1":"n",
-      "TP":"n"
+      "9.1":"n #3",
+      "10":"n #3",
+      "10.1":"n #3",
+      "TP":"n #3"
     },
     "opera":{
       "9":"n",
@@ -279,7 +279,8 @@
   "notes":"",
   "notes_by_num":{
     "1":"Partial support refers to not supporting `PushEvent.data` and `PushMessageData`",
-    "2":"Requires full browser to be running to receive messages"
+    "2":"Requires full browser to be running to receive messages",
+    "3":"Safari supports a custom implementaion https://developer.apple.com/notifications/safari-push-notifications/. WWDC video by apple : https://developer.apple.com/videos/play/wwdc2013/614/ "
   },
   "usage_perc_y":60.28,
   "usage_perc_a":2.05,


### PR DESCRIPTION
https://developer.apple.com/notifications/safari-push-notifications/
https://appadvice.com/appnn/2013/09/apple-to-enable-ios-inspired-safari-push-notifications-for-developers-in-os-x-mavericks