### PR TITLE
multicolumn.json - Add helpful workaround details to note about Firefox support

### DIFF
--- a/features-json/multicolumn.json
+++ b/features-json/multicolumn.json
@@ -349,7 +349,7 @@
   },
   "notes":"",
   "notes_by_num":{
-    "1":"Partial support refers to not supporting the `break-before`, `break-after`, `break-inside` properties. WebKit- and Blink-based browsers do have equivalent support for the non-standard `-webkit-column-break-*` properties to accomplish the same result (but only the `auto` and `always` values). Firefox does not support `break-*`.",
+    "1":"Partial support refers to not supporting the `break-before`, `break-after`, `break-inside` properties. WebKit- and Blink-based browsers do have equivalent support for the non-standard `-webkit-column-break-*` properties to accomplish the same result (but only the `auto` and `always` values). Firefox does not support `break-*` but does support the `page-break-*` properties to accomplish the same result.",
     "2":"Partial support refers to not supporting the `column-fill` property."
   },
   "usage_perc_y":86.53,


### PR DESCRIPTION
Add to note that `page-break-*` properties in Firefox can accomplish the same result as `break-` properties, as noted in https://bugzilla.mozilla.org/show_bug.cgi?id=549114 and tested in latest Firefox. Not sure how long this support has been available.