### PR TITLE
Safari 11+ supports localStorage in private mode

### DIFF
--- a/features-json/namevalue-storage.json
+++ b/features-json/namevalue-storage.json
@@ -33,7 +33,7 @@
       "description":"In iOS 5 & 6 localStorage data is stored in a location that may occasionally be cleared out by the OS."
     },
     {
-      "description":"In private browsing mode, Safari, iOS Safari and the Android browser (not include Chrome for Android) do not support setting sessionStorage or localStorage."
+      "description":"In private browsing mode, Safari and iOS Safari up to including version 10.x as well as the Android browser (not include Chrome for Android) do not support setting sessionStorage or localStorage."
     },
     {
       "description":"In IE attempting to access localStorage on HTML files served from the file system results in the localStorage object being `undefined`"


### PR DESCRIPTION
Per <https://webkit.org/blog/7532/release-notes-for-safari-technology-preview-29/>

> Fixed QuotaExceededError when saving to localStorage in private browsing mode or WebDriver sessions

or more precise <https://bugs.webkit.org/show_bug.cgi?id=157010#c18>

> Per discussion with Brady, the fix will be to make localStorage in-memory for ephemeral sessions. This means that in private browsing and automation (i.e., WebDriver), we'll allow read/write and the contents do not persist.

EDIT: I also compared the behavior using <http://dev-test.nemikor.com/web-storage/support-test/> with iOS 10.3.2 vs iOS 11 beta 2, or rather the corresponding Safari.

---

Additionally 

1. I highly doubt that 
  
    >  do not support setting sessionStorage

    was ever correct for Safari, or at least isn't anymore since multiple years.

2. > the Android browser (not include Chrome for Android) do not support setting sessionStorage or localStorage."

    I would be very surprised if this is still the case.

3. > Storing large amounts of data in Safari (on OSX & iOS) can result in freezing the browser [see bug](https://bugs.webkit.org/show_bug.cgi?id=149585)

    The bug or rather the one it has been marked as duplicate of has been fixed since december.

But as I can't really test those points with the appropriate depth, I resort to mentioning that this should be checked, sorry 0:-)