### PR TITLE
Add Safari bug information on display:contents

### DIFF
--- a/features-json/css-display-contents.json
+++ b/features-json/css-display-contents.json
@@ -22,7 +22,8 @@
     }
   ],
   "bugs":[
-    
+    {
+      "description":"iOS Safari 10 and 11, and Safari 11 renders `display:contents` as `display:inline`. @supports will also report as true."
   ],
   "categories":[
     "CSS"

--- a/features-json/css-display-contents.json
+++ b/features-json/css-display-contents.json
@@ -24,6 +24,7 @@
   "bugs":[
     {
       "description":"iOS Safari 10 and 11, and Safari 11 renders `display:contents` as `display:inline`. @supports will also report as true."
+    }
   ],
   "categories":[
     "CSS"


### PR DESCRIPTION
I wrote up [my notes](https://snook.ca/archives/html_and_css/safari-display-contents-bug) on this particular Safari bug and wanted to include it on Caniuse. I didn't link up my article so as not to be self-promotional but you can link up the article if you'd like.