### PR TITLE
Update Ambient Light Sensor support

### DIFF
--- a/features-json/ambient-light.json
+++ b/features-json/ambient-light.json
@@ -1,24 +1,20 @@
 {
-  "title":"Ambient Light API",
-  "description":"Defines events that provide information about the ambient light level, as measured by a device's light sensor.",
+  "title":"Ambient Light Sensor",
+  "description":"Defines a concrete sensor interface to monitor the ambient light level or illuminance of the device’s environment.",
   "spec":"https://www.w3.org/TR/ambient-light/",
   "status":"cr",
   "links":[
     {
-      "url":"http://aurelio.audero.it/demo/ambient-light-api-demo.html",
+      "url":"https://intel.github.io/generic-sensor-demos/ambient-map/build/bundled/",
       "title":"Demo"
     },
     {
-      "url":"http://modernweb.com/2014/05/27/introduction-to-the-ambient-light-api/",
+      "url":"https://developers.google.com/web/updates/2017/09/sensors-for-the-web",
       "title":"Article"
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/Ambient_Light_Sensor_API",
       "title":"MDN Web Docs - Ambient Light Sensor"
-    },
-    {
-      "url":"https://developer.mozilla.org/en-US/docs/Web/API/Ambient_Light_Events",
-      "title":"MDN Web Docs - Ambient Light Events"
     }
   ],
   "bugs":[
@@ -40,11 +36,11 @@
     "edge":{
       "12":"n",
       "13":"n",
-      "14":"y",
-      "15":"y",
-      "16":"y",
-      "17":"y",
-      "18":"y"
+      "14":"a #1",
+      "15":"a #1",
+      "16":"a #1",
+      "17":"a #1",
+      "18":"a #1"
     },
     "firefox":{
       "2":"n",
@@ -107,8 +103,8 @@
       "57":"a #1",
       "58":"a #1",
       "59":"a #1",
-      "60":"a #1",
-      "61":"a #1"
+      "60":"n d #1",
+      "61":"n d #1"
     },
     "chrome":{
       "4":"n",
@@ -318,8 +314,8 @@
   },
   "notes":"",
   "notes_by_num":{
-    "1":"Partial support in desktop Firefox refers to support being limited to Mac OS X. [Support for Windows 7 is in progress](https://bugzilla.mozilla.org/show_bug.cgi?id=754199)",
-    "2":"Available by enabling the \"Experimental Web Platform Features\" experimental flag in `about:flags`"
+    "1":"Implements an [outdated version of the spec](https://www.w3.org/TR/2015/WD-ambient-light-20150903/).",
+    "2":"Available by enabling the \"Generic Sensor Extra Classes\" experimental flag in `about:flags`"
   },
   "usage_perc_y":2.07,
   "usage_perc_a":5.04,


### PR DESCRIPTION
- Reflect spec redesign and rename to 'Ambient Light Sensor'
- Update Chrome, Firefox, and Edge implementation status
- Update Demo and Article accordingly
- Update Notes

Fix #4191