### PR TITLE
Don’t encode slash in input-selection spec URL

### DIFF
--- a/features-json/input-selection.json
+++ b/features-json/input-selection.json
@@ -1,7 +1,7 @@
 {
   "title":"Selection controls for input & textarea",
   "description":"Controls for setting and getting text selection via `setSelectionRange()` and the `selectionStart` & `selectionEnd` properties.",
-  "spec":"https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-textarea%2Finput-setselectionrange",
+  "spec":"https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-textarea/input-setselectionrange",
   "status":"ls",
   "links":[
     {


### PR DESCRIPTION
This makes #dom-textarea/input-setselectionrange the spec URL for
https://caniuse.com/#feat=input-selection. That form of the URL — with an actual
U+002F slash character rather than with that URL-encoded at %2F — matches the
formatting of the actual ID in the spec and so prevents an error that otherwise
occurs when building the spec output, with the caniuse-based support annotations,
from the HTML spec source.