### PR TITLE
Update FF Android tracking bug

### DIFF
--- a/features-json/internationalization.json
+++ b/features-json/internationalization.json
@@ -21,7 +21,7 @@
       "title":"WebKit tracking bug"
     },
     {
-      "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=1215247",
+      "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=1344625",
       "title":"Firefox for Android tracking bug"
     }
   ],


### PR DESCRIPTION
The current tracking bug is resolved fixed, but the Intl API is currently disabled for the release build. The bug to enable it on release builds it 1344625