### PR TITLE
css-variables: Added Edge 15 bug

### DIFF
--- a/features-json/css-variables.json
+++ b/features-json/css-variables.json
@@ -23,6 +23,9 @@
     },
     {
       "description":"In Edge 15 animations with css variables may cause the webpage to crash [see bug](https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/11676012/)"
+    },
+    {
+      "description":"In Edge 15, nested calculations with css variables are not computed and are ignored [see bug](https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/12143022/)"
     }
   ],
   "categories":[


### PR DESCRIPTION
Related to a current and verified bug with Edge 15 that IMHO makes css-variables unusable in large projects. 

Microsoft bug link https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/12143022/