### PR TITLE
Use “Path2D objects” heading for Path2D spec URL

### DIFF
--- a/features-json/path2d.json
+++ b/features-json/path2d.json
@@ -1,7 +1,7 @@
 {
   "title":"Path2D",
   "description":"Allows path objects to be declared on 2D canvas surfaces",
-  "spec":"https://html.spec.whatwg.org/multipage/canvas.html#dom-path2d",
+  "spec":"https://html.spec.whatwg.org/multipage/canvas.html#path2d-objects",
   "status":"ls",
   "links":[
     {


### PR DESCRIPTION
This makes https://html.spec.whatwg.org/multipage/canvas.html#path2d-objects the
spec URL for https://caniuse.com/#feat=path2d. That lets a (caniuse-based)
support annotation for the Path2D feature also appear in the developer edition
at https://html.spec.whatwg.org/dev/canvas.html#path2d-objects.

(The spec URL was https://html.spec.whatwg.org/multipage/canvas.html#dom-path2d
previously — which is the part of the spec about the Path2D() constructor — but
that isn’t present in the developer edition, so no Path2D support annotation
could appear in the developer edition.)