### PR TITLE
Update transforms3d.json

### DIFF
--- a/features-json/transforms3d.json
+++ b/features-json/transforms3d.json
@@ -328,7 +328,7 @@
   "notes":"",
   "notes_by_num":{
     "1":"Partial support in IE refers to not supporting [the transform-style: preserve-3d property](http://msdn.microsoft.com/en-us/library/ie/hh673529%28v=vs.85%29.aspx#the_ms_transform_style_property). This prevents nesting 3D transformed elements.",
-    "2":"Safari 9 & 10 are reported to still require a prefix for the related `backface-visibility` property."
+    "2":"Safari 9, 10 & 11 are reported to still require a prefix for the related `backface-visibility` property."
   },
   "usage_perc_y":91.18,
   "usage_perc_a":3.54,


### PR DESCRIPTION
Safari 9, 10 & 11 are reported to still require a prefix for the related `backface-visibility` property.