### PR TITLE
css-grid: mention Firefox bugs fixed in 54

### DIFF
--- a/features-json/css-grid.json
+++ b/features-json/css-grid.json
@@ -104,8 +104,8 @@
       "49":"p d #3",
       "50":"p d #3",
       "51":"p d #3",
-      "52":"y",
-      "53":"y",
+      "52":"y #5",
+      "53":"y #5",
       "54":"y",
       "55":"y",
       "56":"y"
@@ -298,7 +298,8 @@
     "1":"Enabled in Chrome through the \"experimental Web Platform features\" flag in chrome://flags",
     "2":"Partial support in IE refers to supporting an [older version](http://www.w3.org/TR/2011/WD-css3-grid-layout-20110407/) of the specification.",
     "3":"Enabled in Firefox through the `layout.css.grid.enabled ` flag",
-    "4":"Grid does not initially display with certain JavaScript ([bug report](https://bugs.chromium.org/p/chromium/issues/detail?id=700383))"
+    "4":"Grid does not initially display with certain JavaScript ([bug report](https://bugs.chromium.org/p/chromium/issues/detail?id=700383))",
+    "5":"There are some bugs with overflow ([1356820](https://bugzilla.mozilla.org/show_bug.cgi?id=1356820), [1348857](https://bugzilla.mozilla.org/show_bug.cgi?id=1348857), [1350925](https://bugzilla.mozilla.org/show_bug.cgi?id=1350925))"
   },
   "usage_perc_y":31.32,
   "usage_perc_a":5.69,


### PR DESCRIPTION
I didn't add the note to all previous versions, but the bugs are probably there too.