### PR TITLE
Replace broken resource link for CSS ::selection

### DIFF
--- a/features-json/css-selection.json
+++ b/features-json/css-selection.json
@@ -9,8 +9,8 @@
       "title":"::selection test"
     },
     {
-      "url":"https://www.webplatform.org/docs/css/selectors/pseudo-elements/::selection",
-      "title":"WebPlatform Docs"
+      "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/::selection",
+      "title":"MDN web docs"
     }
   ],
   "bugs":[


### PR DESCRIPTION
The existing url <https://webplatform.github.io/docs/css/selectors/pseudo-elements/::selection> is returning 404 and the site itself has been [discontinued](https://github.com/webplatform/webplatform.github.io/).