### PR TITLE
css-fixed: Safari 9.1 doesn't draw element with `position: fixed` that has animated parent

### DIFF
--- a/features-json/css-fixed.json
+++ b/features-json/css-fixed.json
@@ -181,7 +181,7 @@
       "7.1":"y",
       "8":"y",
       "9":"y",
-      "9.1":"y",
+      "9.1":"y #4",
       "10":"y",
       "10.1":"y",
       "11":"y",
@@ -306,7 +306,8 @@
   "notes_by_num":{
     "1":"Partial support in older iOS Safari refers to [buggy behavior](http://remysharp.com/2012/05/24/issues-with-position-fixed-scrolling-on-ios/).",
     "2":"Only works in Android 2.1 thru 2.3 by using the following meta tag: <meta name=\"viewport\" content=\"width=device-width, user-scalable=no\">.",
-    "3":"Android 4.0-4.3 [ignore transforms and margin:auto on position:fixed elements](https://codepen.io/mattiacci/pen/mPRKZY)."
+    "3":"Android 4.0-4.3 [ignore transforms and margin:auto on position:fixed elements](https://codepen.io/mattiacci/pen/mPRKZY).",
+    "4":"in Safari 9.1, having a `position:fixed`-element inside an animated element, [may cause the `position:fixed`-element to not appear](https://jsbin.com/fuxipax)."
   },
   "usage_perc_y":94.4,
   "usage_perc_a":0.05,


### PR DESCRIPTION
Safari 9.1 doesn't draw elements with `position: fixed` that have an
animated parent. The element will show up on redraws (e.g. resizing the
window).

Works in Safari 5.1, 6.2, 7.1, 8, and 10.1. I have not been able to test
Safari 9.0.

Screenshots:
https://www.browserstack.com/screenshots/05a0ae8ea84eab952eb13de45e1de4108fe8822e

jsbin:
https://output.jsbin.com/fuxipax