### PR TITLE
Remove unnecessary "guess"

### DIFF
--- a/features-json/websockets.json
+++ b/features-json/websockets.json
@@ -31,7 +31,7 @@
   ],
   "bugs":[
     {
-      "description":"Firefox 37 and lower cannot host a WebSocket within a WebWorker context, this support may arrive [in Firefox 38](https://developer.mozilla.org/en-US/Firefox/Releases/38)"
+      "description":"Firefox 37 and lower cannot host a WebSocket within a WebWorker context"
     }
   ],
   "categories":[


### PR DESCRIPTION
Support for hosting WebSockets in WebWorkers did indeed arrive in Firefox 38, so unneeded wording can be removed.