### PR TITLE
Update TLS 1.3 support for Chrome on Android

### DIFF
--- a/features-json/tls1-3.json
+++ b/features-json/tls1-3.json
@@ -276,7 +276,7 @@
       "37":"n"
     },
     "and_chr":{
-      "61":"u"
+      "61":"n d #1"
     },
     "and_ff":{
       "56":"u"
@@ -301,8 +301,7 @@
   },
   "notes":"",
   "notes_by_num":{
-    "1":"Can be enabled by setting the `security.tls.version.max` flag value to `4` at `about:flags`",
-    "2":"Can be enabled by setting \"Maximum TLS version enabled\" to \"TLS 1.3\"at `chrome://flags/`. Support is reported to have be currently enabled as of version 56 for 1/10th of all users."
+    "1":"Can be enabled by setting \"TLS 1.3\" to \"Enabled (Draft)\" at `chrome://flags/tls13-variant`."
   },
   "usage_perc_y":29.59,
   "usage_perc_a":0,


### PR DESCRIPTION
Chrome on Android 61 supports TLS 1.3 behind a flag, as verified by visiting https://www.ssllabs.com/ssltest/viewMyClient.html with the flag enabled.
Removed unreferenced notes so that the first note is #1.