### PR TITLE
Replace abandoned polyfill with newer one.

### DIFF
--- a/features-json/css-sticky.json
+++ b/features-json/css-sticky.json
@@ -17,7 +17,7 @@
       "title":"WebPlatform Docs"
     },
     {
-      "url":"https://github.com/filamentgroup/fixed-sticky",
+      "url":"https://github.com/dollarshaveclub/stickybits",
       "title":"Polyfill"
     },
     {


### PR DESCRIPTION
The polyfill https://github.com/filamentgroup/fixed-sticky has been abandoned/deprecated. The developers recommend the newly released https://github.com/dollarshaveclub/stickybits instead.