### PR TITLE
Add FF undraggable-unless-dataTransfer-is-set bug.

### DIFF
--- a/features-json/dragndrop.json
+++ b/features-json/dragndrop.json
@@ -61,6 +61,9 @@
     },
     {
       "description":"In Firefox, the dragging near the edge of scrollable regions does not cause [scrolling](https://bugzilla.mozilla.org/show_bug.cgi?id=41708)"
+    },
+    {
+      "description":"In Firefox, an element won't drag unless the `dragstart` handler sets `dataTransfer` data (even if it doesn't get retrieved). [Test case](https://codepen.io/michai/pen/NwORqO)"
     }
   ],
   "categories":[


### PR DESCRIPTION
The bug text includes a link to a codepen containing a test case for this (as well as the FF can't-drag-a-button bug).

https://codepen.io/michai/pen/NwORqO