### PR TITLE
Microsoft Edge does not support IndexedDB inside blob web workers

### DIFF
--- a/features-json/indexeddb.json
+++ b/features-json/indexeddb.json
@@ -30,6 +30,9 @@
     },
     {
       "description":"Chrome has a bug where a deleted indexedDB can be re-created when dev tools are open (fixed in latest builds) [see bug](https://code.google.com/p/chromium/issues/detail?id=539931)"
+    },
+    {
+      "description": "Microsoft Edge does not support IndexedDB inside blob web workers. [See issue](https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/5942817/)."
     }
   ],
   "categories":[
@@ -312,7 +315,7 @@
   },
   "notes":"",
   "notes_by_num":{
-    "1":"Partial support in IE 10 & 11 refers to a number of subfeatures [not being supported](http://codepen.io/cemerick/pen/Itymi).",
+    "1":"Partial support in IE 10 & 11 refers to a number of subfeatures [not being supported](http://codepen.io/cemerick/pen/Itymi). Edge does not support IndexedDB inside blob web workers. [See issue](https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/5942817/)",
     "2":"Partial support in Safari & iOS 8 & 9 refers to [seriously buggy behavior](http://www.raymondcamden.com/2014/09/25/IndexedDB-on-iOS-8-Broken-Bad/) as well as complete lack of support in WebViews."
   },
   "usage_perc_y":87.6,


### PR DESCRIPTION
Microsoft Edge does not support IndexedDB inside blob web workers. [See issue](https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/5942817/).