### PR TITLE
css-crisp-edges: Add link to Firefox & Chrome bugs

### DIFF
--- a/features-json/css-crisp-edges.json
+++ b/features-json/css-crisp-edges.json
@@ -11,6 +11,10 @@
     {
       "url":"http://updates.html5rocks.com/2015/01/pixelated",
       "title":"HTML5Rocks article"
+    },
+    {
+      "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=856337",
+      "title":"Firefox bug #856337: Implement image-rendering: pixelated"
     }
   ],
   "bugs":[

--- a/features-json/css-crisp-edges.json
+++ b/features-json/css-crisp-edges.json
@@ -15,6 +15,10 @@
     {
       "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=856337",
       "title":"Firefox bug #856337: Implement image-rendering: pixelated"
+    },
+    {
+      "url":"https://bugs.chromium.org/p/chromium/issues/detail?id=317991",
+      "title":"Chrome bug #317991: Implement image-rendering:crisp-edges"
     }
   ],
   "bugs":[


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=856337