### PR TITLE
Fix incorrect data on let in IE11

### DIFF
--- a/features-json/let.json
+++ b/features-json/let.json
@@ -27,7 +27,7 @@
       "8":"n",
       "9":"n",
       "10":"n",
-      "11":"y"
+      "11":"a #5"
     },
     "edge":{
       "12":"y",
@@ -312,7 +312,8 @@
     "1":"Supports a non-standard version that can only be used in script elements with a type attribute of `application/javascript;version=1.7`. As other browsers do not support these types of `script` tags this makes support useless for cross-browser support.",
     "2":"Requires the \u2018Experimental JavaScript features\u2019 flag to be enabled",
     "3":"Only supported in strict mode",
-    "4":"`let` bindings in for loops are incorrectly treated as function-scoped instead of block scoped."
+    "4":"`let` bindings in for loops are incorrectly treated as function-scoped instead of block scoped.",
+    "5":"`let` variables are not bound separately to each iteration of `for` loops"
   },
   "usage_perc_y":88.22,
   "usage_perc_a":3.18,


### PR DESCRIPTION
The `let` data indicates that `let` is fully supported in IE11, but `let` variables are not correctly bound in `for` loops. This seems similar to Note #4, but the variables are in fact scoped to the `for` block and not the function so it seems like a separate issue.

This behavior can be observed with the following:

```js
for (let i = 0; i < 10; i += 1) {
    setTimeout(function () { console.log(i); }, 200);
}
```

In Chrome, this correctly logs the numbers 0-9. In IE, this logs the number 10, 10 times.