### PR TITLE
Standardize MDN references to “MDN Web Docs”

### DIFF
--- a/features-json/addeventlistener.json
+++ b/features-json/addeventlistener.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener",
-      "title":"Mozilla Developer Network (MDN) documentation - addEventListener"
+      "title":"MDN Web Docs - addEventListener"
     },
     {
       "url":"https://github.com/Financial-Times/polyfill-service/blob/master/polyfills/Event/polyfill.js",

--- a/features-json/alternate-stylesheet.json
+++ b/features-json/alternate-stylesheet.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/Alternative_style_sheets#Specifications",
-      "title":"Mozilla Developer Network (MDN) documentation - alternate stylesheet"
+      "title":"MDN Web Docs - alternate stylesheet"
     },
     {
       "url":"https://www.w3.org/Style/Examples/007/alternatives.en.html",

--- a/features-json/ambient-light.json
+++ b/features-json/ambient-light.json
@@ -14,11 +14,11 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/Ambient_Light_Sensor_API",
-      "title":"Mozilla Developer Network (MDN) documentation - Ambient Light Sensor"
+      "title":"MDN Web Docs - Ambient Light Sensor"
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/Ambient_Light_Events",
-      "title":"Mozilla Developer Network (MDN) documentation - Ambient Light Events"
+      "title":"MDN Web Docs - Ambient Light Events"
     }
   ],
   "bugs":[

--- a/features-json/apng.json
+++ b/features-json/apng.json
@@ -30,7 +30,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Mozilla/Tech/APNG",
-      "title":"Mozilla Developer Network (MDN) documentation - APNG"
+      "title":"MDN Web Docs - APNG"
     }
   ],
   "bugs":[

--- a/features-json/arrow-functions.json
+++ b/features-json/arrow-functions.json
@@ -10,7 +10,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions",
-      "title":"Mozilla Developer Network (MDN) documentation - Arrow functions"
+      "title":"MDN Web Docs - Arrow functions"
     }
   ],
   "bugs":[

--- a/features-json/async-functions.json
+++ b/features-json/async-functions.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function",
-      "title":"Mozilla Developer Network (MDN) documentation - Async functions"
+      "title":"MDN Web Docs - Async functions"
     },
     {
       "url":"https://developers.google.com/web/fundamentals/getting-started/primers/async-functions",

--- a/features-json/atob-btoa.json
+++ b/features-json/atob-btoa.json
@@ -6,11 +6,11 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/Window.btoa",
-      "title":"Mozilla Developer Network (MDN) documentation - btoa()"
+      "title":"MDN Web Docs - btoa()"
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/Window.atob",
-      "title":"Mozilla Developer Network (MDN) documentation - atob()"
+      "title":"MDN Web Docs - atob()"
     },
     {
       "url":"https://github.com/davidchambers/Base64.js",

--- a/features-json/audio-api.json
+++ b/features-json/audio-api.json
@@ -22,7 +22,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/Web_Audio_API",
-      "title":"Mozilla Developer Network (MDN) documentation - Web Audio API"
+      "title":"MDN Web Docs - Web Audio API"
     }
   ],
   "bugs":[

--- a/features-json/autofocus.json
+++ b/features-json/autofocus.json
@@ -10,7 +10,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en/docs/Web/HTML/Element/input#attr-autofocus",
-      "title":"Mozilla Developer Network (MDN) documentation - autofocus attribute"
+      "title":"MDN Web Docs - autofocus attribute"
     }
   ],
   "bugs":[

--- a/features-json/aux-click.json
+++ b/features-json/aux-click.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/Events/auxclick",
-      "title":"Mozilla Developer Network (MDN) documentation - auxclick"
+      "title":"MDN Web Docs - auxclick"
     },
     {
       "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=1304044",

--- a/features-json/background-attachment.json
+++ b/features-json/background-attachment.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/background-attachment",
-      "title":"Mozilla Developer Network (MDN) documentation - background-attachment"
+      "title":"MDN Web Docs - background-attachment"
     }
   ],
   "bugs":[

--- a/features-json/background-img-opts.json
+++ b/features-json/background-img-opts.json
@@ -14,7 +14,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en/docs/Web/CSS/background-image",
-      "title":"Mozilla Developer Network (MDN) documentation - background-image"
+      "title":"MDN Web Docs - background-image"
     }
   ],
   "bugs":[

--- a/features-json/background-position-x-y.json
+++ b/features-json/background-position-x-y.json
@@ -18,11 +18,11 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/background-position-x",
-      "title":"Mozilla Developer Network (MDN) documentation - background-position-x"
+      "title":"MDN Web Docs - background-position-x"
     },
     {
       "url":"https://developer.mozilla.org/en/docs/Web/CSS/background-position-y",
-      "title":"Mozilla Developer Network (MDN) documentation - background-position-y"
+      "title":"MDN Web Docs - background-position-y"
     }
   ],
   "bugs":[

--- a/features-json/background-repeat-round-space.json
+++ b/features-json/background-repeat-round-space.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org//docs/Web/CSS/background-repeat",
-      "title":"Mozilla Developer Network (MDN) documentation - background-repeat"
+      "title":"MDN Web Docs - background-repeat"
     },
     {
       "url":"https://css-tricks.com/almanac/properties/b/background-repeat/",

--- a/features-json/battery-status.json
+++ b/features-json/battery-status.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/WebAPI/Battery_Status",
-      "title":"Mozilla Developer Network (MDN) documentation - battery status"
+      "title":"MDN Web Docs - battery status"
     },
     {
       "url":"http://www.smartjava.org/examples/webapi-battery/",

--- a/features-json/beacon.json
+++ b/features-json/beacon.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/Navigator/sendBeacon",
-      "title":"Mozilla Developer Network (MDN) documentation - Beacon"
+      "title":"MDN Web Docs - Beacon"
     }
   ],
   "bugs":[

--- a/features-json/beforeafterprint.json
+++ b/features-json/beforeafterprint.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/Guide/Printing#Detecting_print_requests",
-      "title":"Mozilla Developer Network (MDN) documentation - Detecting print requests"
+      "title":"MDN Web Docs - Detecting print requests"
     },
     {
       "url":"http://crbug.com/218205",

--- a/features-json/blobbuilder.json
+++ b/features-json/blobbuilder.json
@@ -6,11 +6,11 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en/DOM/BlobBuilder",
-      "title":"Mozilla Developer Network (MDN) documentation - BlobBuilder"
+      "title":"MDN Web Docs - BlobBuilder"
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/DOM/Blob",
-      "title":"Mozilla Developer Network (MDN) documentation - Blobs"
+      "title":"MDN Web Docs - Blobs"
     }
   ],
   "bugs":[

--- a/features-json/bloburls.json
+++ b/features-json/bloburls.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en/DOM/window.URL.createObjectURL",
-      "title":"Mozilla Developer Network (MDN) documentation - createObjectURL"
+      "title":"MDN Web Docs - createObjectURL"
     }
   ],
   "bugs":[

--- a/features-json/border-image.json
+++ b/features-json/border-image.json
@@ -10,7 +10,7 @@
     },
     {
       "url":"https://developer.mozilla.org//docs/Web/CSS/border-image",
-      "title":"Mozilla Developer Network (MDN) documentation - Border image"
+      "title":"MDN Web Docs - Border image"
     }
   ],
   "bugs":[

--- a/features-json/border-radius.json
+++ b/features-json/border-radius.json
@@ -22,7 +22,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en/docs/Web/CSS/border-radius",
-      "title":"Mozilla Developer Network (MDN) documentation - CSS border-radius"
+      "title":"MDN Web Docs - CSS border-radius"
     }
   ],
   "bugs":[

--- a/features-json/broadcastchannel.json
+++ b/features-json/broadcastchannel.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/BroadcastChannel",
-      "title":"Mozilla Developer Network (MDN) documentation - Broadcast Channel"
+      "title":"MDN Web Docs - Broadcast Channel"
     }
   ],
   "bugs":[

--- a/features-json/calc.json
+++ b/features-json/calc.json
@@ -10,7 +10,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en/docs/Web/CSS/calc",
-      "title":"Mozilla Developer Network (MDN) documentation - calc"
+      "title":"MDN Web Docs - calc"
     },
     {
       "url":"https://www.webplatform.org/docs/css/functions/calc",

--- a/features-json/canvas.json
+++ b/features-json/canvas.json
@@ -30,7 +30,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API",
-      "title":"Mozilla Developer Network (MDN) documentation - Canvas API"
+      "title":"MDN Web Docs - Canvas API"
     }
   ],
   "bugs":[

--- a/features-json/channel-messaging.json
+++ b/features-json/channel-messaging.json
@@ -10,7 +10,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/Channel_Messaging_API",
-      "title":"Mozilla Developer Network (MDN) documentation - Channel Messaging API"
+      "title":"MDN Web Docs - Channel Messaging API"
     }
   ],
   "bugs":[

--- a/features-json/childnode-remove.json
+++ b/features-json/childnode-remove.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/ChildNode/remove",
-      "title":"Mozilla Developer Network (MDN) documentation - ChildNode.remove"
+      "title":"MDN Web Docs - ChildNode.remove"
     }
   ],
   "bugs":[

--- a/features-json/classlist.json
+++ b/features-json/classlist.json
@@ -26,7 +26,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/Element.classList",
-      "title":"Mozilla Developer Network (MDN) documentation - Element.classList"
+      "title":"MDN Web Docs - Element.classList"
     }
   ],
   "bugs":[

--- a/features-json/clipboard.json
+++ b/features-json/clipboard.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/ClipboardEvent",
-      "title":"Mozilla Developer Network (MDN) documentation - ClipboardEvent"
+      "title":"MDN Web Docs - ClipboardEvent"
     },
     {
       "url":"https://www.lucidchart.com/techblog/2014/12/02/definitive-guide-copying-pasting-javascript/",

--- a/features-json/comparedocumentposition.json
+++ b/features-json/comparedocumentposition.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/Node/compareDocumentPosition",
-      "title":"Mozilla Developer Network (MDN) documentation - Node.compareDocumentPosition"
+      "title":"MDN Web Docs - Node.compareDocumentPosition"
     }
   ],
   "bugs":[

--- a/features-json/console-basic.json
+++ b/features-json/console-basic.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/Console",
-      "title":"Mozilla Developer Network (MDN) documentation - Console"
+      "title":"MDN Web Docs - Console"
     },
     {
       "url":"https://developer.chrome.com/devtools/docs/console-api",

--- a/features-json/const.json
+++ b/features-json/const.json
@@ -10,7 +10,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/const",
-      "title":"Mozilla Developer Network (MDN) documentation - const"
+      "title":"MDN Web Docs - const"
     }
   ],
   "bugs":[

--- a/features-json/contenteditable.json
+++ b/features-json/contenteditable.json
@@ -22,7 +22,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en/docs/Web/API/HTMLElement/contentEditable",
-      "title":"Mozilla Developer Network (MDN) documentation - contentEditable attribute"
+      "title":"MDN Web Docs - contentEditable attribute"
     }
   ],
   "bugs":[

--- a/features-json/contentsecuritypolicy.json
+++ b/features-json/contentsecuritypolicy.json
@@ -14,7 +14,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP",
-      "title":"Mozilla Developer Network (MDN) documentation - Content Security Policy"
+      "title":"MDN Web Docs - Content Security Policy"
     }
   ],
   "bugs":[

--- a/features-json/contentsecuritypolicy2.json
+++ b/features-json/contentsecuritypolicy2.json
@@ -10,7 +10,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP",
-      "title":"Mozilla Developer Network (MDN) documentation - Content Security Policy"
+      "title":"MDN Web Docs - Content Security Policy"
     }
   ],
   "bugs":[

--- a/features-json/cors.json
+++ b/features-json/cors.json
@@ -22,7 +22,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS",
-      "title":"Mozilla Developer Network (MDN) documentation - Access control CORS"
+      "title":"MDN Web Docs - Access control CORS"
     }
   ],
   "bugs":[

--- a/features-json/credential-management.json
+++ b/features-json/credential-management.json
@@ -10,7 +10,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/Credential_Management_API",
-      "title":"Mozilla Developer Network (MDN) documentation - Credential Management API"
+      "title":"MDN Web Docs - Credential Management API"
     },
     {
       "url":"https://g.co/codelabs/cmapi",

--- a/features-json/cryptography.json
+++ b/features-json/cryptography.json
@@ -38,7 +38,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API",
-      "title":"Mozilla Developer Network (MDN) documentation - Web Crypto API"
+      "title":"MDN Web Docs - Web Crypto API"
     }
   ],
   "bugs":[

--- a/features-json/css-all.json
+++ b/features-json/css-all.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/all",
-      "title":"Mozilla Developer Network (MDN) documentation - CSS all"
+      "title":"MDN Web Docs - CSS all"
     },
     {
       "url":"http://mcc.id.au/blog/2013/10/all-unset",

--- a/features-json/css-any-link.json
+++ b/features-json/css-any-link.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/:any-link",
-      "title":"Mozilla Developer Network (MDN) documentation - CSS :any-link"
+      "title":"MDN Web Docs - CSS :any-link"
     }
   ],
   "bugs":[

--- a/features-json/css-at-counter-style.json
+++ b/features-json/css-at-counter-style.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/@counter-style",
-      "title":"Mozilla Developer Network (MDN) documentation - CSS counter style"
+      "title":"MDN Web Docs - CSS counter style"
     }
   ],
   "bugs":[

--- a/features-json/css-backdrop-filter.json
+++ b/features-json/css-backdrop-filter.json
@@ -10,7 +10,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/backdrop-filter",
-      "title":"Mozilla Developer Network (MDN) documentation - CSS backdrop filter"
+      "title":"MDN Web Docs - CSS backdrop filter"
     },
     {
       "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/9160189-backdrop-filters",

--- a/features-json/css-background-offsets.json
+++ b/features-json/css-background-offsets.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/background-position",
-      "title":"Mozilla Developer Network (MDN) documentation - background-position"
+      "title":"MDN Web Docs - background-position"
     },
     {
       "url":"http://briantree.se/quick-tip-06-use-four-value-syntax-properly-position-background-images/",

--- a/features-json/css-boxdecorationbreak.json
+++ b/features-json/css-boxdecorationbreak.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/box-decoration-break",
-      "title":"Mozilla Developer Network (MDN) documentation - CSS box-decoration-break"
+      "title":"MDN Web Docs - CSS box-decoration-break"
     },
     {
       "url":"http://jsbin.com/xojoro/edit?css,output",

--- a/features-json/css-boxshadow.json
+++ b/features-json/css-boxshadow.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/En/CSS/-moz-box-shadow",
-      "title":"Mozilla Developer Network (MDN) documentation - box-shadow"
+      "title":"MDN Web Docs - box-shadow"
     },
     {
       "url":"http://westciv.com/tools/boxshadows/index.html",

--- a/features-json/css-case-insensitive.json
+++ b/features-json/css-case-insensitive.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/Attribute_selectors#case-insensitive",
-      "title":"Mozilla Developer Network (MDN) documentation - CSS case-insensitive"
+      "title":"MDN Web Docs - CSS case-insensitive"
     },
     {
       "url":"http://jsbin.com/zutuna/edit?html,css,output",

--- a/features-json/css-counters.json
+++ b/features-json/css-counters.json
@@ -10,7 +10,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en/CSS_Counters",
-      "title":"Mozilla Developer Network (MDN) documentation - CSS Counters"
+      "title":"MDN Web Docs - CSS Counters"
     },
     {
       "url":"https://www.webplatform.org/docs/css/properties/counter-reset",

--- a/features-json/css-crisp-edges.json
+++ b/features-json/css-crisp-edges.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/image-rendering",
-      "title":"Mozilla Developer Network (MDN) documentation - CSS Image rendering"
+      "title":"MDN Web Docs - CSS Image rendering"
     },
     {
       "url":"http://updates.html5rocks.com/2015/01/pixelated",

--- a/features-json/css-default-pseudo.json
+++ b/features-json/css-default-pseudo.json
@@ -10,7 +10,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/:default",
-      "title":"Mozilla Developer Network (MDN) documentation - CSS :default"
+      "title":"MDN Web Docs - CSS :default"
     },
     {
       "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/13311459--default-pseudo-class-from-selectors-level-4",

--- a/features-json/css-descendant-gtgt.json
+++ b/features-json/css-descendant-gtgt.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/Descendant_selectors",
-      "title":"Mozilla Developer Network (MDN) documentation - Descendant selectors"
+      "title":"MDN Web Docs - Descendant selectors"
     },
     {
       "url":"http://jsbin.com/qipekof/edit?html,css,output",

--- a/features-json/css-dir-pseudo.json
+++ b/features-json/css-dir-pseudo.json
@@ -10,7 +10,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/:dir",
-      "title":"Mozilla Developer Network (MDN) documentation - CSS :dir"
+      "title":"MDN Web Docs - CSS :dir"
     },
     {
       "url":"https://bugs.chromium.org/p/chromium/issues/detail?id=576815",

--- a/features-json/css-element-function.json
+++ b/features-json/css-element-function.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/element",
-      "title":"Mozilla Developer Network (MDN) documentation - CSS element"
+      "title":"MDN Web Docs - CSS element"
     }
   ],
   "bugs":[

--- a/features-json/css-featurequeries.json
+++ b/features-json/css-featurequeries.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/@supports",
-      "title":"Mozilla Developer Network (MDN) documentation - CSS @supports"
+      "title":"MDN Web Docs - CSS @supports"
     },
     {
       "url":"http://mcc.id.au/blog/2012/08/supports",

--- a/features-json/css-first-letter.json
+++ b/features-json/css-first-letter.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/::first-letter",
-      "title":"Mozilla Developer Network (MDN) documentation - :first-letter"
+      "title":"MDN Web Docs - :first-letter"
     }
   ],
   "bugs":[

--- a/features-json/css-first-line.json
+++ b/features-json/css-first-line.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/::first-line",
-      "title":"Mozilla Developer Network (MDN) documentation - ::first-line"
+      "title":"MDN Web Docs - ::first-line"
     },
     {
       "url":"https://css-tricks.com/almanac/selectors/f/first-line/",

--- a/features-json/css-focus-within.json
+++ b/features-json/css-focus-within.json
@@ -34,7 +34,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-within",
-      "title":"Mozilla Developer Network (MDN) documentation - :focus-within"
+      "title":"MDN Web Docs - :focus-within"
     }
   ],
   "bugs":[

--- a/features-json/css-font-rendering-controls.json
+++ b/features-json/css-font-rendering-controls.json
@@ -10,7 +10,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display",
-      "title":"Mozilla Developer Network (MDN) documentation - font-display"
+      "title":"MDN Web Docs - font-display"
     },
     {
       "url":"https://css-tricks.com/font-display-masses/",

--- a/features-json/css-font-stretch.json
+++ b/features-json/css-font-stretch.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/font-stretch",
-      "title":"Mozilla Developer Network (MDN) documentation - font-stretch"
+      "title":"MDN Web Docs - font-stretch"
     },
     {
       "url":"http://css-tricks.com/almanac/properties/f/font-stretch/",

--- a/features-json/css-has.json
+++ b/features-json/css-has.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/:has",
-      "title":"Mozilla Developer Network (MDN) documentation - :has"
+      "title":"MDN Web Docs - :has"
     },
     {
       "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=418039",

--- a/features-json/css-hyphens.json
+++ b/features-json/css-hyphens.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en/CSS/hyphens",
-      "title":"Mozilla Developer Network (MDN) documentation - CSS hyphens"
+      "title":"MDN Web Docs - CSS hyphens"
     },
     {
       "url":"http://blog.fontdeck.com/post/9037028497/hyphens",

--- a/features-json/css-image-orientation.json
+++ b/features-json/css-image-orientation.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/image-orientation",
-      "title":"Mozilla Developer Network (MDN) documentation - CSS image-orientation"
+      "title":"MDN Web Docs - CSS image-orientation"
     },
     {
       "url":"http://sethfowler.org/blog/2013/09/13/new-in-firefox-26-css-image-orientation/",

--- a/features-json/css-in-out-of-range.json
+++ b/features-json/css-in-out-of-range.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/:out-of-range",
-      "title":"Mozilla Developer Network (MDN) documentation - CSS :out-of-range"
+      "title":"MDN Web Docs - CSS :out-of-range"
     },
     {
       "url":"https://html.spec.whatwg.org/multipage/scripting.html#selector-in-range",

--- a/features-json/css-indeterminate-pseudo.json
+++ b/features-json/css-indeterminate-pseudo.json
@@ -10,7 +10,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/:indeterminate",
-      "title":"Mozilla Developer Network (MDN) documentation - CSS :indeterminate"
+      "title":"MDN Web Docs - CSS :indeterminate"
     },
     {
       "url":"https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/7124038/",

--- a/features-json/css-initial-letter.json
+++ b/features-json/css-initial-letter.json
@@ -10,7 +10,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/initial-letter",
-      "title":"Mozilla Developer Network (MDN) documentation - CSS initial-letter"
+      "title":"MDN Web Docs - CSS initial-letter"
     },
     {
       "url":"https://webdesign.tutsplus.com/tutorials/better-css-drop-caps-with-initial-letter--cms-26350",

--- a/features-json/css-initial-value.json
+++ b/features-json/css-initial-value.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/initial",
-      "title":"Mozilla Developer Network (MDN) documentation - CSS initial"
+      "title":"MDN Web Docs - CSS initial"
     },
     {
       "url":"https://css-tricks.com/getting-acquainted-with-initial/",

--- a/features-json/css-letter-spacing.json
+++ b/features-json/css-letter-spacing.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/letter-spacing",
-      "title":"Mozilla Developer Network (MDN) documentation - CSS letter-spacing"
+      "title":"MDN Web Docs - CSS letter-spacing"
     }
   ],
   "bugs":[

--- a/features-json/css-logical-props.json
+++ b/features-json/css-logical-props.json
@@ -6,11 +6,11 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/-moz-margin-start",
-      "title":"Mozilla Developer Network (MDN) documentation - CSS -moz-margin-start"
+      "title":"MDN Web Docs - CSS -moz-margin-start"
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/-moz-padding-start",
-      "title":"Mozilla Developer Network (MDN) documentation - CSS -moz-padding-start"
+      "title":"MDN Web Docs - CSS -moz-padding-start"
     },
     {
       "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/7438435-css-logical-properties",

--- a/features-json/css-marker-pseudo.json
+++ b/features-json/css-marker-pseudo.json
@@ -22,7 +22,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/::marker",
-      "title":"Mozilla Developer Network (MDN) documentation - CSS ::marker"
+      "title":"MDN Web Docs - CSS ::marker"
     },
     {
       "url":"https://css-tricks.com/almanac/selectors/m/marker/",

--- a/features-json/css-matches-pseudo.json
+++ b/features-json/css-matches-pseudo.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/:any",
-      "title":"Mozilla Developer Network (MDN) documentation - CSS :any"
+      "title":"MDN Web Docs - CSS :any"
     },
     {
       "url":"https://webkit.org/blog/3615/css-selectors-inside-selectors-discover-matches-not-and-nth-child/",

--- a/features-json/css-motion-paths.json
+++ b/features-json/css-motion-paths.json
@@ -10,7 +10,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/motion-path",
-      "title":"Mozilla Developer Network (MDN) documentation - CSS motion-path"
+      "title":"MDN Web Docs - CSS motion-path"
     },
     {
       "url":"https://googlechrome.github.io/samples/css-motion-path/index.html",

--- a/features-json/css-namespaces.json
+++ b/features-json/css-namespaces.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/@namespace",
-      "title":"Mozilla Developer Network (MDN) documentation - CSS @namespace"
+      "title":"MDN Web Docs - CSS @namespace"
     }
   ],
   "bugs":[

--- a/features-json/css-not-sel-list.json
+++ b/features-json/css-not-sel-list.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/:not",
-      "title":"Mozilla Developer Network (MDN) documentation - CSS :not"
+      "title":"MDN Web Docs - CSS :not"
     },
     {
       "url":"https://bugs.chromium.org/p/chromium/issues/detail?id=580628",

--- a/features-json/css-optional-pseudo.json
+++ b/features-json/css-optional-pseudo.json
@@ -10,7 +10,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/:optional",
-      "title":"Mozilla Developer Network (MDN) documentation - CSS :optional"
+      "title":"MDN Web Docs - CSS :optional"
     },
     {
       "url":"http://jsbin.com/fihudu/edit?html,css,output",

--- a/features-json/css-paged-media.json
+++ b/features-json/css-paged-media.json
@@ -10,7 +10,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/@page",
-      "title":"Mozilla Developer Network (MDN) documentation - CSS @page"
+      "title":"MDN Web Docs - CSS @page"
     },
     {
       "url":"https://bugs.webkit.org/show_bug.cgi?id=85062",

--- a/features-json/css-placeholder.json
+++ b/features-json/css-placeholder.json
@@ -18,7 +18,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/::-moz-placeholder",
-      "title":"Mozilla Developer Network (MDN) documentation - CSS ::-moz-placeholder"
+      "title":"MDN Web Docs - CSS ::-moz-placeholder"
     },
     {
       "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=1069012",

--- a/features-json/css-read-only-write.json
+++ b/features-json/css-read-only-write.json
@@ -14,7 +14,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/:read-write",
-      "title":"Mozilla Developer Network (MDN) documentation - CSS :read-write"
+      "title":"MDN Web Docs - CSS :read-write"
     },
     {
       "url":"https://drafts.csswg.org/selectors-4/#rw-pseudos",

--- a/features-json/css-repeating-gradients.json
+++ b/features-json/css-repeating-gradients.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en/CSS/repeating-linear-gradient",
-      "title":"Mozilla Developer Network (MDN) documentation - CSS repeating linear gradient"
+      "title":"MDN Web Docs - CSS repeating linear gradient"
     },
     {
       "url":"https://www.webplatform.org/docs/css/repeating-linear-gradient",

--- a/features-json/css-revert-value.json
+++ b/features-json/css-revert-value.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/revert",
-      "title":"Mozilla Developer Network (MDN) documentation - CSS revert"
+      "title":"MDN Web Docs - CSS revert"
     },
     {
       "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=1215878",

--- a/features-json/css-scroll-behavior.json
+++ b/features-json/css-scroll-behavior.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-behavior",
-      "title":"Mozilla Developer Network (MDN) documentation - CSS scroll-behavior"
+      "title":"MDN Web Docs - CSS scroll-behavior"
     },
     {
       "url":"https://code.google.com/p/chromium/issues/detail?id=243871",

--- a/features-json/css-snappoints.json
+++ b/features-json/css-snappoints.json
@@ -10,7 +10,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Scroll_Snap_Points",
-      "title":"Mozilla Developer Network (MDN) documentation - CSS Scroll snap points"
+      "title":"MDN Web Docs - CSS Scroll snap points"
     },
     {
       "url":"https://github.com/ckrack/scrollsnap-polyfill",

--- a/features-json/css-sticky.json
+++ b/features-json/css-sticky.json
@@ -10,7 +10,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/position",
-      "title":"Mozilla Developer Network (MDN) documentation - CSS position"
+      "title":"MDN Web Docs - CSS position"
     },
     {
       "url":"https://www.webplatform.org/docs/css/properties/position",

--- a/features-json/css-supports-api.json
+++ b/features-json/css-supports-api.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/CSS.supports",
-      "title":"Mozilla Developer Network (MDN) documentation - CSS supports()"
+      "title":"MDN Web Docs - CSS supports()"
     },
     {
       "url":"http://jsbin.com/rimevilotari/1/edit",

--- a/features-json/css-text-align-last.json
+++ b/features-json/css-text-align-last.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/text-align-last",
-      "title":"Mozilla Developer Network (MDN) documentation - CSS text-align-last"
+      "title":"MDN Web Docs - CSS text-align-last"
     },
     {
       "url":"http://blogs.adobe.com/webplatform/2014/02/25/improving-your-sites-visual-details-css3-text-align-last/",

--- a/features-json/css-text-indent.json
+++ b/features-json/css-text-indent.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/text-indent",
-      "title":"Mozilla Developer Network (MDN) documentation - CSS text-indent"
+      "title":"MDN Web Docs - CSS text-indent"
     },
     {
       "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=784648",

--- a/features-json/css-touch-action-2.json
+++ b/features-json/css-touch-action-2.json
@@ -18,7 +18,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/touch-action",
-      "title":"Mozilla Developer Network (MDN) documentation - CSS touch-action"
+      "title":"MDN Web Docs - CSS touch-action"
     }
   ],
   "bugs":[

--- a/features-json/css-touch-action.json
+++ b/features-json/css-touch-action.json
@@ -22,7 +22,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/touch-action",
-      "title":"Mozilla Developer Network (MDN) documentation - CSS touch-action"
+      "title":"MDN Web Docs - CSS touch-action"
     },
     {
       "url":"https://bugs.webkit.org/show_bug.cgi?id=149854",

--- a/features-json/css-unicode-bidi.json
+++ b/features-json/css-unicode-bidi.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/unicode-bidi",
-      "title":"Mozilla Developer Network (MDN) documentation - CSS unicode-bidi"
+      "title":"MDN Web Docs - CSS unicode-bidi"
     }
   ],
   "bugs":[

--- a/features-json/css-unset-value.json
+++ b/features-json/css-unset-value.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/unset",
-      "title":"Mozilla Developer Network (MDN) documentation - CSS unset"
+      "title":"MDN Web Docs - CSS unset"
     },
     {
       "url":"http://mcc.id.au/blog/2013/10/all-unset",

--- a/features-json/css-variables.json
+++ b/features-json/css-variables.json
@@ -10,7 +10,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_variables",
-      "title":"Mozilla Developer Network (MDN) documentation - Using CSS variables"
+      "title":"MDN Web Docs - Using CSS variables"
     },
     {
       "url":"https://blogs.windows.com/msedgedev/2017/03/24/css-custom-properties/",

--- a/features-json/css-writing-mode.json
+++ b/features-json/css-writing-mode.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/writing-mode",
-      "title":"Mozilla Developer Network (MDN) documentation - CSS writing-mode"
+      "title":"MDN Web Docs - CSS writing-mode"
     },
     {
       "url":"https://www.chromestatus.com/feature/5707470202732544",

--- a/features-json/css-zoom.json
+++ b/features-json/css-zoom.json
@@ -26,7 +26,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/zoom",
-      "title":"Mozilla Developer Network (MDN) documentation - CSS zoom"
+      "title":"MDN Web Docs - CSS zoom"
     }
   ],
   "bugs":[

--- a/features-json/css3-attr.json
+++ b/features-json/css3-attr.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/attr",
-      "title":"Mozilla Developer Network (MDN) documentation - CSS attr"
+      "title":"MDN Web Docs - CSS attr"
     },
     {
       "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/7671960-css-attr-as-defined-in-css-values-level-3",

--- a/features-json/css3-boxsizing.json
+++ b/features-json/css3-boxsizing.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/En/CSS/Box-sizing",
-      "title":"Mozilla Developer Network (MDN) documentation - CSS box-sizing"
+      "title":"MDN Web Docs - CSS box-sizing"
     },
     {
       "url":"http://www.456bereastreet.com/archive/201104/controlling_width_with_css3_box-sizing/",

--- a/features-json/css3-cursors-grab.json
+++ b/features-json/css3-cursors-grab.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/cursor",
-      "title":"Mozilla Developer Network (MDN) documentation - CSS cursor"
+      "title":"MDN Web Docs - CSS cursor"
     }
   ],
   "bugs":[

--- a/features-json/css3-cursors-newer.json
+++ b/features-json/css3-cursors-newer.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/cursor",
-      "title":"Mozilla Developer Network (MDN) documentation - CSS cursor"
+      "title":"MDN Web Docs - CSS cursor"
     }
   ],
   "bugs":[

--- a/features-json/css3-cursors.json
+++ b/features-json/css3-cursors.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/cursor",
-      "title":"Mozilla Developer Network (MDN) documentation - CSS cursor"
+      "title":"MDN Web Docs - CSS cursor"
     }
   ],
   "bugs":[

--- a/features-json/css3-tabsize.json
+++ b/features-json/css3-tabsize.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/tab-size",
-      "title":"Mozilla Developer Network (MDN) documentation - CSS tab-size"
+      "title":"MDN Web Docs - CSS tab-size"
     },
     {
       "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6524689-tab-size-property",

--- a/features-json/currentcolor.json
+++ b/features-json/currentcolor.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#currentcolor_keyword",
-      "title":"Mozilla Developer Network (MDN) documentation - CSS currentColor"
+      "title":"MDN Web Docs - CSS currentColor"
     },
     {
       "url":"http://css-tricks.com/currentcolor/",

--- a/features-json/customevent.json
+++ b/features-json/customevent.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent",
-      "title":"Mozilla Developer Network (MDN) documentation - CustomEvent"
+      "title":"MDN Web Docs - CustomEvent"
     },
     {
       "url":"https://github.com/krambuhl/custom-event-polyfill",

--- a/features-json/datalist.json
+++ b/features-json/datalist.json
@@ -14,7 +14,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en/HTML/Element/datalist",
-      "title":"Mozilla Developer Network (MDN) documentation - datalist"
+      "title":"MDN Web Docs - datalist"
     },
     {
       "url":"https://www.webplatform.org/docs/html/elements/datalist",

--- a/features-json/dataset.json
+++ b/features-json/dataset.json
@@ -22,7 +22,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement.dataset",
-      "title":"Mozilla Developer Network (MDN) documentation - dataset"
+      "title":"MDN Web Docs - dataset"
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Using_data_attributes",

--- a/features-json/devicepixelratio.json
+++ b/features-json/devicepixelratio.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio",
-      "title":"Mozilla Developer Network (MDN) documentation - devicePixelRatio"
+      "title":"MDN Web Docs - devicePixelRatio"
     }
   ],
   "bugs":[

--- a/features-json/dispatchevent.json
+++ b/features-json/dispatchevent.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/dispatchEvent",
-      "title":"Mozilla Developer Network (MDN) documentation - dispatchEvent"
+      "title":"MDN Web Docs - dispatchEvent"
     },
     {
       "url":"https://github.com/Financial-Times/polyfill-service/blob/master/polyfills/Event/polyfill-ie8.js",

--- a/features-json/document-evaluate-xpath.json
+++ b/features-json/document-evaluate-xpath.json
@@ -10,7 +10,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Introduction_to_using_XPath_in_JavaScript",
-      "title":"Mozilla Developer Network (MDN) documentation - XPath introduction"
+      "title":"MDN Web Docs - XPath introduction"
     },
     {
       "url":"https://blogs.windows.com/msedgedev/2015/03/19/improving-interoperability-with-dom-l3-xpath/",

--- a/features-json/document-execcommand.json
+++ b/features-json/document-execcommand.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand",
-      "title":"Mozilla Developer Network (MDN) documentation - execCommand"
+      "title":"MDN Web Docs - execCommand"
     },
     {
       "url":"http://codepen.io/netsi1964/pen/QbLLGW",

--- a/features-json/documenthead.json
+++ b/features-json/documenthead.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/Document/head",
-      "title":"Mozilla Developer Network (MDN) documentation - head"
+      "title":"MDN Web Docs - head"
     }
   ],
   "bugs":[

--- a/features-json/dom-manip-convenience.json
+++ b/features-json/dom-manip-convenience.json
@@ -18,7 +18,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/ParentNode",
-      "title":"ParentNode article on Mozilla Developer Network"
+      "title":"Mozilla Developer Network (MDN) documentation - ParentNode"
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/ChildNode",

--- a/features-json/dom-manip-convenience.json
+++ b/features-json/dom-manip-convenience.json
@@ -18,11 +18,11 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/ParentNode",
-      "title":"Mozilla Developer Network (MDN) documentation - ParentNode"
+      "title":"MDN Web Docs - ParentNode"
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/ChildNode",
-      "title":"Mozilla Developer Network (MDN) documentation - ChildNode"
+      "title":"MDN Web Docs - ChildNode"
     },
     {
       "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/16036408",

--- a/features-json/dom-range.json
+++ b/features-json/dom-range.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/Range",
-      "title":"Mozilla Developer Network (MDN) documentation - Range"
+      "title":"MDN Web Docs - Range"
     },
     {
       "url":"http://www.quirksmode.org/dom/range_intro.html",

--- a/features-json/domcontentloaded.json
+++ b/features-json/domcontentloaded.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/Reference/Events/DOMContentLoaded",
-      "title":"Mozilla Developer Network (MDN) documentation - DOMContentLoaded"
+      "title":"MDN Web Docs - DOMContentLoaded"
     }
   ],
   "bugs":[

--- a/features-json/dommatrix.json
+++ b/features-json/dommatrix.json
@@ -14,7 +14,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/DOMMatrix",
-      "title":"Mozilla Developer Network (MDN) documentation - DOMMatrix"
+      "title":"MDN Web Docs - DOMMatrix"
     },
     {
       "url":"https://crbug.com/581955",

--- a/features-json/element-closest.json
+++ b/features-json/element-closest.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/Element/closest",
-      "title":"Mozilla Developer Network (MDN) documentation - closest"
+      "title":"MDN Web Docs - closest"
     },
     {
       "url":"https://github.com/jonathantneal/closest",

--- a/features-json/element-from-point.json
+++ b/features-json/element-from-point.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/Document/elementFromPoint",
-      "title":"Mozilla Developer Network (MDN) documentation - elementFromPoint"
+      "title":"MDN Web Docs - elementFromPoint"
     }
   ],
   "bugs":[

--- a/features-json/es6-class.json
+++ b/features-json/es6-class.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes",
-      "title":"Mozilla Developer Network (MDN) documentation - ES6 classes"
+      "title":"MDN Web Docs - ES6 classes"
     },
     {
       "url":"https://www.sitepoint.com/object-oriented-javascript-deep-dive-es6-classes/",

--- a/features-json/fileapi.json
+++ b/features-json/fileapi.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en/Using_files_from_web_applications",
-      "title":"Mozilla Developer Network (MDN) documentation - Using Files"
+      "title":"MDN Web Docs - Using Files"
     },
     {
       "url":"https://www.webplatform.org/docs/apis/file",

--- a/features-json/filereader.json
+++ b/features-json/filereader.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en/DOM/FileReader",
-      "title":"Mozilla Developer Network (MDN) documentation - FileReader"
+      "title":"MDN Web Docs - FileReader"
     },
     {
       "url":"https://www.webplatform.org/docs/apis/file/FileReader",

--- a/features-json/filereadersync.json
+++ b/features-json/filereadersync.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/FileReaderSync",
-      "title":"Mozilla Developer Network (MDN) documentation - FileReaderSync"
+      "title":"MDN Web Docs - FileReaderSync"
     }
   ],
   "bugs":[

--- a/features-json/focusin-focusout-events.json
+++ b/features-json/focusin-focusout-events.json
@@ -6,11 +6,11 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/Events/focusin",
-      "title":"Mozilla Developer Network (MDN) documentation - focusin"
+      "title":"MDN Web Docs - focusin"
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/Events/focusout",
-      "title":"Mozilla Developer Network (MDN) documentation - focusout"
+      "title":"MDN Web Docs - focusout"
     },
     {
       "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=687787",

--- a/features-json/font-feature.json
+++ b/features-json/font-feature.json
@@ -22,7 +22,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/font-feature-settings",
-      "title":"Mozilla Developer Network (MDN) documentation - font-feature-settings"
+      "title":"MDN Web Docs - font-feature-settings"
     },
     {
       "url":"https://www.microsoft.com/typography/otspec/featuretags.htm",

--- a/features-json/font-kerning.json
+++ b/features-json/font-kerning.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/font-kerning",
-      "title":"Mozilla Developer Network (MDN) documentation - CSS font-kerning"
+      "title":"MDN Web Docs - CSS font-kerning"
     }
   ],
   "bugs":[

--- a/features-json/font-size-adjust.json
+++ b/features-json/font-size-adjust.json
@@ -10,7 +10,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/font-size-adjust",
-      "title":"Mozilla Developer Network (MDN) documentation - CSS font-size-adjust"
+      "title":"MDN Web Docs - CSS font-size-adjust"
     },
     {
       "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6514821-font-size-adjust-other-font-properties",

--- a/features-json/font-smooth.json
+++ b/features-json/font-smooth.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/font-smooth",
-      "title":"Mozilla Developer Network (MDN) documentation - font-smooth"
+      "title":"MDN Web Docs - font-smooth"
     },
     {
       "url":"http://www.w3.org/TR/WD-font/#font-smooth",

--- a/features-json/font-unicode-range.json
+++ b/features-json/font-unicode-range.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/unicode-range",
-      "title":"Mozilla Developer Network (MDN) documentation - CSS unicode-range"
+      "title":"MDN Web Docs - CSS unicode-range"
     },
     {
       "url":"https://developer.apple.com/library/safari/documentation/AppleApplications/Reference/SafariCSSRef/Articles/StandardCSSProperties.html#//apple_ref/css/property/unicode-range",

--- a/features-json/font-variant-alternates.json
+++ b/features-json/font-variant-alternates.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-alternates",
-      "title":"Mozilla Developer Network (MDN) documentation - font-variant-alternates"
+      "title":"MDN Web Docs - font-variant-alternates"
     }
   ],
   "bugs":[

--- a/features-json/fullscreen.json
+++ b/features-json/fullscreen.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en/DOM/Using_full-screen_mode",
-      "title":"Mozilla Developer Network (MDN) documentation - Using Full Screen"
+      "title":"MDN Web Docs - Using Full Screen"
     },
     {
       "url":"http://jlongster.com/2011/11/21/canvas.html",

--- a/features-json/gamepad.json
+++ b/features-json/gamepad.json
@@ -10,7 +10,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/Gamepad_API",
-      "title":"Mozilla Developer Network (MDN) documentation - Gamepad"
+      "title":"MDN Web Docs - Gamepad"
     },
     {
       "url":"http://www.html5rocks.com/en/tutorials/doodles/gamepad/",

--- a/features-json/getboundingclientrect.json
+++ b/features-json/getboundingclientrect.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect",
-      "title":"Mozilla Developer Network (MDN) documentation - getBoundingClientRect"
+      "title":"MDN Web Docs - getBoundingClientRect"
     },
     {
       "url":"https://msdn.microsoft.com/en-us/library/ms536433(VS.85).aspx",

--- a/features-json/getcomputedstyle.json
+++ b/features-json/getcomputedstyle.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en/DOM/window.getComputedStyle",
-      "title":"Mozilla Developer Network (MDN) documentation - getComputedStyle"
+      "title":"MDN Web Docs - getComputedStyle"
     },
     {
       "url":"http://ie.microsoft.com/testdrive/HTML5/getComputedStyle/",

--- a/features-json/getrandomvalues.json
+++ b/features-json/getrandomvalues.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/window.crypto.getRandomValues",
-      "title":"Mozilla Developer Network (MDN) documentation - crypto.getRandomValues"
+      "title":"MDN Web Docs - crypto.getRandomValues"
     }
   ],
   "bugs":[

--- a/features-json/hardwareconcurrency.json
+++ b/features-json/hardwareconcurrency.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/NavigatorConcurrentHardware/hardwareConcurrency",
-      "title":"Mozilla Developer Network"
+      "title":"Mozilla Developer Network (MDN) documentation - navigator.hardwareConcurrency"
     },
     {
       "url":"https://wiki.whatwg.org/wiki/Navigator_HW_Concurrency",

--- a/features-json/hardwareconcurrency.json
+++ b/features-json/hardwareconcurrency.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/NavigatorConcurrentHardware/hardwareConcurrency",
-      "title":"Mozilla Developer Network (MDN) documentation - navigator.hardwareConcurrency"
+      "title":"MDN Web Docs - navigator.hardwareConcurrency"
     },
     {
       "url":"https://wiki.whatwg.org/wiki/Navigator_HW_Concurrency",

--- a/features-json/hashchange.json
+++ b/features-json/hashchange.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en/DOM/window.onhashchange",
-      "title":"Mozilla Developer Network (MDN) documentation - onhashchange"
+      "title":"MDN Web Docs - onhashchange"
     },
     {
       "url":"http://msdn.microsoft.com/en-us/library/cc288209(VS.85).aspx",

--- a/features-json/high-resolution-time.json
+++ b/features-json/high-resolution-time.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/Performance.now()",
-      "title":"Mozilla Developer Network (MDN) documentation - Performance.now"
+      "title":"MDN Web Docs - Performance.now"
     },
     {
       "url":"http://updates.html5rocks.com/2012/08/When-milliseconds-are-not-enough-performance-now",

--- a/features-json/history.json
+++ b/features-json/history.json
@@ -10,7 +10,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en/DOM/Manipulating_the_browser_history",
-      "title":"Mozilla Developer Network (MDN) documentation - Manipulating the browser history"
+      "title":"MDN Web Docs - Manipulating the browser history"
     },
     {
       "url":"http://html5demos.com/history",

--- a/features-json/iframe-srcdoc.json
+++ b/features-json/iframe-srcdoc.json
@@ -10,7 +10,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe",
-      "title":"Mozilla Developer Network (MDN) documentation - iframe"
+      "title":"MDN Web Docs - iframe"
     },
     {
       "url":"https://github.com/jugglinmike/srcdoc-polyfill",

--- a/features-json/indexeddb2.json
+++ b/features-json/indexeddb2.json
@@ -10,7 +10,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API",
-      "title":"MDN Docs"
+      "title":"Mozilla Developer Network (MDN) documentation - IndexedDB API"
     }
   ],
   "bugs":[

--- a/features-json/indexeddb2.json
+++ b/features-json/indexeddb2.json
@@ -10,7 +10,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API",
-      "title":"Mozilla Developer Network (MDN) documentation - IndexedDB API"
+      "title":"MDN Web Docs - IndexedDB API"
     }
   ],
   "bugs":[

--- a/features-json/innertext.json
+++ b/features-json/innertext.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/Node/innerText",
-      "title":"Mozilla Developer Network (MDN) documentation - innerText"
+      "title":"MDN Web Docs - innerText"
     },
     {
       "url":"https://github.com/whatwg/compat/issues/5",

--- a/features-json/input-autocomplete-onoff.json
+++ b/features-json/input-autocomplete-onoff.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-autocomplete",
-      "title":"Mozilla Developer Network (MDN) documentation - autocomplete attribute"
+      "title":"MDN Web Docs - autocomplete attribute"
     }
   ],
   "bugs":[

--- a/features-json/input-event.json
+++ b/features-json/input-event.json
@@ -10,7 +10,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/Events/input",
-      "title":"Mozilla Developer Network (MDN) documentation - input event"
+      "title":"MDN Web Docs - input event"
     },
     {
       "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/10182111--input-type-checkbox-type-radio-should-fire-in",

--- a/features-json/input-pattern.json
+++ b/features-json/input-pattern.json
@@ -10,7 +10,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-pattern",
-      "title":"Mozilla Developer Network (MDN) documentation - input element: pattern attribute"
+      "title":"MDN Web Docs - input element: pattern attribute"
     }
   ],
   "bugs":[

--- a/features-json/insert-adjacent.json
+++ b/features-json/insert-adjacent.json
@@ -10,11 +10,11 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/Element/insertAdjacentElement",
-      "title":"Mozilla Developer Network (MDN) documentation - Element.insertAdjacentElement()"
+      "title":"MDN Web Docs - Element.insertAdjacentElement()"
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/Element/insertAdjacentText",
-      "title":"Mozilla Developer Network (MDN) documentation - Element.insertAdjacentText()"
+      "title":"MDN Web Docs - Element.insertAdjacentText()"
     },
     {
       "url":"http://jsbin.com/yanadu/edit?html,js,output",

--- a/features-json/insertadjacenthtml.json
+++ b/features-json/insertadjacenthtml.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/Element/insertAdjacentHTML",
-      "title":"Mozilla Developer Network (MDN) documentation - insertAdjacentHTML"
+      "title":"MDN Web Docs - insertAdjacentHTML"
     },
     {
       "url":"https://gist.github.com/eligrey/1276030",

--- a/features-json/internationalization.json
+++ b/features-json/internationalization.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
-      "title":"Mozilla Developer Network (MDN) documentation - Internationalization"
+      "title":"MDN Web Docs - Internationalization"
     },
     {
       "url":"http://norbertlindenberg.com/2012/12/ecmascript-internationalization-api/",

--- a/features-json/intersectionobserver.json
+++ b/features-json/intersectionobserver.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API",
-      "title":"Mozilla Developer Network (MDN) documentation - Intersection Observer"
+      "title":"MDN Web Docs - Intersection Observer"
     },
     {
       "url":"https://github.com/WICG/IntersectionObserver/tree/gh-pages/polyfill",

--- a/features-json/json.json
+++ b/features-json/json.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/En/Using_native_JSON",
-      "title":"Mozilla Developer Network (MDN) documentation - Using JSON"
+      "title":"MDN Web Docs - Using JSON"
     },
     {
       "url":"http://www.json.org/js.html",

--- a/features-json/kerning-pairs-ligatures.json
+++ b/features-json/kerning-pairs-ligatures.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/text-rendering",
-      "title":"Mozilla Developer Network (MDN) documentation - CSS text-rendering"
+      "title":"MDN Web Docs - CSS text-rendering"
     },
     {
       "url":"http://css-tricks.com/almanac/properties/t/text-rendering/",

--- a/features-json/keyboardevent-charcode.json
+++ b/features-json/keyboardevent-charcode.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/charCode",
-      "title":"Mozilla Developer Network (MDN) documentation - charCode"
+      "title":"MDN Web Docs - charCode"
     }
   ],
   "bugs":[

--- a/features-json/keyboardevent-code.json
+++ b/features-json/keyboardevent-code.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code",
-      "title":"Mozilla Developer Network (MDN) documentation - code"
+      "title":"MDN Web Docs - code"
     },
     {
       "url":"https://code.google.com/p/chromium/issues/detail?id=227231",

--- a/features-json/keyboardevent-getmodifierstate.json
+++ b/features-json/keyboardevent-getmodifierstate.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/getModifierState",
-      "title":"Mozilla Developer Network (MDN) documentation - getModifierState"
+      "title":"MDN Web Docs - getModifierState"
     },
     {
       "url":"https://bugs.webkit.org/show_bug.cgi?id=40999",

--- a/features-json/keyboardevent-key.json
+++ b/features-json/keyboardevent-key.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key",
-      "title":"Mozilla Developer Network (MDN) documentation - key"
+      "title":"MDN Web Docs - key"
     },
     {
       "url":"https://code.google.com/p/chromium/issues/detail?id=227231",

--- a/features-json/keyboardevent-location.json
+++ b/features-json/keyboardevent-location.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/location",
-      "title":"Mozilla Developer Network (MDN) documentation - location"
+      "title":"MDN Web Docs - location"
     }
   ],
   "bugs":[

--- a/features-json/keyboardevent-which.json
+++ b/features-json/keyboardevent-which.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/which",
-      "title":"Mozilla Developer Network (MDN) documentation - which"
+      "title":"MDN Web Docs - which"
     }
   ],
   "bugs":[

--- a/features-json/let.json
+++ b/features-json/let.json
@@ -10,7 +10,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let",
-      "title":"Mozilla Developer Network (MDN) documentation - let"
+      "title":"MDN Web Docs - let"
     }
   ],
   "bugs":[

--- a/features-json/link-rel-preload.json
+++ b/features-json/link-rel-preload.json
@@ -14,7 +14,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/HTML/Preloading_content",
-      "title":"Mozilla Developer Network (MDN) documentation - Preloading content with rel=\"preload\""
+      "title":"MDN Web Docs - Preloading content with rel=\"preload\""
     }
   ],
   "bugs":[

--- a/features-json/matchesselector.json
+++ b/features-json/matchesselector.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en/docs/Web/API/Element/matches",
-      "title":"Mozilla Developer Network (MDN) documentation - Element matches"
+      "title":"MDN Web Docs - Element matches"
     },
     {
       "url":"https://www.webplatform.org/docs/dom/HTMLElement/matches",

--- a/features-json/matchmedia.json
+++ b/features-json/matchmedia.json
@@ -10,11 +10,11 @@
     },
     {
       "url":"https://developer.mozilla.org/en/DOM/window.matchMedia",
-      "title":"Mozilla Developer Network (MDN) documentation - matchMedia"
+      "title":"MDN Web Docs - matchMedia"
     },
     {
       "url":"https://developer.mozilla.org/en/CSS/Using_media_queries_from_code",
-      "title":"Mozilla Developer Network (MDN) documentation - Using matchMedia"
+      "title":"MDN Web Docs - Using matchMedia"
     },
     {
       "url":"https://www.webplatform.org/docs/css/media_queries/apis/matchMedia",

--- a/features-json/mathml.json
+++ b/features-json/mathml.json
@@ -18,7 +18,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en/MathML/Element",
-      "title":"Mozilla Developer Network (MDN) documentation - MathML Element"
+      "title":"MDN Web Docs - MathML Element"
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Mozilla/MathML_Project/MathML_Torture_Test",

--- a/features-json/maxlength.json
+++ b/features-json/maxlength.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-maxlength",
-      "title":"Mozilla Developer Network (MDN) documentation - attribute maxlength"
+      "title":"MDN Web Docs - attribute maxlength"
     }
   ],
   "bugs":[

--- a/features-json/mediacapture-fromelement.json
+++ b/features-json/mediacapture-fromelement.json
@@ -6,11 +6,11 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/captureStream",
-      "title":"Mozilla Developer Network (MDN) documentation - capture from <canvas>"
+      "title":"MDN Web Docs - capture from <canvas>"
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/captureStream",
-      "title":"Mozilla Developer Network (MDN) documentation - capture from <video>/<audio>"
+      "title":"MDN Web Docs - capture from <video>/<audio>"
     },
     {
       "url":"https://www.chromestatus.com/features/4817998447640576",

--- a/features-json/mediarecorder.json
+++ b/features-json/mediarecorder.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/MediaRecorder_API",
-      "title":"Mozilla Developer Network (MDN) documentation - MediaRecorder"
+      "title":"MDN Web Docs - MediaRecorder"
     }
   ],
   "bugs":[

--- a/features-json/mediasource.json
+++ b/features-json/mediasource.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/MediaSource#Browser_compatibility",
-      "title":"Mozilla Developer Network (MDN) documentation - MediaSource"
+      "title":"MDN Web Docs - MediaSource"
     },
     {
       "url":"https://msdn.microsoft.com/en-us/library/dn594470%28v=vs.85%29.aspx",

--- a/features-json/meter.json
+++ b/features-json/meter.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meter",
-      "title":"Mozilla Developer Network (MDN) documentation - Element meter"
+      "title":"MDN Web Docs - Element meter"
     },
     {
       "url":"http://html5doctor.com/measure-up-with-the-meter-tag/",

--- a/features-json/mutation-events.json
+++ b/features-json/mutation-events.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/Guide/Events/Mutation_events",
-      "title":"Mozilla Developer Network (MDN) documentation - Mutation events"
+      "title":"MDN Web Docs - Mutation events"
     }
   ],
   "bugs":[

--- a/features-json/namevalue-storage.json
+++ b/features-json/namevalue-storage.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/Web_Storage_API",
-      "title":"Mozilla Developer Network (MDN) documentation - Web Storage"
+      "title":"MDN Web Docs - Web Storage"
     },
     {
       "url":"http://code.google.com/p/sessionstorage/",

--- a/features-json/nav-timing.json
+++ b/features-json/nav-timing.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en/API/navigationTiming",
-      "title":"Mozilla Developer Network (MDN) documentation - Navigation Timing"
+      "title":"MDN Web Docs - Navigation Timing"
     },
     {
       "url":"http://www.html5rocks.com/en/tutorials/webperformance/basics/",

--- a/features-json/node-contains.json
+++ b/features-json/node-contains.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/Node/contains",
-      "title":"Mozilla Developer Network (MDN) documentation - Node.contains"
+      "title":"MDN Web Docs - Node.contains"
     }
   ],
   "bugs":[

--- a/features-json/node-parentelement.json
+++ b/features-json/node-parentelement.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/Node/parentElement",
-      "title":"Mozilla Developer Network (MDN) documentation - Node.parentElement"
+      "title":"MDN Web Docs - Node.parentElement"
     }
   ],
   "bugs":[

--- a/features-json/notifications.json
+++ b/features-json/notifications.json
@@ -18,7 +18,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/notification",
-      "title":"Mozilla Developer Network (MDN) documentation - Notification"
+      "title":"MDN Web Docs - Notification"
     },
     {
       "url":"http://www.sitepoint.com/introduction-web-notifications-api/",

--- a/features-json/online-status.json
+++ b/features-json/online-status.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/NavigatorOnLine.onLine#Specification",
-      "title":"Mozilla Developer Network (MDN) documentation - NavigatorOnLine.onLine"
+      "title":"MDN Web Docs - NavigatorOnLine.onLine"
     }
   ],
   "bugs":[

--- a/features-json/outline.json
+++ b/features-json/outline.json
@@ -10,7 +10,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/CSS/outline",
-      "title":"Mozilla Developer Network (MDN) documentation - CSS outline"
+      "title":"MDN Web Docs - CSS outline"
     }
   ],
   "bugs":[

--- a/features-json/pad-start-end.json
+++ b/features-json/pad-start-end.json
@@ -6,11 +6,11 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/padStart",
-      "title":"Mozilla Developer Network (MDN) documentation - padStart()"
+      "title":"MDN Web Docs - padStart()"
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/padEnd",
-      "title":"Mozilla Developer Network (MDN) documentation - padEnd()"
+      "title":"MDN Web Docs - padEnd()"
     }
   ],
   "bugs":[

--- a/features-json/page-transition-events.json
+++ b/features-json/page-transition-events.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/Events/pageshow",
-      "title":"Mozilla Developer Network (MDN) documentation - pageshow"
+      "title":"MDN Web Docs - pageshow"
     },
     {
       "url":"http://www.w3schools.com/tags/ev_onpageshow.asp",

--- a/features-json/pagevisibility.json
+++ b/features-json/pagevisibility.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/DOM/Using_the_Page_Visibility_API",
-      "title":"Mozilla Developer Network (MDN) documentation - Page Visibility"
+      "title":"MDN Web Docs - Page Visibility"
     },
     {
       "url":"https://docs.webplatform.org/wiki/dom/Document/visibilityState",

--- a/features-json/payment-request.json
+++ b/features-json/payment-request.json
@@ -18,7 +18,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/Payment_Request_API",
-      "title":"Mozilla Developer Network (MDN) documentation - Payment Request API"
+      "title":"MDN Web Docs - Payment Request API"
     },
     {
       "url":"https://emerald-eon.appspot.com/",

--- a/features-json/ping.json
+++ b/features-json/ping.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-ping",
-      "title":"Mozilla Developer Network (MDN) documentation - Element ping attribute"
+      "title":"MDN Web Docs - Element ping attribute"
     },
     {
       "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6996308-implement-hyperlink-auditing-aka-the-ping-attribu",

--- a/features-json/pointerlock.json
+++ b/features-json/pointerlock.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/Pointer_Lock_API",
-      "title":"Mozilla Developer Network (MDN) documentation - Pointer Lock"
+      "title":"MDN Web Docs - Pointer Lock"
     },
     {
       "url":"http://mdn.github.io/pointer-lock-demo",

--- a/features-json/progress.json
+++ b/features-json/progress.json
@@ -10,7 +10,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/HTML/Element/progress",
-      "title":"Mozilla Developer Network (MDN) documentation - Element progress"
+      "title":"MDN Web Docs - Element progress"
     },
     {
       "url":"https://dev.opera.com/articles/new-form-features-in-html5/#newoutput",

--- a/features-json/proxy.json
+++ b/features-json/proxy.json
@@ -10,7 +10,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy",
-      "title":"Mozilla Developer Network (MDN) documentation - Proxy"
+      "title":"MDN Web Docs - Proxy"
     },
     {
       "url":"http://www.nczonline.net/blog/2011/09/15/experimenting-with-ecmascript-6-proxies/",

--- a/features-json/publickeypinning.json
+++ b/features-json/publickeypinning.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/Security/Public_Key_Pinning",
-      "title":"Mozilla Developer Network (MDN) documentation - Public Key Pinning"
+      "title":"MDN Web Docs - Public Key Pinning"
     }
   ],
   "bugs":[

--- a/features-json/push-api.json
+++ b/features-json/push-api.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/Push_API",
-      "title":"Mozilla Developer Network (MDN) documentation - Push API"
+      "title":"MDN Web Docs - Push API"
     },
     {
       "url":"https://developers.google.com/web/updates/2015/03/push-notifications-on-the-open-web",

--- a/features-json/queryselector.json
+++ b/features-json/queryselector.json
@@ -6,11 +6,11 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en/DOM/element.querySelector",
-      "title":"Mozilla Developer Network (MDN) documentation - querySelector"
+      "title":"MDN Web Docs - querySelector"
     },
     {
       "url":"https://developer.mozilla.org/En/DOM/Element.querySelectorAll",
-      "title":"Mozilla Developer Network (MDN) documentation - querySelectorAll"
+      "title":"MDN Web Docs - querySelectorAll"
     },
     {
       "url":"http://cjihrig.com/blog/javascripts-selectors-api/",

--- a/features-json/readonly-attr.json
+++ b/features-json/readonly-attr.json
@@ -10,7 +10,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Input#attr-readonly",
-      "title":"Mozilla Developer Network (MDN) documentation - readonly attribute"
+      "title":"MDN Web Docs - readonly attribute"
     }
   ],
   "bugs":[

--- a/features-json/registerprotocolhandler.json
+++ b/features-json/registerprotocolhandler.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/Navigator/registerProtocolHandler",
-      "title":"Mozilla Developer Network (MDN) documentation - Register protocol handler"
+      "title":"MDN Web Docs - Register protocol handler"
     }
   ],
   "bugs":[

--- a/features-json/rellist.json
+++ b/features-json/rellist.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/DOM/DOMTokenList",
-      "title":"Mozilla Developer Network (MDN) documentation - DOMTokenList"
+      "title":"MDN Web Docs - DOMTokenList"
     },
     {
       "url":"https://github.com/jwilsson/domtokenlist",

--- a/features-json/requestanimationframe.json
+++ b/features-json/requestanimationframe.json
@@ -18,7 +18,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame",
-      "title":"Mozilla Developer Network (MDN) documentation - requestAnimationFrame"
+      "title":"MDN Web Docs - requestAnimationFrame"
     }
   ],
   "bugs":[

--- a/features-json/requestidlecallback.json
+++ b/features-json/requestidlecallback.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/Window/requestIdleCallback",
-      "title":"Mozilla Developer Network (MDN) documentation - requestIdleCallback"
+      "title":"MDN Web Docs - requestIdleCallback"
     },
     {
       "url":"https://developers.google.com/web/updates/2015/08/using-requestidlecallback",

--- a/features-json/screen-orientation.json
+++ b/features-json/screen-orientation.json
@@ -10,7 +10,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/Screen.orientation",
-      "title":"Mozilla Developer Network (MDN) documentation - Screen Orientation"
+      "title":"MDN Web Docs - Screen Orientation"
     },
     {
       "url":"http://www.sitepoint.com/introducing-screen-orientation-api/",

--- a/features-json/script-async.json
+++ b/features-json/script-async.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en/HTML/Element/script#Attributes",
-      "title":"Mozilla Developer Network (MDN) documentation - Script attributes"
+      "title":"MDN Web Docs - Script attributes"
     },
     {
       "url":"http://ie.microsoft.com/testdrive/Performance/AsyncScripts/Default.html",

--- a/features-json/script-defer.json
+++ b/features-json/script-defer.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en/HTML/Element/script#Attributes",
-      "title":"Mozilla Developer Network (MDN) documentation - Script Attributes"
+      "title":"MDN Web Docs - Script Attributes"
     },
     {
       "url":"https://raw.github.com/phiggins42/has.js/master/detect/script.js#script-defer",

--- a/features-json/scrollintoview.json
+++ b/features-json/scrollintoview.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView",
-      "title":"Mozilla Developer Network (MDN) documentation - scrollIntoView"
+      "title":"MDN Web Docs - scrollIntoView"
     }
   ],
   "bugs":[

--- a/features-json/serviceworkers.json
+++ b/features-json/serviceworkers.json
@@ -10,7 +10,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorker_API",
-      "title":"Mozilla Developer Network (MDN) documentation - Service Workers"
+      "title":"MDN Web Docs - Service Workers"
     },
     {
       "url":"https://jakearchibald.github.io/isserviceworkerready/resources.html",

--- a/features-json/spellcheck-attribute.json
+++ b/features-json/spellcheck-attribute.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/HTML/Controlling_spell_checking_in_HTML_formsControlling_spell_checking_in_HTML_forms",
-      "title":"Mozilla Developer Network (MDN) documentation - Controlling spell checking"
+      "title":"MDN Web Docs - Controlling spell checking"
     }
   ],
   "bugs":[

--- a/features-json/stopimmediatepropagation.json
+++ b/features-json/stopimmediatepropagation.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/Event/stopImmediatePropagation",
-      "title":"Mozilla Developer Network (MDN) documentation - stopImmediatePropagation"
+      "title":"MDN Web Docs - stopImmediatePropagation"
     }
   ],
   "bugs":[

--- a/features-json/stricttransportsecurity.json
+++ b/features-json/stricttransportsecurity.json
@@ -10,7 +10,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Security/HTTP_Strict_Transport_Security",
-      "title":"Mozilla Developer Network (MDN) documentation - Strict Transport Security"
+      "title":"MDN Web Docs - Strict Transport Security"
     },
     {
       "url":"https://www.owasp.org/index.php/HTTP_Strict_Transport_Security",

--- a/features-json/svg-html.json
+++ b/features-json/svg-html.json
@@ -6,11 +6,11 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en/SVG/Tutorial/Other_content_in_SVG",
-      "title":"Mozilla Developer Network (MDN) documentation - Other content in SVG"
+      "title":"MDN Web Docs - Other content in SVG"
     },
     {
       "url":"https://developer.mozilla.org/En/Applying_SVG_effects_to_HTML_content",
-      "title":"Mozilla Developer Network (MDN) documentation - Applying SVG effects"
+      "title":"MDN Web Docs - Applying SVG effects"
     },
     {
       "url":"http://www.w3.org/TR/filter-effects/",

--- a/features-json/svg-smil.json
+++ b/features-json/svg-smil.json
@@ -10,7 +10,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en/SVG/SVG_animation_with_SMIL",
-      "title":"Mozilla Developer Network (MDN) documentation - animation with SMIL"
+      "title":"MDN Web Docs - animation with SMIL"
     },
     {
       "url":"http://leunen.me/fakesmile/",

--- a/features-json/tabindex-attr.json
+++ b/features-json/tabindex-attr.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex",
-      "title":"Mozilla Developer Network (MDN) documentation - tabindex attribute"
+      "title":"MDN Web Docs - tabindex attribute"
     }
   ],
   "bugs":[

--- a/features-json/template-literals.json
+++ b/features-json/template-literals.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals",
-      "title":"Mozilla Developer Network (MDN) documentation - Template literals"
+      "title":"MDN Web Docs - Template literals"
     },
     {
       "url":"https://ponyfoo.com/articles/es6-template-strings-in-depth",

--- a/features-json/text-decoration.json
+++ b/features-json/text-decoration.json
@@ -22,7 +22,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-skip",
-      "title":"MDN Documentation for text-decoration-skip"
+      "title":"Mozilla Developer Network (MDN) documentation - text-decoration-skip"
     },
     {
       "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=812990",

--- a/features-json/text-decoration.json
+++ b/features-json/text-decoration.json
@@ -6,15 +6,15 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style",
-      "title":"Mozilla Developer Network (MDN) documentation - text-decoration-style"
+      "title":"MDN Web Docs - text-decoration-style"
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color",
-      "title":"Mozilla Developer Network (MDN) documentation - text-decoration-color"
+      "title":"MDN Web Docs - text-decoration-color"
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line",
-      "title":"Mozilla Developer Network (MDN) documentation - text-decoration-line"
+      "title":"MDN Web Docs - text-decoration-line"
     },
     {
       "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6514536-text-decoration-styling",
@@ -22,7 +22,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-skip",
-      "title":"Mozilla Developer Network (MDN) documentation - text-decoration-skip"
+      "title":"MDN Web Docs - text-decoration-skip"
     },
     {
       "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=812990",

--- a/features-json/text-emphasis.json
+++ b/features-json/text-emphasis.json
@@ -14,7 +14,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/text-emphasis",
-      "title":"Mozilla Developer Network (MDN) documentation - text-emphasis"
+      "title":"MDN Web Docs - text-emphasis"
     }
   ],
   "bugs":[

--- a/features-json/text-overflow.json
+++ b/features-json/text-overflow.json
@@ -10,7 +10,7 @@
     },
     {
       "url":"https://developer.mozilla.org/En/CSS/Text-overflow",
-      "title":"Mozilla Developer Network (MDN) documentation - text-overflow"
+      "title":"MDN Web Docs - text-overflow"
     },
     {
       "url":"https://raw.github.com/phiggins42/has.js/master/detect/css.js#css-text-overflow",

--- a/features-json/text-size-adjust.json
+++ b/features-json/text-size-adjust.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/text-size-adjust",
-      "title":"Mozilla Developer Network (MDN) documentation - text-size-adjust"
+      "title":"MDN Web Docs - text-size-adjust"
     },
     {
       "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=1226116",

--- a/features-json/text-stroke.json
+++ b/features-json/text-stroke.json
@@ -14,7 +14,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-text-stroke",
-      "title":"Mozilla Developer Network (MDN) documentation - text-stroke"
+      "title":"MDN Web Docs - text-stroke"
     }
   ],
   "bugs":[

--- a/features-json/textcontent.json
+++ b/features-json/textcontent.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent",
-      "title":"Mozilla Developer Network (MDN) documentation - Node.textContent"
+      "title":"MDN Web Docs - Node.textContent"
     }
   ],
   "bugs":[

--- a/features-json/textencoder.json
+++ b/features-json/textencoder.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/TextEncoder",
-      "title":"Mozilla Developer Network (MDN) documentation - TextEncoder"
+      "title":"MDN Web Docs - TextEncoder"
     },
     {
       "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6558040-support-the-encoding-api",

--- a/features-json/transforms2d.json
+++ b/features-json/transforms2d.json
@@ -10,7 +10,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/transform",
-      "title":"Mozilla Developer Network (MDN) documentation - CSS transform"
+      "title":"MDN Web Docs - CSS transform"
     },
     {
       "url":"http://www.webresourcesdepot.com/cross-browser-css-transforms-csssandpaper/",

--- a/features-json/typedarrays.json
+++ b/features-json/typedarrays.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en/javascript_typed_arrays",
-      "title":"Mozilla Developer Network (MDN) documentation - Typed arrays"
+      "title":"MDN Web Docs - Typed arrays"
     }
   ],
   "bugs":[

--- a/features-json/upgradeinsecurerequests.json
+++ b/features-json/upgradeinsecurerequests.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/Security/CSP/CSP_policy_directives#upgrade-insecure-requests",
-      "title":"Mozilla Developer Network (MDN) documentation - Upgrade Insecure Requests"
+      "title":"MDN Web Docs - Upgrade Insecure Requests"
     },
     {
       "url":"https://googlechrome.github.io/samples/csp-upgrade-insecure-requests/index.html",

--- a/features-json/url.json
+++ b/features-json/url.json
@@ -6,11 +6,11 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/URL",
-      "title":"Mozilla Developer Network (MDN) documentation - URL interface"
+      "title":"MDN Web Docs - URL interface"
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/URL/URL",
-      "title":"Mozilla Developer Network (MDN) documentation - URL constructor"
+      "title":"MDN Web Docs - URL constructor"
     }
   ],
   "bugs":[

--- a/features-json/urlsearchparams.json
+++ b/features-json/urlsearchparams.json
@@ -10,7 +10,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams",
-      "title":"Mozilla Developer Network (MDN) documentation - URLSearchParams"
+      "title":"MDN Web Docs - URLSearchParams"
     },
     {
       "url":"https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/8993198/",

--- a/features-json/user-select-none.json
+++ b/features-json/user-select-none.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/CSS/user-select",
-      "title":"Mozilla Developer Network (MDN) documentation - CSS user-select"
+      "title":"MDN Web Docs - CSS user-select"
     },
     {
       "url":"http://css-tricks.com/almanac/properties/u/user-select/",

--- a/features-json/vibration.json
+++ b/features-json/vibration.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/Guide/API/Vibration",
-      "title":"Mozilla Developer Network (MDN) documentation - Vibration"
+      "title":"MDN Web Docs - Vibration"
     },
     {
       "url":"http://davidwalsh.name/vibration-api",

--- a/features-json/wbr-element.json
+++ b/features-json/wbr-element.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/HTML/Element/wbr",
-      "title":"Mozilla Developer Network (MDN) documentation - Element wbr"
+      "title":"MDN Web Docs - Element wbr"
     }
   ],
   "bugs":[

--- a/features-json/web-app-manifest.json
+++ b/features-json/web-app-manifest.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/Manifest",
-      "title":"Mozilla Developer Network (MDN) documentation - Web App Manifest"
+      "title":"MDN Web Docs - Web App Manifest"
     },
     {
       "url":"https://webmanife.st",

--- a/features-json/websockets.json
+++ b/features-json/websockets.json
@@ -26,7 +26,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API",
-      "title":"Mozilla Developer Network (MDN) documentation - WebSockets API"
+      "title":"MDN Web Docs - WebSockets API"
     }
   ],
   "bugs":[

--- a/features-json/webvr.json
+++ b/features-json/webvr.json
@@ -22,7 +22,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/WebVR_API",
-      "title":"Mozilla Developer Network (MDN) documentation - WebVR API"
+      "title":"MDN Web Docs - WebVR API"
     }
   ],
   "bugs":[

--- a/features-json/webvtt.json
+++ b/features-json/webvtt.json
@@ -14,7 +14,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/WebVTT_API",
-      "title":"Mozilla Developer Network (MDN) documentation - WebVTT"
+      "title":"MDN Web Docs - WebVTT"
     }
   ],
   "bugs":[

--- a/features-json/webworkers.json
+++ b/features-json/webworkers.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/En/Using_web_workers",
-      "title":"Mozilla Developer Network (MDN) documentation - Using Web Workers"
+      "title":"MDN Web Docs - Using Web Workers"
     },
     {
       "url":"http://nerget.com/rayjs-mt/rayjs.html",

--- a/features-json/will-change.json
+++ b/features-json/will-change.json
@@ -14,7 +14,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/will-change",
-      "title":"Mozilla Developer Network (MDN) documentation - will-change"
+      "title":"MDN Web Docs - will-change"
     }
   ],
   "bugs":[

--- a/features-json/word-break.json
+++ b/features-json/word-break.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en/CSS/word-break",
-      "title":"Mozilla Developer Network (MDN) documentation - CSS word-break"
+      "title":"MDN Web Docs - CSS word-break"
     },
     {
       "url":"https://www.webplatform.org/docs/css/properties/word-break",

--- a/features-json/wordwrap.json
+++ b/features-json/wordwrap.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/En/CSS/Word-wrap",
-      "title":"Mozilla Developer Network (MDN) documentation - CSS word-wrap"
+      "title":"MDN Web Docs - CSS word-wrap"
     },
     {
       "url":"https://www.webplatform.org/docs/css/properties/word-wrap",

--- a/features-json/x-doc-messaging.json
+++ b/features-json/x-doc-messaging.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en/DOM/window.postMessage",
-      "title":"Mozilla Developer Network (MDN) documentation - window.postMessage"
+      "title":"MDN Web Docs - window.postMessage"
     },
     {
       "url":"http://html5demos.com/postmessage2",

--- a/features-json/x-frame-options.json
+++ b/features-json/x-frame-options.json
@@ -10,7 +10,7 @@
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options",
-      "title":"Mozilla Developer Network (MDN) documentation - X-Frame-Options"
+      "title":"MDN Web Docs - X-Frame-Options"
     },
     {
       "url":"https://www.owasp.org/index.php/Clickjacking_Defense_Cheat_Sheet",

--- a/features-json/xhr2.json
+++ b/features-json/xhr2.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en/XMLHttpRequest/FormData",
-      "title":"Mozilla Developer Network (MDN) documentation - FormData"
+      "title":"MDN Web Docs - FormData"
     },
     {
       "url":"https://github.com/jimmywarting/FormData",

--- a/features-json/xml-serializer.json
+++ b/features-json/xml-serializer.json
@@ -6,7 +6,7 @@
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/XMLSerializer",
-      "title":"Mozilla Developer Network (MDN) documentation - XMLSerializer"
+      "title":"MDN Web Docs - XMLSerializer"
     },
     {
       "url":"http://ejohn.org/blog/dom-insertadjacenthtml/",


### PR DESCRIPTION
[The first commit](https://github.com/Fyrd/caniuse/commit/bb5bef96af2a318b367c7f97585a0fc406399f3c) standardizes a few remaining titles which were missed in https://github.com/Fyrd/caniuse/pull/3334.

[The second commit](https://github.com/Fyrd/caniuse/commit/ae9f96e55f7f2a9ef6f4a6e578f7c4d0f89b5264) replaces all occurrences of “Mozilla Developer Network (MDN) documentation” with “MDN Web Docs”. From [*The Future of MDN: A Focus on Web Docs*](https://blog.mozilla.org/opendesign/future-mdn-focus-web-docs/) (on June 6, 2017):

> MDN is clearly a web documentation reference, and in no way is it a developer network. We want the name to clearly reflect the purpose and mission of MDN, and so we’re going to be updating it to: MDN Web Docs.