### PR TITLE
Add know issue on edge support for blob url

### DIFF
--- a/features-json/bloburls.json
+++ b/features-json/bloburls.json
@@ -31,11 +31,11 @@
       "11":"y"
     },
     "edge":{
-      "12":"y",
-      "13":"y",
-      "14":"y",
-      "15":"y",
-      "16":"y"
+      "12":"y #1",
+      "13":"y #1",
+      "14":"y #1",
+      "15":"y #1",
+      "16":"y #1"
     },
     "firefox":{
       "2":"n",
@@ -291,7 +291,7 @@
   },
   "notes":"",
   "notes_by_num":{
-    
+    "1": "Created blob url can't be used in object or iframe (see https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/5411066/)",
   },
   "usage_perc_y":94.44,
   "usage_perc_a":0,


### PR DESCRIPTION
Reflect missing support for blob url in object.data and iframe.src tag