### PR TITLE
css-mixblendmode: Add known issues for Chrome and Opera

### DIFF
--- a/features-json/css-mixblendmode.json
+++ b/features-json/css-mixblendmode.json
@@ -18,10 +18,7 @@
       "description":"Firefox on OSX [has a bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1135271) where content may turn entirely black"
     },
     {
-      "description":"Chrome sometimes renders mix-blend-mode incorrectly. See [bug report](https://bugs.chromium.org/p/chromium/issues/detail?id=762966). [There is a workaround though.](https://codepen.io/lumio/pen/vJqExB)"
-    },
-    {
-      "description":"Opera won't render mix-blend-mode correctly or at all sometimes. [There is a workaround though.](https://codepen.io/lumio/pen/vJqExB)"
+      "description":"[Chrome](https://bugs.chromium.org/p/chromium/issues/detail?id=762966)/Opera sometimes renders mix-blend-mode incorrectly. [There is a workaround though.](https://codepen.io/lumio/pen/vJqExB)"
     }
   ],
   "categories":[

--- a/features-json/css-mixblendmode.json
+++ b/features-json/css-mixblendmode.json
@@ -16,6 +16,12 @@
   "bugs":[
     {
       "description":"Firefox on OSX [has a bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1135271) where content may turn entirely black"
+    },
+    {
+      "description":"Chrome sometimes renders mix-blend-mode incorrectly. See [bug report](https://bugs.chromium.org/p/chromium/issues/detail?id=762966). [There is a workaround though.](https://codepen.io/lumio/pen/vJqExB)"
+    },
+    {
+      "description":"Opera won't render mix-blend-mode correctly or at all sometimes. [There is a workaround though.](https://codepen.io/lumio/pen/vJqExB)"
     }
   ],
   "categories":[


### PR DESCRIPTION
Chrome (including current Chromium) and Opera render mix-blend-mode differently in SVG when non-SVG elements are present.

- [Incorrect rendering](https://codepen.io/lumio/pen/YxoPWo)
- [Correct rendering](https://codepen.io/lumio/pen/vJqExB)