### PR TITLE
Updated Edge15 "css variables" - bugs

### DIFF
--- a/features-json/css-variables.json
+++ b/features-json/css-variables.json
@@ -22,7 +22,7 @@
       "description":"In Edge 15 is not possible to use css variables in pseudo elements [see bug](https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/11495448/)"
     },
     {
-      "description":"In Edge 15 may css variables cause crash of webpage [see bug](https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/11676012/)"
+      "description":"In Edge 15 may animations with css variables cause crash of webpage [see bug](https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/11676012/)"
     }
   ],
   "categories":[

--- a/features-json/css-variables.json
+++ b/features-json/css-variables.json
@@ -18,7 +18,12 @@
     }
   ],
   "bugs":[
-    
+    {
+      "description":"In Edge 15 is not possible to use css variables in pseudo elements [see bug](https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/11495448/)"
+    },
+    {
+      "description":"In Edge 15 may css variables cause crash of webpage [see bug](https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/11676012/)"
+    }
   ],
   "categories":[
     "CSS3"
@@ -37,7 +42,7 @@
       "12":"n",
       "13":"n",
       "14":"n",
-      "15":"y"
+      "15":"a #2"
     },
     "firefox":{
       "2":"n",
@@ -287,7 +292,8 @@
   },
   "notes":"",
   "notes_by_num":{
-    "1":"Enabled through the \"Experimental Web Platform features\" flag in `chrome://flags`"
+    "1":"Enabled through the \"Experimental Web Platform features\" flag in `chrome://flags`",
+    "2":"Partial support is due to bugs present (see known issues)"
   },
   "usage_perc_y":72.03,
   "usage_perc_a":0,


### PR DESCRIPTION
I've just tried to implement `css variables` but looks like in Edge it's still not ready to be used. There are critical bugs. So I made correction to partial support - it's my first contrib to this repo so please check if it's everything in correct format.

Edge bugs: https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/?page=1&q=css%20variables