### PR TITLE
Correct Firefox flag information for WebComponents

### DIFF
--- a/features-json/custom-elements.json
+++ b/features-json/custom-elements.json
@@ -126,9 +126,9 @@
       "56":"p d #1",
       "57":"p d #1",
       "58":"p d #1",
-      "59":"p d #1",
-      "60":"p d #1",
-      "61":"p d #1"
+      "59":"p d #2",
+      "60":"p d #2",
+      "61":"p d #2"
     },
     "chrome":{
       "4":"n",
@@ -338,7 +338,8 @@
   },
   "notes":"",
   "notes_by_num":{
-    "1":"Enabled through the \"dom.webcomponents.enabled\" preference in about:config"
+    "1":"Enabled through the \"dom.webcomponents.enabled\" preference in about:config",
+    "2":"Enabled through the \"dom.webcomponents.customelements.enabled\" preference in about:config"
   },
   "usage_perc_y":70.76,
   "usage_perc_a":0,

--- a/features-json/custom-elementsv1.json
+++ b/features-json/custom-elementsv1.json
@@ -110,9 +110,9 @@
       "56":"p d #2 #1",
       "57":"p d #2 #1",
       "58":"p d #2 #1",
-      "59":"a #1",
-      "60":"a #1",
-      "61":"a #1"
+      "59":"p d #3 #1",
+      "60":"p d #3 #1",
+      "61":"p d #3 #1"
     },
     "chrome":{
       "4":"n",
@@ -323,7 +323,8 @@
   "notes":"Chrome 36+/Opera 20+ implemented a previous version of Custom Elements (v0) that used `.registerElement()`. Other browsers are implementing v1, `window.customElements.define()`.",
   "notes_by_num":{
     "1":"Supports \"Autonomous custom elements\" but not \"Customized built-in elements\"",
-    "2":"Enabled through the \"dom.webcomponents.enabled\" or \"dom.webcomponents.customelements.enabled\" preference in about:config"
+    "2":"Enabled through the \"dom.webcomponents.enabled\" or \"dom.webcomponents.customelements.enabled\" preference in about:config",
+    "3":"Enabled through the \"dom.webcomponents.customelements.enabled\" preference in about:config"
   },
   "usage_perc_y":9.9,
   "usage_perc_a":68.97,

--- a/features-json/shadowdom.json
+++ b/features-json/shadowdom.json
@@ -109,9 +109,9 @@
       "56":"n d #1",
       "57":"n d #1",
       "58":"n d #1",
-      "59":"n d #1",
-      "60":"n d #1",
-      "61":"n d #1"
+      "59":"n d #2",
+      "60":"n d #2",
+      "61":"n d #2"
     },
     "chrome":{
       "4":"n",
@@ -321,7 +321,8 @@
   },
   "notes":"",
   "notes_by_num":{
-    "1":"Supported in Firefox behind the `dom.webcomponents.enabled` flag."
+    "1":"Supported in Firefox behind the `dom.webcomponents.enabled` flag.",
+    "2":"Supported in Firefox behind the `dom.webcomponents.shadowdom.enabled` flag."
   },
   "usage_perc_y":71.73,
   "usage_perc_a":0,

--- a/features-json/shadowdomv1.json
+++ b/features-json/shadowdomv1.json
@@ -101,9 +101,9 @@
       "56":"n",
       "57":"n",
       "58":"n d #2",
-      "59":"n d #2",
-      "60":"n d #2",
-      "61":"n d #2"
+      "59":"n d #3",
+      "60":"n d #3",
+      "61":"n d #3"
     },
     "chrome":{
       "4":"n",
@@ -314,7 +314,8 @@
   "notes":"Shadow DOM v0 was implemented in Chrome/Opera but other browser vendors are implementing v1.",
   "notes_by_num":{
     "1":"Certain CSS selectors do not work (`:host > .local-child`) and styling slotted content (`::slotted`) is buggy.",
-    "2":"Enabled through the \"dom.webcomponents.enabled\" preference in about:config"
+    "2":"Enabled through the \"dom.webcomponents.enabled\" preference in about:config",
+    "3":"Enabled through the \"dom.webcomponents.shadowdom.enabled\" preference in about:config"
   },
   "usage_perc_y":67.51,
   "usage_perc_a":11.93,


### PR DESCRIPTION
Firefox 59 removed the `dom.webcomponents.enabled` preference and split it into `dom.webcomponents.shadowdom.enabled` and `dom.webcomponents.customelements.enabled`.

Also, custom elements are not yet enabled in Firefox 59 stable.

# See also:
- mdn/browser-compat-data#1294
- [https://bugzil.la/1400762](https://bugzil.la/1400762 "1400762 - Deprecate dom.webcomponents.enabled and only use dom.webcomponents.customelements.enabled for Custom Elements")
- [https://bugzil.la/1428685](https://bugzil.la/1428685 "1428685 - Consider renaming pref dom.webcomponents.enabled to dom.webcomponents.shadowdom.enabled")