### PR TITLE
Update css-placeholder.json

### DIFF
--- a/features-json/css-placeholder.json
+++ b/features-json/css-placeholder.json
@@ -5,8 +5,8 @@
   "status":"wd",
   "links":[
     {
-      "url":"http://msdn.microsoft.com/en-us/library/ie/hh772745(v=vs.85).aspx",
-      "title":"MSDN article"
+      "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/::placeholder",
+      "title":"MDN web docs - ::placeholder"
     },
     {
       "url":"https://css-tricks.com/snippets/css/style-placeholder-text/",
@@ -15,10 +15,6 @@
     {
       "url":"http://wiki.csswg.org/ideas/placeholder-styling",
       "title":"CSSWG discussion"
-    },
-    {
-      "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/::-moz-placeholder",
-      "title":"MDN Web Docs - CSS ::-moz-placeholder"
     },
     {
       "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=1069012",


### PR DESCRIPTION
Microsoft article was erroneously redirecting to the MDN :placeholder-shown page, rather than the MDN ::placeholder page.