### PR TITLE
Edge 18 has partial CSS Mask support

### DIFF
--- a/features-json/css-masks.json
+++ b/features-json/css-masks.json
@@ -48,7 +48,7 @@
       "15":"n",
       "16":"n",
       "17":"n",
-      "18":"n"
+      "18":"a #4"
     },
     "firefox":{
       "2":"n",
@@ -324,7 +324,8 @@
   "notes_by_num":{
     "1":"Partial support in WebKit/Blink browsers refers to supporting the mask-image and mask-box-image properties, but lacking support for other parts of the spec.",
     "2":"Partial support in Firefox refers to only support for inline SVG mask elements i.e. mask: url(#foo).",
-    "3":"Partial support refers to supporting the mask-box-image shorthand but not the longhand properties"
+    "3":"Partial support refers to supporting the mask-box-image shorthand but not the longhand properties",
+    "4":"Partial support refers to supporting mask-image, mask-size, mask-position, and the mask shorthand"
   },
   "usage_perc_y":4.19,
   "usage_perc_a":85.87,


### PR DESCRIPTION
Edge 17 also has some support, but I've not tested that yet (mask-size, and mask-image I believe)