### PR TITLE
:memo: `justify-content: space-evenly` is only supported by Firefox

### DIFF
--- a/features-json/flexbox.json
+++ b/features-json/flexbox.json
@@ -69,6 +69,9 @@
     },
     {
       "description":"Safari 10 and below uses min/max width/height declarations for actually rendering the size of flex items, but it ignores those values when calculating how many items should be on a single line of a multi-line flex container. Instead, it simply uses the item's flex-basis value, or its width if the flex basis is set to auto. [see bug](https://bugs.webkit.org/show_bug.cgi?id=136041). Fixed in all versions > 10."
+    },
+    {
+      "The space-evenly value of the justify-content property, as described in the [CSS Box Alignement Module Level 3](https://www.w3.org/TR/css-align-3/#distribution-values) is only supported by Firefox."
     }
   ],
   "categories":[

--- a/features-json/flexbox.json
+++ b/features-json/flexbox.json
@@ -71,7 +71,7 @@
       "description":"Safari 10 and below uses min/max width/height declarations for actually rendering the size of flex items, but it ignores those values when calculating how many items should be on a single line of a multi-line flex container. Instead, it simply uses the item's flex-basis value, or its width if the flex basis is set to auto. [see bug](https://bugs.webkit.org/show_bug.cgi?id=136041). Fixed in all versions > 10."
     },
     {
-      "The space-evenly value of the justify-content property, as described in the [CSS Box Alignement Module Level 3](https://www.w3.org/TR/css-align-3/#distribution-values) is only supported by Firefox."
+      "description":"The space-evenly value of the justify-content property, as described in the [CSS Box Alignment Module Level 3](https://www.w3.org/TR/css-align-3/#distribution-values) is only supported by Firefox."
     }
   ],
   "categories":[


### PR DESCRIPTION
Adds the info about Firefox being the only browser that supports `justify-content: space-evenly` into the list of bugs for the Flexible Box Layout Module.