### PR TITLE
added info about polyfill of readAsBinaryString

### DIFF
--- a/features-json/filereader.json
+++ b/features-json/filereader.json
@@ -300,7 +300,7 @@
   },
   "notes":"",
   "notes_by_num":{
-    "1":"Does not support `readAsBinaryString`"
+    "1":"Does not support `readAsBinaryString`, but `readAsBinaryString` can be polyfilled https://stackoverflow.com/q/31391207"
   },
   "usage_perc_y":90.43,
   "usage_perc_a":3.29,


### PR DESCRIPTION
 added info about polyfill for `readAsBinaryString` in IE10, IE11