### PR TITLE
css-image-set: Add Firefox bug link

### DIFF
--- a/features-json/css-image-set.json
+++ b/features-json/css-image-set.json
@@ -9,6 +9,10 @@
       "title":"Demo"
     },
     {
+      "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=1107646",
+      "title":"Firefox feature request bug"
+    },
+    {
       "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6606738-image-set",
       "title":"Microsoft Edge feature request on UserVoice"
     }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1107646