### PR TITLE
Date input with min/max works fine

### DIFF
--- a/features-json/input-datetime.json
+++ b/features-json/input-datetime.json
@@ -26,9 +26,7 @@
     }
   ],
   "bugs":[
-    {
-      "description":"Chrome for Android grays out dates that are out of range (using `min` and `max` attributes), but does not prevent the user from selecting these dates."
-    }
+    
   ],
   "categories":[
     "HTML5"


### PR DESCRIPTION
This feature works as intended as of Chrome for Android 62. It was probably fixed in an earlier version.

I'm not sure in which version the bug was found, but the note was added in da91eb4b2fc5dad27bebd1e22e26ae20b211e5f3 (when Chrome 42 was stable).