### PR TITLE
Update intersectionobserver.json for Edge15 capability

### DIFF
--- a/features-json/intersectionobserver.json
+++ b/features-json/intersectionobserver.json
@@ -38,7 +38,7 @@
       "12":"n",
       "13":"n",
       "14":"n",
-      "15":"a #2"
+      "15":"y"
     },
     "firefox":{
       "2":"n",
@@ -283,8 +283,7 @@
   },
   "notes":"",
   "notes_by_num":{
-    "1":"Enabled in Firefox by setting the `about:config` preference `dom.IntersectionObserver.enabled` to true",
-    "2":"\"Preliminary\" support as feature is still in development"
+    "1":"Enabled in Firefox by setting the `about:config` preference `dom.IntersectionObserver.enabled` to true"
   },
   "usage_perc_y":51.5,
   "usage_perc_a":0,


### PR DESCRIPTION
Updates Edge15 to full support (from partial). This was added in 14986 (Edge15 is 15063)

https://developer.microsoft.com/en-us/microsoft-edge/platform/status/intersectionobserver/