### PR TITLE
Tweak some spec IDs for HTML

### DIFF
--- a/features-json/hardwareconcurrency.json
+++ b/features-json/hardwareconcurrency.json
@@ -1,7 +1,7 @@
 {
   "title":"navigator.hardwareConcurrency",
   "description":"Returns the number of logical cores of the user's CPU. The value may be reduced to prevent device fingerprinting or because it exceeds the allowed number of simultaneous web workers.",
-  "spec":"https://html.spec.whatwg.org/multipage/workers.html#navigatorconcurrenthardware",
+  "spec":"https://html.spec.whatwg.org/multipage/workers.html#navigator.hardwareconcurrency",
   "status":"ls",
   "links":[
     {

--- a/features-json/xhtml.json
+++ b/features-json/xhtml.json
@@ -1,7 +1,7 @@
 {
   "title":"XHTML served as application/xhtml+xml",
   "description":"A strict form of HTML, and allows embedding of other XML languages",
-  "spec":"https://html.spec.whatwg.org/multipage/xhtml.html#parsing-xhtml-documents",
+  "spec":"https://html.spec.whatwg.org/multipage/xhtml.html#the-xhtml-syntax",
   "status":"ls",
   "links":[
     {


### PR DESCRIPTION
These IDs also appear in the developer's edition of HTML (https://html.spec.whatwg.org/dev), and so including these allows caniuse integration with the dev edition (whatwg/html#2794).