### PR TITLE
Update resource-timing.json

### DIFF
--- a/features-json/resource-timing.json
+++ b/features-json/resource-timing.json
@@ -184,7 +184,7 @@
       "9.1":"n",
       "10":"n",
       "10.1":"n",
-      "11":"y",
+      "11":"a #2",
       "TP":"y"
     },
     "opera":{
@@ -306,7 +306,8 @@
   },
   "notes":"",
   "notes_by_num":{
-    "1":"Can be enabled in Firefox using the dom.enable_resource_timing flag"
+    "1":"Can be enabled in Firefox using the dom.enable_resource_timing flag",
+    "2":"Partial support in Safari refers to being limited to OSX 10.12+"
   },
   "usage_perc_y":89.13,
   "usage_perc_a":0,


### PR DESCRIPTION
Discovered with the help of my coworkers, and confirmed on twitter (https://twitter.com/JohnRiv/status/930532827103399943) that Resource Timing in Safari is not supported on OSX prior to Sierra.

Technology Preview is only available for Sierra & up so Safari 11 should be the only partial support occurrence. 