### PR TITLE
Change demo page for battery status API

### DIFF
--- a/features-json/battery-status.json
+++ b/features-json/battery-status.json
@@ -9,7 +9,7 @@
       "title":"MDN Web Docs - battery status"
     },
     {
-      "url":"http://www.smartjava.org/examples/webapi-battery/",
+      "url":"http://pazguille.github.io/demo-battery-api/",
       "title":"Simple demo"
     }
   ],


### PR DESCRIPTION
Previous demo site only supports the outdated spec version.
New demo site supports both current and outdated spec version, and therefore works with Chrome.