### PR TITLE
rem: Use more precise spec link

### DIFF
--- a/features-json/rem.json
+++ b/features-json/rem.json
@@ -1,7 +1,7 @@
 {
   "title":"rem (root em) units",
   "description":"Type of unit similar to `em`, but relative only to the root element, not any parent element. Thus compounding does not occur as it does with `em` units.",
-  "spec":"http://www.w3.org/TR/css3-values/#font-relative-lengths",
+  "spec":"https://www.w3.org/TR/css3-values/#rem",
   "status":"cr",
   "links":[
     {


### PR DESCRIPTION
The original link was for the entire font-relative lengths section (which also includes the em, ex, and ch units, some of which even have their own caniuse entries).
The new link is for the rem unit specifically, for precision.