### PR TITLE
touch-action note for Firefox 52+

### DIFF
--- a/features-json/css-touch-action.json
+++ b/features-json/css-touch-action.json
@@ -108,10 +108,10 @@
       "49":"n d #1",
       "50":"n d #1",
       "51":"n d #1",
-      "52":"y",
-      "53":"y",
-      "54":"y",
-      "55":"y"
+      "52":"y #4",
+      "53":"y #4",
+      "54":"y #4",
+      "55":"y #4"
     },
     "chrome":{
       "4":"n",
@@ -300,7 +300,8 @@
   "notes_by_num":{
     "1":"Supported in Firefox behind the `layout.css.touch_action.enabled` flag, Firefox for Windows 8 Touch ('Metro') enabled by default.",
     "2":"IE10+ has already supported these property which are not in standard at present such as `double-tap-zoom`, `cross-slide-x`, `cross-slide-y`.",
-    "3":"Safari only supports `auto` and `manipulation`."
+    "3":"Safari only supports `auto` and `manipulation`.",
+    "4":"Not applicable to Firefox platforms that support neither pointer nor touch events."
   },
   "usage_perc_y":66.2,
   "usage_perc_a":11.64,


### PR DESCRIPTION
Added a note about not all Firefox platforms supporting pointer events or touch events, rendering touch-action support moot (eg Windows without APZ, Mac OS). 