### PR TITLE
Correct grammar in flex property description

### DIFF
--- a/features-json/flexbox.json
+++ b/features-json/flexbox.json
@@ -1,6 +1,6 @@
 {
   "title":"CSS Flexible Box Layout Module",
-  "description":"Method of positioning elements in horizontal or vertical stacks. Support includes the support for the all properties prefixed with `flex` as well as `display: flex`, `display: inline-flex`, `align-content`, `align-items`, `align-self`, `justify-content` and `order`.",
+  "description":"Method of positioning elements in horizontal or vertical stacks. Support includes all properties prefixed with `flex`, as well as `display: flex`, `display: inline-flex`, `align-content`, `align-items`, `align-self`, `justify-content` and `order`.",
   "spec":"http://www.w3.org/TR/css3-flexbox/",
   "status":"cr",
   "links":[


### PR DESCRIPTION
The sentence found in the description for the flex property sounds awkward,
and is most-likely incorrect and confusing. Reword it to make it clearer.