### PR TITLE
data-uri: Edge 14 doesn't support SVGs with XML declarations

### DIFF
--- a/features-json/datauri.json
+++ b/features-json/datauri.json
@@ -42,7 +42,7 @@
     "edge":{
       "12":"a #2",
       "13":"a #2",
-      "14":"a #2",
+      "14":"a #2 #3",
       "15":"a #2",
       "16":"a #2"
     },
@@ -301,7 +301,8 @@
   "notes":"",
   "notes_by_num":{
     "1":"Support is limited to images and linked resources like CSS files, not HTML or JS files. Max URI length is 32KB.",
-    "2":"Support is limited to images and linked resources like CSS or JS, not HTML files. Maximum size limit is 4GB."
+    "2":"Support is limited to images and linked resources like CSS or JS, not HTML files. Maximum size limit is 4GB.",
+    "3":"SVGs with XML declarations are not displayed when used in data-urls"
   },
   "usage_perc_y":92.28,
   "usage_perc_a":5.94,


### PR DESCRIPTION
IE Edge 14 doesn't support SVGs with XML declarations in data-uris.
Works in IE 11 and in Edge 15. I am unable to test Edge 12 and 13.

Screenshots:
https://www.browserstack.com/screenshots/1ec164d16c5fffe93b88699b21158d1f618fff02

Codepen:
https://codepen.io/malthejorgensen/full/MooKQe/