### PR TITLE
Opus: Opera and Firefox support Opus in WebM

### DIFF
--- a/features-json/opus.json
+++ b/features-json/opus.json
@@ -18,9 +18,6 @@
     }
   ],
   "bugs":[
-    {
-      "description":"Opera and Firefox are reported to not support Opus in WebM files yet, only in OGG."
-    }
   ],
   "categories":[
     "Other"


### PR DESCRIPTION
Opera should be fine as it inherits Chrome's support. Firefox support is mentioned [here](https://support.mozilla.org/en-US/kb/html5-audio-and-video-firefox):

> Vorbis audio, Opus audio (...) can be viewed in Firefox if they are embedded in the following container formats: Ogg (.ogg, .oga, .ogv, .ogx, .spx, .opus file types) or WebM (.webm file type).

Verify by playing [this file](https://sebbro.nl/opus_test.webm) (thanks to https://freepd.com/), or by running the following:
```javascript
MediaSource.isTypeSupported('audio/webm; codecs=opus')
```