### PR TITLE
Safari TP 46: Service Workers enabled by default

### DIFF
--- a/features-json/serviceworkers.json
+++ b/features-json/serviceworkers.json
@@ -185,7 +185,7 @@
       "10":"n",
       "10.1":"n",
       "11":"n",
-      "TP":"n d #4"
+      "TP":"y"
     },
     "opera":{
       "9":"n",
@@ -308,8 +308,7 @@
   "notes_by_num":{
     "1":"Partial support can be enabled in Firefox with the `dom.serviceWorkers.enabled` flag.",
     "2":"Available behind the \"Enable service workers\" flag",
-    "3":"Disabled on Firefox ESR, but can be re-enabled with the `dom.serviceWorkers.enabled` flag",
-    "4":"Can be enabled via the \"Experimental Features\" developer menu"
+    "3":"Disabled on Firefox ESR, but can be re-enabled with the `dom.serviceWorkers.enabled` flag"
   },
   "usage_perc_y":65.22,
   "usage_perc_a":8.44,


### PR DESCRIPTION
<https://webkit.org/blog/8042/release-notes-for-safari-technology-preview-46/>

> Made Service Workers enabled by default 

Though

> **While work continues**, we’re excited to enable Service Workers by default in this release.

I was optimistic and chose `y`, but one could maybe(?) argue for partial, too.