### PR TITLE
Brotli in STP too & add note about from macOS High Sierra

### DIFF
--- a/features-json/brotli.json
+++ b/features-json/brotli.json
@@ -180,8 +180,8 @@
       "9.1":"n",
       "10":"n",
       "10.1":"n",
-      "11":"y",
-      "TP":"n"
+      "11":"y #3",
+      "TP":"y #3"
     },
     "opera":{
       "9":"n",
@@ -300,7 +300,8 @@
   "notes":"",
   "notes_by_num":{
     "1":"Supported in Chrome and Opera behind the 'Brotli Content-Encoding' flag",
-    "2":"Enabled since 27 May 2016"
+    "2":"Enabled since 27 May 2016",
+    "3":"Support starting with macOS 10.13 High Sierra"
   },
   "usage_perc_y":58.85,
   "usage_perc_a":0,


### PR DESCRIPTION
Per <https://developer.apple.com/library/content/releasenotes/Foundation/RN-Foundation/index.html>

> For binary compatibility reasons, URLSession brotli support is enabled only for apps linked against the macOS 10.13 / iOS 11 SDKs and later.

and Safari Technology Preview was missing from the initial PR.

---

 I didn't add the note to iOS Safari 11, like at <https://caniuse.com/#feat=heif>, because I don't think that makes sense, as iOS Safari 11 is only available on iOS 11 unlike  macOS Safari which is available for multiple versions of macOS.
Should I change the note from HEIF?

Also I don't think marking partial support for macOS Safari makes sense, like at <https://caniuse.com/#feat=woff2>. I could change that too, keeping the note of course, if you like?

But what do you think in general? How should support depending on the OS version be marked? Or should I open an issue to discuss this further?