### PR TITLE
Update dead MS connect link

### DIFF
--- a/features-json/innertext.json
+++ b/features-json/innertext.json
@@ -26,7 +26,9 @@
     }
   ],
   "bugs":[
-    
+    {
+      "description":"In IE10 and IE11, when using `innerText` (and also `innerHTML` or `outerHTML`) on a `textarea` which has a `placeholder` attribute, the returned HTML/text also uses the `placeholder`'s value as the actual `textarea`'s value. [See bug](https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/101525/)."
+    }
   ],
   "categories":[
     "DOM"

--- a/features-json/input-placeholder.json
+++ b/features-json/input-placeholder.json
@@ -33,7 +33,7 @@
       "description":"Internet Explorer 10 and 11 fire the input event when an input field with a placeholder [is focused](https://connect.microsoft.com/IE/feedback/details/885747/ie-11-fires-the-input-event-when-a-input-field-with-placeholder-is-focused) or on page load when the placeholder [contains certain characters](https://jsfiddle.net/yiminghe/fm3rckaz/), like Chinese. "
     },
     {
-      "description":"IE 10, 11 & above can accidentally [show placeholder attributes on textareas as their actual value](https://connect.microsoft.com/IE/feedback/details/811408/ie10-11-a-textareas-placeholder-text-becomes-its-actual-value-when-using-innertext-innerhtml-or-outerhtml) when using `innerHTML`, etc.\r\n"
+      "description":"IE 10, 11 & above can accidentally [show placeholder attributes on textareas as their actual value](https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/101525/) when using `innerHTML`, etc.\r\n"
     }
   ],
   "categories":[

--- a/features-json/xml-serializer.json
+++ b/features-json/xml-serializer.json
@@ -15,7 +15,7 @@
   ],
   "bugs":[
     {
-      "description":"In IE10 and IE11, when using `innerText`, `innerHTML` or `outerHTML` on a `textarea` which has a `placeholder` attribute, the returned HTML/text also uses the `placeholder`'s value as the actual `textarea`'s value. [See bug](https://connect.microsoft.com/IE/feedback/details/811408)."
+      "description":"In IE10 and IE11, when using `innerText`, `innerHTML` or `outerHTML` on a `textarea` which has a `placeholder` attribute, the returned HTML/text also uses the `placeholder`'s value as the actual `textarea`'s value. [See bug](https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/101525/)."
     },
     {
       "description":"innerHTML, insertAdjacentHTML, etc aren't supported or are read-only on the following elements in IE9 and below: col, colgroup, frameset, html, head, style, table, tbody, tfoot, thead, title, and tr."


### PR DESCRIPTION
MS Connect is dead.

The bug was moved from https://connect.microsoft.com/IE/feedback/details/811408/ie10-11-a-textareas-placeholder-text-becomes-its-actual-value-when-using-innertext-innerhtml-or-outerhtml to https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/101525/

I also mention the bug at the innertext features because it is effected as well.