### PR TITLE
docs: add bug about IE/Edge truncating values #3946

### DIFF
--- a/features-json/calc.json
+++ b/features-json/calc.json
@@ -53,6 +53,9 @@
     },
     {
       "description":"Firefox does not support `calc()` on color functions. Example: `color: hsl(calc(60 * 2), 100%, 50%)`. [Bug Report](https://bugzilla.mozilla.org/show_bug.cgi?id=984021)"
+    },
+    {
+      "description":"IE and Edge truncate all units to 2 decimals places. Lengths comming from fractions may not be rendered with the expected value."
     }
   ],
   "categories":[

--- a/features-json/calc.json
+++ b/features-json/calc.json
@@ -55,7 +55,7 @@
       "description":"Firefox does not support `calc()` on color functions. Example: `color: hsl(calc(60 * 2), 100%, 50%)`. [Bug Report](https://bugzilla.mozilla.org/show_bug.cgi?id=984021)"
     },
     {
-      "description":"IE and Edge truncate all units to 2 decimals places. Lengths comming from fractions may not be rendered with the expected value."
+      "description":"IE and Edge truncate all units to 2 decimals places. Lengths coming from fractions may not be rendered with the expected value."
     }
   ],
   "categories":[

--- a/features-json/rem.json
+++ b/features-json/rem.json
@@ -30,7 +30,7 @@
       "description":"Causes content display and scrolling issues on iPhone 4 which typically has Safari 5.1."
     },
     {
-      "description":"IE and Edge truncate all units to 2 decimals places. Lengths comming from fractions may not be rendered with the expected value."
+      "description":"IE and Edge truncate all units to 2 decimals places. Lengths coming from fractions may not be rendered with the expected value."
     }
   ],
   "categories":[

--- a/features-json/rem.json
+++ b/features-json/rem.json
@@ -28,6 +28,9 @@
     },
     {
       "description":"Causes content display and scrolling issues on iPhone 4 which typically has Safari 5.1."
+    },
+    {
+      "description":"IE and Edge truncate all units to 2 decimals places. Lengths comming from fractions may not be rendered with the expected value."
     }
   ],
   "categories":[

--- a/features-json/viewport-units.json
+++ b/features-json/viewport-units.json
@@ -60,7 +60,7 @@
       "description":"`vh` on iOS is reported to include the height of the bottom toolbar in the height calculation, and the width of the sidebar (bookmarks) in the `vw` width calculation."
     },
     {
-      "description":"IE and Edge truncate all units to 2 decimals places. Lengths comming from fractions may not be rendered with the expected value."
+      "description":"IE and Edge truncate all units to 2 decimals places. Lengths coming from fractions may not be rendered with the expected value."
     }
   ],
   "categories":[

--- a/features-json/viewport-units.json
+++ b/features-json/viewport-units.json
@@ -58,6 +58,9 @@
     },
     {
       "description":"`vh` on iOS is reported to include the height of the bottom toolbar in the height calculation, and the width of the sidebar (bookmarks) in the `vw` width calculation."
+    },
+    {
+      "description":"IE and Edge truncate all units to 2 decimals places. Lengths comming from fractions may not be rendered with the expected value."
     }
   ],
   "categories":[


### PR DESCRIPTION
Changes: Add bug about IE/Edge truncating values to 2 decimals place, in `rem`, `viewport-units` and `calc()`. I think these are the 3 places were this bug can have big impacts.

Note: I tested `px`, `em`, `rem`, `%`, `vh`, `ex`, `ch` in IE 9-10 and Edge 14-15-16.

Closes https://github.com/Fyrd/caniuse/issues/3946
See: https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/961517/