### PR TITLE
CSS Grid is now enabled by default in Edge

### DIFF
--- a/features-json/css-grid.json
+++ b/features-json/css-grid.json
@@ -50,7 +50,7 @@
       "13":"a x #2",
       "14":"a x #2",
       "15":"a x #2",
-      "16":"y #5"
+      "16":"y"
     },
     "firefox":{
       "2":"n",
@@ -310,8 +310,7 @@
     "1":"Enabled in Chrome through the \"experimental Web Platform features\" flag in chrome://flags",
     "2":"Partial support in IE refers to supporting an [older version](http://www.w3.org/TR/2011/WD-css3-grid-layout-20110407/) of the specification.",
     "3":"Enabled in Firefox through the `layout.css.grid.enabled ` flag",
-    "4":"There are some bugs with overflow ([1356820](https://bugzilla.mozilla.org/show_bug.cgi?id=1356820), [1348857](https://bugzilla.mozilla.org/show_bug.cgi?id=1348857), [1350925](https://bugzilla.mozilla.org/show_bug.cgi?id=1350925))",
-    "5":"Enabled in Edge through the \"Enable Unprefixed CSS Grid Layout\" flag in about:flags"
+    "4":"There are some bugs with overflow ([1356820](https://bugzilla.mozilla.org/show_bug.cgi?id=1356820), [1348857](https://bugzilla.mozilla.org/show_bug.cgi?id=1348857), [1350925](https://bugzilla.mozilla.org/show_bug.cgi?id=1350925))"
   },
   "usage_perc_y":65.64,
   "usage_perc_a":5.11,


### PR DESCRIPTION
Per <https://developer.microsoft.com/en-us/microsoft-edge/platform/changelog/desktop/16237/>

> Unprefixed CSS Grid is now enabled by default

🎉