### PR TITLE
Fixes typo; adds various Safari experimental features that can be enabled

### DIFF
--- a/features-json/input-file-directory.json
+++ b/features-json/input-file-directory.json
@@ -173,7 +173,7 @@
       "10":"n",
       "10.1":"n",
       "11":"n",
-      "TP":"n"
+      "TP":"n d #1"
     },
     "opera":{
       "9":"n",
@@ -292,7 +292,7 @@
   },
   "notes":"Lack of support in mobile browsers may be due to the OS file picker not having support for selecting a directory.",
   "notes_by_num":{
-    
+    "1":"Can be enabled via the \"Experimental Features\" developer menu"
   },
   "usage_perc_y":32.73,
   "usage_perc_a":0,

--- a/features-json/link-rel-preload.json
+++ b/features-json/link-rel-preload.json
@@ -243,7 +243,7 @@
       "9.3":"n",
       "10.0-10.2":"n",
       "10.3":"n",
-      "11":"y"
+      "11":"n d #2"
     },
     "op_mini":{
       "all":"n"
@@ -299,7 +299,8 @@
   },
   "notes":"",
   "notes_by_num":{
-    "1":"Only cachable resources can be preloaded. This includes the following `as` values: script, style, image, video, audio, track, fetch, and font (note font/collection is not supported)."
+    "1":"Only cachable resources can be preloaded. This includes the following `as` values: script, style, image, video, audio, track, fetch, and font (note font/collection is not supported).",
+    "2":"Can be enabled via the \"Experimental Features\" developer menu"
   },
   "usage_perc_y":56.75,
   "usage_perc_a":0.06,

--- a/features-json/push-api.json
+++ b/features-json/push-api.json
@@ -297,7 +297,7 @@
   "notes_by_num":{
     "1":"Partial support refers to not supporting `PushEvent.data` and `PushMessageData`",
     "2":"Requires full browser to be running to receive messages",
-    "3":"Safari supports a custom implementaion https://developer.apple.com/notifications/safari-push-notifications/. WWDC video by apple : https://developer.apple.com/videos/play/wwdc2013/614/ ",
+    "3":"Safari supports a custom implementation https://developer.apple.com/notifications/safari-push-notifications/. WWDC video by apple : https://developer.apple.com/videos/play/wwdc2013/614/ ",
     "4":"Disabled on Firefox ESR, but can be re-enabled with the `dom.serviceWorkers.enabled` and `dom.push.enabled` flags"
   },
   "usage_perc_y":71.58,

--- a/features-json/serviceworkers.json
+++ b/features-json/serviceworkers.json
@@ -180,7 +180,7 @@
       "10":"n",
       "10.1":"n",
       "11":"n",
-      "TP":"n"
+      "TP":"n d #4"
     },
     "opera":{
       "9":"n",
@@ -301,7 +301,8 @@
   "notes_by_num":{
     "1":"Partial support can be enabled in Firefox with the `dom.serviceWorkers.enabled` flag.",
     "2":"Available behind the \"Enable service workers\" flag",
-    "3":"Disabled on Firefox ESR, but can be re-enabled with the `dom.serviceWorkers.enabled` flag"
+    "3":"Disabled on Firefox ESR, but can be re-enabled with the `dom.serviceWorkers.enabled` flag",
+    "4":"Can be enabled via the \"Experimental Features\" developer menu"
   },
   "usage_perc_y":65.29,
   "usage_perc_a":8.16,

--- a/features-json/subresource-integrity.json
+++ b/features-json/subresource-integrity.json
@@ -248,7 +248,7 @@
       "9.3":"n",
       "10.0-10.2":"n",
       "10.3":"n",
-      "11":"n"
+      "11":"n d #1"
     },
     "op_mini":{
       "all":"n"
@@ -304,7 +304,7 @@
   },
   "notes":"",
   "notes_by_num":{
-    
+    "1":"Can be enabled via the \"Experimental Features\" developer menu"
   },
   "usage_perc_y":63.81,
   "usage_perc_a":0,

--- a/features-json/web-animation.json
+++ b/features-json/web-animation.json
@@ -185,7 +185,7 @@
       "10":"n",
       "10.1":"n",
       "11":"n",
-      "TP":"n"
+      "TP":"n d #4"
     },
     "opera":{
       "9":"n",
@@ -248,7 +248,7 @@
       "9.3":"n",
       "10.0-10.2":"n",
       "10.3":"n",
-      "11":"n"
+      "11":"n d #4"
     },
     "op_mini":{
       "all":"n"
@@ -306,7 +306,8 @@
   "notes_by_num":{
     "1":"Partial support refers to basic support of `element.animate()`",
     "2":"Partial support refers to basic support of `element.animate()` and [playback control of AnimationPlayer](https://www.chromestatus.com/features/5633748733263872)",
-    "3":"Partial support in Firefox is detailed in [Are we animated yet?](https://birtles.github.io/areweanimatedyet/)"
+    "3":"Partial support in Firefox is detailed in [Are we animated yet?](https://birtles.github.io/areweanimatedyet/)",
+    "4":"Can be enabled via the \"Experimental Features\" developer menu"
   },
   "usage_perc_y":0,
   "usage_perc_a":73.87,


### PR DESCRIPTION
Catches up featuresets to TP 39 and iOS 11 experimental features that are disabled by default but can be enabled.