### PR TITLE
CSS font-display: Supported in Chrome for Android 60+; Add Edge feature request

### DIFF
--- a/features-json/css-font-rendering-controls.json
+++ b/features-json/css-font-rendering-controls.json
@@ -15,6 +15,10 @@
     {
       "url":"https://css-tricks.com/font-display-masses/",
       "title":"CSS tricks article"
+    },
+    {
+      "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/14653365-prevent-fout-and-control-font-loading-with-css-fon",
+      "title":"Microsoft Edge feature request on UserVoice"
     }
   ],
   "bugs":[
@@ -277,7 +281,7 @@
       "37":"n d #1"
     },
     "and_chr":{
-      "61":"n d #1"
+      "61":"y"
     },
     "and_ff":{
       "56":"n"


### PR DESCRIPTION
Via <https://www.chromestatus.com/feature/4799947908055040>:

> Chrome for desktop release 60
Chrome for Android release 60
Android WebView release 60

=> +~30% support in the table B-)

(Android WebView is probably at least at v60 currently, which needs to be updated, and then changed to `y` 0:-))

Added the Edge feature request, too.