### PR TITLE
update csp2 link to spec

### DIFF
--- a/features-json/contentsecuritypolicy2.json
+++ b/features-json/contentsecuritypolicy2.json
@@ -1,7 +1,7 @@
 {
   "title":"Content Security Policy Level 2",
   "description":"Mitigate cross-site scripting attacks by whitelisting allowed sources of script, style, and other resources. CSP 2 adds hash-source, nonce-source, and five new directives",
-  "spec":"https://www.w3.org/TR/CSP/",
+  "spec":"https://www.w3.org/TR/CSP2/",
   "status":"cr",
   "links":[
     {


### PR DESCRIPTION
The https://www.w3.org/TR/CSP link without version now redirects to the CSP3 spec, therefore for CSP2 the version must now be specified in the link.