### PR TITLE
Firefox 59 supports modules

### DIFF
--- a/features-json/es6-module.json
+++ b/features-json/es6-module.json
@@ -113,8 +113,8 @@
       "56":"n d #2",
       "57":"n d #2",
       "58":"n d #2",
-      "59":"n d #2",
-      "60":"n d #2"
+      "59":"y #4",
+      "60":"y"
     },
     "chrome":{
       "4":"n",
@@ -320,7 +320,8 @@
   "notes_by_num":{
     "1":"Support can be enabled via `about:flags`",
     "2":"Support can be enabled via `about:config`",
-    "3":"Support can be enabled via the `experimental-web-platform-features` flag"
+    "3":"Support can be enabled via the `experimental-web-platform-features` flag",
+    "4":"Enabled by default since 2018-01-10"
   },
   "usage_perc_y":63.98,
   "usage_perc_a":0,


### PR DESCRIPTION
The feature was enabled by default in Firefox 59 nightlies on 2018-01-10.

* [Upstream ticket](https://bugzilla.mozilla.org/show_bug.cgi?id=1428002)
* [Announcement tweet](https://twitter.com/FirefoxNightly/status/951382754125545473)