### PR TITLE
Replace outdated link to htmluse.com

### DIFF
--- a/features-json/css-paged-media.json
+++ b/features-json/css-paged-media.json
@@ -5,7 +5,7 @@
   "status":"wd",
   "links":[
     {
-      "url":"http://www.htmluse.com/css-paged-media-page-rule/",
+      "url":"https://www.tutorialspoint.com/css/css_paged_media.htm",
       "title":"CSS Paged media article"
     },
     {


### PR DESCRIPTION
htmluse.com is actually a parked domain, I guess it no longer works. I checked https://web.archive.org/web/20150324033405/http://www.htmluse.com/css-paged-media-page-rule/ and https://www.tutorialspoint.com/css/css_paged_media.htm they are identical. As Tutorials point is a well known resource, I'd suggest to use it as replacement.