### PR TITLE
Move ES6 Template Literals to the JS category.

### DIFF
--- a/features-json/template-literals.json
+++ b/features-json/template-literals.json
@@ -17,7 +17,7 @@
     
   ],
   "categories":[
-    "JS API"
+    "JS"
   ],
   "stats":{
     "ie":{


### PR DESCRIPTION
Seems to make more sense there than in JS APIs.