### PR TITLE
Better description for `display:flow-root`

### DIFF
--- a/features-json/flow-root.json
+++ b/features-json/flow-root.json
@@ -1,6 +1,6 @@
 {
   "title":"display: flow-root",
-  "description":"The element generates a block container box, and lays out its contents using flow layout. It always establishes a new block formatting context for its contents. The result is the same as the \"clearfix\" hack.",
+  "description":"The element generates a block container box, and lays out its contents using flow layout. It always establishes a new block formatting context for its contents. It provides a better solution to the most use cases of the \"clearfix\" hack.",
   "spec":"https://www.w3.org/TR/css-display-3/#valdef-display-flow-root",
   "status":"wd",
   "links":[


### PR DESCRIPTION
The statement "The result [of display:flow-root] is the same as the "clearfix" hack" is misleading. The classic "clearfix" hack doesn't establish the new BFC. These two approaches result in the fundamentally different behavior regarding floats going _before_ the "clearfixed" container in the flow and margin collapsing of the descendants of that container ([demo of this difference](https://codepen.io/SelenIT/details/qrORXm)). I suggest different wording saying that it is the better (and standard) solution to the same problem, but not the full equivalent of "clearfix".