### PR TITLE
Expand and add JavaScript modules entries

### DIFF
--- a/features-json/es6-module-dynamic-import.json
+++ b/features-json/es6-module-dynamic-import.json
@@ -1,36 +1,16 @@
 {
-  "title":"JavaScript modules: <script type=\"module\">",
-  "description":"Loading JavaScript modules using `<script type=\"module\">`",
-  "spec":"https://html.spec.whatwg.org/multipage/scripting.html#attr-script-type",
-  "status":"ls",
+  "title":"JavaScript modules: dynamic import()",
+  "description":"Loading JavaScript modules dynamically using the import() syntax",
+  "spec":"https://github.com/tc39/proposal-dynamic-import/blob/master/HTML%20Integration.md",
+  "status":"unoff",
   "links":[
     {
-      "url":"https://tc39.github.io/ecma262/#sec-modules",
-      "title":"Counterpart ECMAScript specification for import/export syntax"
+      "url":"https://tc39.github.io/proposal-dynamic-import/",
+      "title":"Counterpart ECMAScript specification for import() syntax"
     },
     {
-      "url":"https://blogs.windows.com/msedgedev/2016/05/17/es6-modules-and-beyond/",
-      "title":"MS Edge blog post"
-    },
-    {
-      "url":"https://hacks.mozilla.org/2015/08/es6-in-depth-modules/",
-      "title":"Mozilla hacks article"
-    },
-    {
-      "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=568953",
-      "title":"Firefox support bug"
-    },
-    {
-      "url":"https://strongloop.com/strongblog/an-introduction-to-javascript-es6-modules/",
-      "title":"Blog post: Intro to ES6 modules"
-    },
-    {
-      "url":"https://blog.hospodarets.com/native-ecmascript-modules-the-first-overview",
-      "title":"Blog post: Native ECMAScript modules - the first overview"
-    },
-    {
-      "url":"https://jakearchibald.com/2017/es-modules-in-browsers/",
-      "title":"Blog post: ECMAScript modules in browsers"
+      "url":"https://blog.hospodarets.com/native-ecmascript-modules-dynamic-import",
+      "title":"Blog post: Native ECMAScript modules - dynamic import()"
     }
   ],
   "bugs":[
@@ -53,8 +33,8 @@
       "12":"n",
       "13":"n",
       "14":"n",
-      "15":"n d #1",
-      "16":"n d #1"
+      "15":"n",
+      "16":"n"
     },
     "firefox":{
       "2":"n",
@@ -111,10 +91,10 @@
       "51":"n",
       "52":"n",
       "53":"n",
-      "54":"n d #2",
-      "55":"n d #2",
-      "56":"n d #2",
-      "57":"n d #2"
+      "54":"n",
+      "55":"n",
+      "56":"n",
+      "57":"n"
     },
     "chrome":{
       "4":"n",
@@ -173,9 +153,9 @@
       "57":"n",
       "58":"n",
       "59":"n",
-      "60":"n d #1",
-      "61":"y",
-      "62":"y"
+      "60":"n",
+      "61":"n",
+      "62":"n"
     },
     "safari":{
       "3.1":"n",
@@ -191,8 +171,8 @@
       "9":"n",
       "9.1":"n",
       "10":"n",
-      "10.1":"y",
-      "11":"y",
+      "10.1":"n #1",
+      "11":"u",
       "TP":"y"
     },
     "opera":{
@@ -239,8 +219,8 @@
       "44":"n",
       "45":"n",
       "46":"n",
-      "47":"n d #1",
-      "48":"n d #1"
+      "47":"n",
+      "48":"n"
     },
     "ios_saf":{
       "3.2":"n",
@@ -254,8 +234,8 @@
       "9.0-9.2":"n",
       "9.3":"n",
       "10.0-10.2":"n",
-      "10.3":"y",
-      "11":"y"
+      "10.3":"n #1",
+      "11":"u"
     },
     "op_mini":{
       "all":"n"
@@ -289,7 +269,7 @@
       "59":"n"
     },
     "and_ff":{
-      "54":"n d #2"
+      "54":"n"
     },
     "ie_mob":{
       "10":"n",
@@ -311,18 +291,16 @@
   },
   "notes":"",
   "notes_by_num":{
-    "1":"Support can be enabled via `about:flags`",
-    "2":"Support can be enabled via `about:config`",
-    "3":"Support can be enabled via the `experimental-web-platform-features` flag"
+    "1": "A [polyfill is available](https://gist.github.com/samthor/64b114e4a4f539915a95b91ffd340acc) for Safari 10.1/iOS Safari 10.3"
   },
   "usage_perc_y":8.91,
   "usage_perc_a":0,
   "ucprefix":false,
-  "parent":"",
+  "parent":"es6-module",
   "keywords":"es6,javascript,module,import,export",
-  "ie_id":"moduleses6",
-  "chrome_id":"5365692190687232",
+  "ie_id":"",
+  "chrome_id":"5684934484164608",
   "firefox_id":"",
-  "webkit_id":"feature-modules",
+  "webkit_id":"",
   "shown":true
 }

--- a/features-json/es6-module-nomodule.json
+++ b/features-json/es6-module-nomodule.json
@@ -1,36 +1,20 @@
 {
-  "title":"JavaScript modules: <script type=\"module\">",
-  "description":"Loading JavaScript modules using `<script type=\"module\">`",
-  "spec":"https://html.spec.whatwg.org/multipage/scripting.html#attr-script-type",
+  "title":"JavaScript modules: <script nomodule>",
+  "description":"Loading JavaScript scripts only if modules are not supported",
+  "spec":"https://html.spec.whatwg.org/multipage/scripting.html#attr-script-nomodule",
   "status":"ls",
   "links":[
     {
-      "url":"https://tc39.github.io/ecma262/#sec-modules",
-      "title":"Counterpart ECMAScript specification for import/export syntax"
-    },
-    {
-      "url":"https://blogs.windows.com/msedgedev/2016/05/17/es6-modules-and-beyond/",
-      "title":"MS Edge blog post"
-    },
-    {
-      "url":"https://hacks.mozilla.org/2015/08/es6-in-depth-modules/",
-      "title":"Mozilla hacks article"
-    },
-    {
-      "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=568953",
-      "title":"Firefox support bug"
-    },
-    {
-      "url":"https://strongloop.com/strongblog/an-introduction-to-javascript-es6-modules/",
-      "title":"Blog post: Intro to ES6 modules"
-    },
-    {
-      "url":"https://blog.hospodarets.com/native-ecmascript-modules-the-first-overview",
-      "title":"Blog post: Native ECMAScript modules - the first overview"
+      "url":"https://html.spec.whatwg.org/multipage/scripting.html#script-nomodule-example",
+      "title":"Example from the specification"
     },
     {
       "url":"https://jakearchibald.com/2017/es-modules-in-browsers/",
       "title":"Blog post: ECMAScript modules in browsers"
+    },
+    {
+      "url":"https://blog.hospodarets.com/native-ecmascript-modules-nomodule",
+      "title":"Blog post: Native ECMAScript modules - nomodule attribute for the migration"
     }
   ],
   "bugs":[
@@ -53,8 +37,8 @@
       "12":"n",
       "13":"n",
       "14":"n",
-      "15":"n d #1",
-      "16":"n d #1"
+      "15":"n",
+      "16":"n #3"
     },
     "firefox":{
       "2":"n",
@@ -111,7 +95,7 @@
       "51":"n",
       "52":"n",
       "53":"n",
-      "54":"n d #2",
+      "54":"n",
       "55":"n d #2",
       "56":"n d #2",
       "57":"n d #2"
@@ -191,7 +175,7 @@
       "9":"n",
       "9.1":"n",
       "10":"n",
-      "10.1":"y",
+      "10.1":"n",
       "11":"y",
       "TP":"y"
     },
@@ -239,7 +223,7 @@
       "44":"n",
       "45":"n",
       "46":"n",
-      "47":"n d #1",
+      "47":"n",
       "48":"n d #1"
     },
     "ios_saf":{
@@ -254,7 +238,7 @@
       "9.0-9.2":"n",
       "9.3":"n",
       "10.0-10.2":"n",
-      "10.3":"y",
+      "10.3":"n",
       "11":"y"
     },
     "op_mini":{
@@ -289,7 +273,7 @@
       "59":"n"
     },
     "and_ff":{
-      "54":"n d #2"
+      "54":"n"
     },
     "ie_mob":{
       "10":"n",
@@ -313,16 +297,16 @@
   "notes_by_num":{
     "1":"Support can be enabled via `about:flags`",
     "2":"Support can be enabled via `about:config`",
-    "3":"Support can be enabled via the `experimental-web-platform-features` flag"
+    "3":"Marked as [\"fixed, not yet flighted\"](https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/10525830/) on the Edge issue tracker"
   },
   "usage_perc_y":8.91,
   "usage_perc_a":0,
   "ucprefix":false,
-  "parent":"",
+  "parent":"es6-module",
   "keywords":"es6,javascript,module,import,export",
   "ie_id":"moduleses6",
   "chrome_id":"5365692190687232",
   "firefox_id":"",
-  "webkit_id":"feature-modules",
+  "webkit_id":"",
   "shown":true
 }


### PR DESCRIPTION
* Turns the existing "ES6 module" entry into "JavaScript modules: <script type="module">", and cleans up its data a bit
* Adds new module-related entries for dynamic import() and the nomodule attribute

Test for nomodule: https://cdn.rawgit.com/jakearchibald/6110fb6df717ebca44c2e40814cc12af/raw/7fc79ed89199c2512a4579c9a3ba19f72c219bd8/

Test for dynamic import(): https://plnkr.co/edit/pgsxdd6hE7uzQY9dHCwz?p=preview

---

Partially solves https://github.com/Fyrd/caniuse/issues/2300, although I refrained from adding module workers as no browser seems to have started work on them yet.