### PR TITLE
Remove relList note mention of Chrome/Chromium

### DIFF
--- a/features-json/rellist.json
+++ b/features-json/rellist.json
@@ -310,7 +310,7 @@
   },
   "notes":"",
   "notes_by_num":{
-    "1":"Chrome and Chromium based browsers support relList on link elements, but not anchor elements"
+    "1":"Support for relList on link but not anchor elements"
   },
   "usage_perc_y":26.35,
   "usage_perc_a":58.89,


### PR DESCRIPTION
Edge supports it now (see #4001) but with the same limitations as Chrome/Chromium, so it's specific to this browser (or rather engine) any more.