### PR TITLE
Removing spam link from css-masks links

### DIFF
--- a/features-json/css-masks.json
+++ b/features-json/css-masks.json
@@ -13,10 +13,6 @@
       "title":"HTML5 Rocks article"
     },
     {
-      "url":"http://thenittygritty.co/css-masking",
-      "title":"Detailed blog post"
-    },
-    {
       "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=1224422",
       "title":"Firefox implementation bug"
     },


### PR DESCRIPTION
The article on `thenittygritty.co` seems to be a spam link, i just get banners for some betting site instead of a CSS tutorial.