### PR TITLE
css-cross-fade: Add link to Firefox bug

### DIFF
--- a/features-json/css-cross-fade.json
+++ b/features-json/css-cross-fade.json
@@ -7,6 +7,10 @@
     {
       "url":"http://peter.sh/files/examples/cross-fading.html",
       "title":"Simple demo"
+    },
+    {
+      "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=546052",
+      "title":"Firefox bug #546052: Implement cross-fade()"
     }
   ],
   "bugs":[


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=546052