### PR TITLE
Update Safari data for image-set

### DIFF
--- a/features-json/css-image-set.json
+++ b/features-json/css-image-set.json
@@ -2,7 +2,7 @@
   "title":"CSS image-set",
   "description":"Method of letting the browser pick the most appropriate CSS background image from a given set, primarily for high PPI screens.",
   "spec":"https://drafts.csswg.org/css-images-4/#image-set-notation",
-  "status":"unoff",
+  "status":"wd",
   "links":[
     {
       "url":"http://cloudfour.com/examples/image-set/",
@@ -184,11 +184,11 @@
       "8":"y x",
       "9":"y x",
       "9.1":"y x",
-      "10":"y x",
-      "10.1":"y x",
-      "11":"y x",
-      "11.1":"y x",
-      "TP":"y x"
+      "10":"y #1",
+      "10.1":"y #1",
+      "11":"y #1",
+      "11.1":"y #1",
+      "TP":"y #1"
     },
     "opera":{
       "9":"n",
@@ -252,10 +252,10 @@
       "8.1-8.4":"y x",
       "9.0-9.2":"y x",
       "9.3":"y x",
-      "10.0-10.2":"y x",
-      "10.3":"y x",
-      "11.0-11.2":"y x",
-      "11.3":"y x"
+      "10.0-10.2":"y #1",
+      "10.3":"y #1",
+      "11.0-11.2":"y #1",
+      "11.3":"y #1"
     },
     "op_mini":{
       "all":"n"
@@ -312,7 +312,7 @@
   },
   "notes":"",
   "notes_by_num":{
-    
+    "1":"Safari's implementation does not completely match the spec, in that only URLs are accepted for the image value and only 'x' is accepted as a resolution. See https://bugs.webkit.org/show_bug.cgi?id=160934."
   },
   "usage_perc_y":83.13,
   "usage_perc_a":0,


### PR DESCRIPTION
image-set was unprefixed in Safari Technical Preview 9 (https://webkit.org/blog/6800/release-notes-for-safari-technology-preview-release-9), which was shipped in Safari 10 (I believe). Add a note that this is not completely spec-compliant.