### PR TITLE
datalist: Cleanup links

### DIFF
--- a/features-json/datalist.json
+++ b/features-json/datalist.json
@@ -17,20 +17,12 @@
       "title":"MDN Web Docs - datalist"
     },
     {
-      "url":"https://www.webplatform.org/docs/html/elements/datalist",
-      "title":"WebPlatform Docs"
-    },
-    {
       "url":"http://demo.agektmr.com/datalist/",
       "title":"Eiji Kitamura's options demos & tests"
     },
     {
       "url":"https://github.com/thgreasi/datalist-polyfill",
       "title":"Minimal Datalist polyfill w/tutorial"
-    },
-    {
-      "url":"https://github.com/mfranzke/datalist-polypill",
-      "title":"Minimal and library dependency-free vanilla JavaScript polypill"
     },
     {
       "url":"https://github.com/mfranzke/datalist-polyfill",


### PR DESCRIPTION
* R.I.P. WebPlatform.org
* Remove "polypill" [sic] misspelled duplicate