### PR TITLE
Use HTTPS links for ecma-international.org

### DIFF
--- a/features-json/arrow-functions.json
+++ b/features-json/arrow-functions.json
@@ -1,7 +1,7 @@
 {
   "title":"Arrow functions",
   "description":"Function shorthand using `=>` syntax and lexical `this` binding.",
-  "spec":"http://www.ecma-international.org/ecma-262/6.0/#sec-arrow-function-definitions",
+  "spec":"https://www.ecma-international.org/ecma-262/6.0/#sec-arrow-function-definitions",
   "status":"other",
   "links":[
     {

--- a/features-json/const.json
+++ b/features-json/const.json
@@ -1,7 +1,7 @@
 {
   "title":"const",
   "description":"Declares a constant with block level scope",
-  "spec":"http://www.ecma-international.org/ecma-262/6.0/#sec-let-and-const-declarations",
+  "spec":"https://www.ecma-international.org/ecma-262/6.0/#sec-let-and-const-declarations",
   "status":"other",
   "links":[
     {

--- a/features-json/es5.json
+++ b/features-json/es5.json
@@ -1,7 +1,7 @@
 {
   "title":"ECMAScript 5",
   "description":"Full support for the ECMAScript 5 specification. Features include `Function.prototype.bind`, Array methods like `indexOf`, `forEach`, `map` & `filter`, Object methods like `defineProperty`, `create` & `keys`, the `trim` method on Strings and many more.",
-  "spec":"http://www.ecma-international.org/ecma-262/5.1/",
+  "spec":"https://www.ecma-international.org/ecma-262/5.1/",
   "status":"other",
   "links":[
     {

--- a/features-json/es6-class.json
+++ b/features-json/es6-class.json
@@ -1,7 +1,7 @@
 {
   "title":"ES6 classes",
   "description":"ES6 classes are syntactical sugar to provide a much simpler and clearer syntax to create objects and deal with inheritance.",
-  "spec":"http://www.ecma-international.org/ecma-262/6.0/#sec-class-definitions",
+  "spec":"https://www.ecma-international.org/ecma-262/6.0/#sec-class-definitions",
   "status":"other",
   "links":[
     {

--- a/features-json/es6-number.json
+++ b/features-json/es6-number.json
@@ -1,7 +1,7 @@
 {
   "title":"ES6 Number",
   "description":"Extensions to the `Number` built-in object in ES6, including constant properties `EPSILON`, `MIN_SAFE_INTEGER`, and `MAX_SAFE_INTEGER`, and methods ` isFinite`, `isInteger`, `isSafeInteger`, and `isNaN`.",
-  "spec":"http://www.ecma-international.org/ecma-262/6.0/#sec-number-objects",
+  "spec":"https://www.ecma-international.org/ecma-262/6.0/#sec-number-objects",
   "status":"other",
   "links":[
     {

--- a/features-json/internationalization.json
+++ b/features-json/internationalization.json
@@ -1,7 +1,7 @@
 {
   "title":"Internationalization API",
   "description":"Locale-sensitive collation (string comparison), number formatting, and date and time formatting.",
-  "spec":"http://www.ecma-international.org/ecma-402/1.0/",
+  "spec":"https://www.ecma-international.org/ecma-402/1.0/",
   "status":"other",
   "links":[
     {

--- a/features-json/json.json
+++ b/features-json/json.json
@@ -1,7 +1,7 @@
 {
   "title":"JSON parsing",
   "description":"Method of converting JavaScript objects to JSON strings and JSON back to objects using JSON.stringify() and JSON.parse()",
-  "spec":"http://www.ecma-international.org/ecma-262/5.1/#sec-15.12",
+  "spec":"https://www.ecma-international.org/ecma-262/5.1/#sec-15.12",
   "status":"other",
   "links":[
     {

--- a/features-json/let.json
+++ b/features-json/let.json
@@ -1,7 +1,7 @@
 {
   "title":"let",
   "description":"Declares a variable with block level scope",
-  "spec":"http://www.ecma-international.org/ecma-262/6.0/#sec-let-and-const-declarations",
+  "spec":"https://www.ecma-international.org/ecma-262/6.0/#sec-let-and-const-declarations",
   "status":"other",
   "links":[
     {

--- a/features-json/localecompare.json
+++ b/features-json/localecompare.json
@@ -1,7 +1,7 @@
 {
   "title":"localeCompare()",
   "description":"The `localeCompare()` method returns a number indicating whether a reference string comes before or after or is the same as the given string in sort order.",
-  "spec":"http://www.ecma-international.org/ecma-402/2.0/#sec-13.1.1",
+  "spec":"https://www.ecma-international.org/ecma-402/2.0/#sec-13.1.1",
   "status":"other",
   "links":[
     {

--- a/features-json/promises.json
+++ b/features-json/promises.json
@@ -1,7 +1,7 @@
 {
   "title":"Promises",
   "description":"A promise represents the eventual result of an asynchronous operation.",
-  "spec":"http://www.ecma-international.org/ecma-262/6.0/#sec-promise-objects",
+  "spec":"https://www.ecma-international.org/ecma-262/6.0/#sec-promise-objects",
   "status":"other",
   "links":[
     {

--- a/features-json/proxy.json
+++ b/features-json/proxy.json
@@ -1,7 +1,7 @@
 {
   "title":"Proxy object",
   "description":"The Proxy object allows custom behaviour to be defined for fundamental operations. Useful for logging, profiling, object virtualisation, etc.",
-  "spec":"http://www.ecma-international.org/ecma-262/6.0/#sec-proxy-object-internal-methods-and-internal-slots",
+  "spec":"https://www.ecma-international.org/ecma-262/6.0/#sec-proxy-object-internal-methods-and-internal-slots",
   "status":"other",
   "links":[
     {

--- a/features-json/rest-parameters.json
+++ b/features-json/rest-parameters.json
@@ -1,7 +1,7 @@
 {
   "title":"Rest parameters",
   "description":"Allows representation of an indefinite number of arguments as an array.",
-  "spec":"http://www.ecma-international.org/ecma-262/6.0/#sec-function-definitions",
+  "spec":"https://www.ecma-international.org/ecma-262/6.0/#sec-function-definitions",
   "status":"other",
   "links":[
     {

--- a/features-json/template-literals.json
+++ b/features-json/template-literals.json
@@ -1,7 +1,7 @@
 {
   "title":"ES6 Template Literals (Template Strings)",
   "description":"Template literals are string literals allowing embedded expressions. You can use multi-line strings and string interpolation features with them. Formerly known as template strings.",
-  "spec":"http://www.ecma-international.org/ecma-262/6.0/#sec-template-literals",
+  "spec":"https://www.ecma-international.org/ecma-262/6.0/#sec-template-literals",
   "status":"other",
   "links":[
     {

--- a/features-json/typedarrays.json
+++ b/features-json/typedarrays.json
@@ -1,7 +1,7 @@
 {
   "title":"Typed Arrays",
   "description":"JavaScript typed arrays provide a mechanism for accessing raw binary data much more efficiently. Includes: `Int8Array`, `Uint8Array`, `Uint8ClampedArray`, `Int16Array`, `Uint16Array`, `Int32Array`, `Uint32Array`, `Float32Array` & `Float64Array`\r\n",
-  "spec":"http://www.ecma-international.org/ecma-262/6.0/#sec-typedarray-objects",
+  "spec":"https://www.ecma-international.org/ecma-262/6.0/#sec-typedarray-objects",
   "status":"other",
   "links":[
     {

--- a/features-json/use-strict.json
+++ b/features-json/use-strict.json
@@ -1,7 +1,7 @@
 {
   "title":"ECMAScript 5 Strict Mode",
   "description":"Method of placing code in a \"strict\" operating context.",
-  "spec":"http://www.ecma-international.org/ecma-262/5.1/#sec-14.1",
+  "spec":"https://www.ecma-international.org/ecma-262/5.1/#sec-14.1",
   "status":"other",
   "links":[
     {


### PR DESCRIPTION
ecma-international.org now supports [HTTPS](https://www.ecma-international.org/ecma-262/6.0/), so let's use it.