### PR TITLE
typo with "nth-of-type"

### DIFF
--- a/features-json/css-sel3.json
+++ b/features-json/css-sel3.json
@@ -1,6 +1,6 @@
 {
   "title":"CSS3 selectors",
-  "description":"Advanced element selection using selectors including: `[foo^=\"bar\"]`, `[foo$=\"bar\"]`, `[foo*=\"bar\"]`, `:root`, `:nth-child()`,  `:nth-last-child()`, `nth-of-type`, `nth-last-of-type()`, `:last-child`, `:first-of-type`, `:last-of-type`, `:only-child`, `:only-of-type`, `:empty`, `:target`, `:enabled`, `:disabled`, `:checked`, `:not()`, `~` (general sibling)",
+  "description":"Advanced element selection using selectors including: `[foo^=\"bar\"]`, `[foo$=\"bar\"]`, `[foo*=\"bar\"]`, `:root`, `:nth-child()`,  `:nth-last-child()`, `:nth-of-type()`, `:nth-last-of-type()`, `:last-child`, `:first-of-type`, `:last-of-type`, `:only-child`, `:only-of-type`, `:empty`, `:target`, `:enabled`, `:disabled`, `:checked`, `:not()`, `~` (general sibling)",
   "spec":"https://www.w3.org/TR/css3-selectors/",
   "status":"rec",
   "links":[


### PR DESCRIPTION
nth-of-type should be with bracktes, because it takes number as a parameter.