### PR TITLE
requestAnimationFrame: Fix typo

### DIFF
--- a/features-json/requestanimationframe.json
+++ b/features-json/requestanimationframe.json
@@ -321,7 +321,7 @@
   "notes":"",
   "notes_by_num":{
     "1":"Partial support refers to lacking `cancelAnimationFrame` support.",
-    "2":"Supports `webkitCancelRequestAnimationFrame` rather than `webkitCancelAnimationFrame."
+    "2":"Supports `webkitCancelRequestAnimationFrame` rather than `webkitCancelAnimationFrame`."
   },
   "usage_perc_y":94.45,
   "usage_perc_a":0.14,


### PR DESCRIPTION
This PR fixes a missing backtick in the description for `requestAnimationFrame`
