### PR TITLE
Correcting Edge status for Payment Request

### DIFF
--- a/features-json/payment-request.json
+++ b/features-json/payment-request.json
@@ -49,8 +49,8 @@
       "12":"n",
       "13":"n",
       "14":"n d #2",
-      "15":"a #3",
-      "16":"a #3"
+      "15":"y",
+      "16":"y"
     },
     "firefox":{
       "2":"n",
@@ -185,10 +185,10 @@
       "8":"n",
       "9":"n",
       "9.1":"n",
-      "10":"n #4",
-      "10.1":"n #4",
-      "11":"n #4",
-      "TP":"n #4"
+      "10":"n #3",
+      "10.1":"n #3",
+      "11":"n #3",
+      "TP":"n #3"
     },
     "opera":{
       "9":"n",
@@ -247,9 +247,9 @@
       "8.1-8.4":"n",
       "9.0-9.2":"n",
       "9.3":"n",
-      "10.0-10.2":"n #4",
-      "10.3":"n #4",
-      "11":"n #4"
+      "10.0-10.2":"n #3",
+      "10.3":"n #3",
+      "11":"n #3"
     },
     "op_mini":{
       "all":"n"
@@ -307,8 +307,7 @@
   "notes_by_num":{
     "1":"Can be enabled via the \"Experimental Web Platform features\" flag",
     "2":"Can be enabled via the \"Experimental Web Payments API\" flag",
-    "3":"Preliminary implementation",
-    "4":"Apple's proprietary implementation"
+    "3":"Apple's proprietary implementation"
   },
   "usage_perc_y":28.22,
   "usage_perc_a":0,


### PR DESCRIPTION
Payment Request is supported and on by default in Edge 15+. The "preliminary implementation" note here appears to come from an Edge changelog note which was specifically referring to an Edge 15 preview build. The stable release has a complete implementation. See https://aka.ms/devguide_edgehtml_15 for details.