### PR TITLE
Samsung browser 7 supports WebAssembly

### DIFF
--- a/features-json/wasm.json
+++ b/features-json/wasm.json
@@ -299,7 +299,7 @@
     "samsung":{
       "4":"n",
       "5":"n",
-      "6.2":"n"
+      "6.2":"n #5"
     },
     "and_qq":{
       "1.2":"n d #2"
@@ -313,7 +313,8 @@
     "1":"Can be enabled via the `javascript.options.wasm` in `about:config`",
     "2":"Can be enabled via the `#enable-webassembly` flag",
     "3":"Can be enabled via the Experimental JavaScript Features flag",
-    "4":"Disabled for Firefox 52 ESR"
+    "4":"Disabled for Firefox 52 ESR",
+    "5":"Available in Samsung Internet 7 beta"
   },
   "usage_perc_y":73.49,
   "usage_perc_a":0,


### PR DESCRIPTION
> Starting with version 7.x, Samsung Internet supports Web Assembly. Web Assembly allows client-side web code to be written in multiple languages and execute at near native speed.

http://developer.samsung.com/internet

I'm not sure where to add Samsung Internet 7 browser beta though