### PR TITLE
Document disabled Service Workers/Push API on Firefox 45/52 ESR

### DIFF
--- a/features-json/push-api.json
+++ b/features-json/push-api.json
@@ -81,14 +81,14 @@
       "42":"n",
       "43":"n",
       "44":"y #2",
-      "45":"y #2",
+      "45":"y #2 #4",
       "46":"y #2",
       "47":"y #2",
       "48":"y #2",
       "49":"y #2",
       "50":"y #2",
       "51":"y #2",
-      "52":"y #2",
+      "52":"y #2 #4",
       "53":"y #2",
       "54":"y #2",
       "55":"y #2",
@@ -286,7 +286,8 @@
   "notes_by_num":{
     "1":"Partial support refers to not supporting `PushEvent.data` and `PushMessageData`",
     "2":"Requires full browser to be running to receive messages",
-    "3":"Safari supports a custom implementaion https://developer.apple.com/notifications/safari-push-notifications/. WWDC video by apple : https://developer.apple.com/videos/play/wwdc2013/614/ "
+    "3":"Safari supports a custom implementaion https://developer.apple.com/notifications/safari-push-notifications/. WWDC video by apple : https://developer.apple.com/videos/play/wwdc2013/614/ ",
+    "4":"Disabled on Firefox ESR, but can be re-enabled with the `dom.serviceWorkers.enabled` and `dom.push.enabled` flags"
   },
   "usage_perc_y":71.12,
   "usage_perc_a":1.74,

--- a/features-json/serviceworkers.json
+++ b/features-json/serviceworkers.json
@@ -85,14 +85,14 @@
       "42":"n d #1",
       "43":"n d #1",
       "44":"y",
-      "45":"y",
+      "45":"y #3",
       "46":"y",
       "47":"y",
       "48":"y",
       "49":"y",
       "50":"y",
       "51":"y",
-      "52":"y",
+      "52":"y #3",
       "53":"y",
       "54":"y",
       "55":"y",
@@ -289,7 +289,8 @@
   "notes":"Details on partial support can be found on [is ServiceWorker Ready?](https://jakearchibald.github.io/isserviceworkerready/)",
   "notes_by_num":{
     "1":"Partial support can be enabled in Firefox with the `dom.serviceWorkers.enabled` flag.",
-    "2":"Available behind the \"Enable service workers\" flag"
+    "2":"Available behind the \"Enable service workers\" flag",
+    "3":"Disabled on Firefox ESR, but can be re-enabled with the `dom.serviceWorkers.enabled` flag"
   },
   "usage_perc_y":32.26,
   "usage_perc_a":41,


### PR DESCRIPTION
https://www.fxsitecompat.com/en-CA/docs/2016/service-workers-have-been-disabled-in-firefox-45-esr/
https://www.fxsitecompat.com/en-CA/docs/2017/service-workers-and-push-notifications-are-disabled-on-firefox-52-esr/