### PR TITLE
css-initial-value: Fix spec link

### DIFF
--- a/features-json/css-initial-value.json
+++ b/features-json/css-initial-value.json
@@ -1,7 +1,7 @@
 {
   "title":"CSS initial value",
   "description":"A CSS value that will apply a property's initial value as defined in the CSS specification that defines the property",
-  "spec":"http://www.w3.org/TR/css-values/#common-keywords",
+  "spec":"https://www.w3.org/TR/css-cascade-4/#initial",
   "status":"cr",
   "links":[
     {


### PR DESCRIPTION
A. The original link was to a general "common keywords" section which also covers 'inherit' and 'unset'.
B. As you'll find if you click the hyperlinked mentions of 'initial' in the section from the original link, CSS technically considers CSS Cascade rather than CSS Values & Units to the be spec that defines 'initial'.

(The `status` field remains unchanged since Cascade Level 4 is also a Candidate Recommendation.)