### PR TITLE
word-break: break-word exists in W3C text module

### DIFF
--- a/features-json/word-break.json
+++ b/features-json/word-break.json
@@ -292,7 +292,7 @@
       "7.12":"y"
     }
   },
-  "notes":"Partial support refers to supporting the `break-all` value, but not the `keep-all` value.\r\n\r\nChrome, Safari and other WebKit/Blink browsers also support the unofficial `break-word` value which is treated like `word-wrap: break-word`.",
+  "notes":"Partial support refers to supporting the `break-all` value, but not the `keep-all` value.\r\n\r\nChrome, Safari and other WebKit/Blink browsers also support the `break-word` value which is treated like `word-wrap: break-word`.",
   "notes_by_num":{
     
   },


### PR DESCRIPTION
There is `word-break: break-word` so this is no longer unofficial. -> https://www.w3.org/TR/css-text-3/#word-break-property