### PR TITLE
Clarify Chrome Variable Fonts Support

### DIFF
--- a/features-json/variable-fonts.json
+++ b/features-json/variable-fonts.json
@@ -97,15 +97,15 @@
       "50":"n",
       "51":"n",
       "52":"n",
-      "53":"n d #2 #4",
-      "54":"n d #2 #4",
-      "55":"n d #2 #4",
-      "56":"n d #2 #4",
-      "57":"n d #2 #4",
-      "58":"n d #2 #4",
-      "59":"n d #2 #4",
-      "60":"n d #2 #4",
-      "61":"n d #2 #4"
+      "53":"n d #2 #4 #5",
+      "54":"n d #2 #4 #5",
+      "55":"n d #2 #4 #5",
+      "56":"n d #2 #4 #5",
+      "57":"n d #2 #4 #5",
+      "58":"n d #2 #4 #5",
+      "59":"n d #2 #4 #5",
+      "60":"n d #2 #4 #5",
+      "61":"n d #2 #4 #5"
     },
     "chrome":{
       "4":"n",
@@ -166,10 +166,10 @@
       "59":"n d #1",
       "60":"n d #1",
       "61":"n d #1",
-      "62":"a #4",
-      "63":"a #4",
-      "64":"a #4",
-      "65":"a #4",
+      "62":"a #5",
+      "63":"a #5",
+      "64":"a #5",
+      "65":"a #5",
       "66":"y",
       "67":"y",
       "68":"y"
@@ -239,10 +239,10 @@
       "46":"n",
       "47":"n",
       "48":"n",
-      "49":"a #4",
-      "50":"a #4",
-      "51":"a #4",
-      "52":"a #4"
+      "49":"a #5",
+      "50":"a #5",
+      "51":"a #5",
+      "52":"a #5"
     },
     "ios_saf":{
       "3.2":"n",
@@ -318,7 +318,8 @@
     "1":"Works with Experimental Web Platform features enabled",
     "2":"Requires MacOS 10.12+ and the following about:config flags to be enabled:\r\n`layout.css.font-variations.enabled`,\r\n`gfx.downloadable_fonts.keep_variation_tables`",
     "3":"Requires MacOS 10.13+",
-    "4":"Does not support `format('*-variations')`"
+    "4":"Does not support the `font-weight` and `font-stretch` properties.",
+    "5":"Does not support `format('truetype-variations')`, `format('woff-variations')`, `format('woff2-variations')`"
   },
   "usage_perc_y":9.54,
   "usage_perc_a":56.09,

--- a/features-json/variable-fonts.json
+++ b/features-json/variable-fonts.json
@@ -19,7 +19,7 @@
   ],
   "bugs":[
     {
-      "description":"Chrome reportedly does not support `format('woff2-variations')` inside the `@font-face` block and has not made `font-weight` and `font-stretch` work on variable fonts yet."
+      "description":"Chrome supports `format('*-variations')` inside the `@font-face` block only starting from Chrome version 66."
     }
   ],
   "categories":[
@@ -170,9 +170,9 @@
       "63":"a #4",
       "64":"a #4",
       "65":"a #4",
-      "66":"a #4",
-      "67":"a #4",
-      "68":"a #4"
+      "66":"y",
+      "67":"y",
+      "68":"y"
     },
     "safari":{
       "3.1":"n",
@@ -318,7 +318,7 @@
     "1":"Works with Experimental Web Platform features enabled",
     "2":"Requires MacOS 10.12+ and the following about:config flags to be enabled:\r\n`layout.css.font-variations.enabled`,\r\n`gfx.downloadable_fonts.keep_variation_tables`",
     "3":"Requires MacOS 10.13+",
-    "4":"Does not support the `font-weight` and `font-stretch` properties, nor `format('truetype-variations')`"
+    "4":"Does not support `format('*-variations')`"
   },
   "usage_perc_y":9.54,
   "usage_perc_a":56.09,


### PR DESCRIPTION
format("*-variations") supported from M66, font-stretch and font-weight
in @font-face working, compare https://codepen.io/anon/pen/bvdOgV