### PR TITLE
Updating dead link in Intersection Observer

### DIFF
--- a/features-json/intersectionobserver.json
+++ b/features-json/intersectionobserver.json
@@ -9,7 +9,7 @@
       "title":"MDN Web Docs - Intersection Observer"
     },
     {
-      "url":"https://github.com/WICG/IntersectionObserver/tree/gh-pages/polyfill",
+      "url":"https://github.com/w3c/IntersectionObserver/tree/master/polyfill",
       "title":"Polyfill"
     },
     {


### PR DESCRIPTION
Not sure if it was better to link to GitHub or NPM. Here's the NPM link just in case:

https://www.npmjs.com/package/intersection-observer