### PR TITLE
Fix SameSite cookie support for Firefox 59

### DIFF
--- a/features-json/same-site-cookie-attribute.json
+++ b/features-json/same-site-cookie-attribute.json
@@ -11,6 +11,10 @@
     {
       "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=795346",
       "title":"Mozilla Bug #795346: Add SameSite support for cookies"
+    },
+    {
+      "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=1286861",
+      "title":"Mozilla Bug #1286861, includes the patches that landed SameSite support in Firefox"
     }
   ],
   "bugs":[
@@ -98,7 +102,7 @@
       "56":"n",
       "57":"n",
       "58":"n",
-      "59":"y",
+      "59":"n",
       "60":"y",
       "61":"y"
     },


### PR DESCRIPTION
Firefox 59 does not support this yet. The relevant changes to Firefox's core [just landed][bug1286821] and won't ship until Firefox 60.

re: #4013

[bug1286821]: https://bugzilla.mozilla.org/show_bug.cgi?id=1286861