### PR TITLE
Removed incorrect platform status mapping

### DIFF
--- a/features-json/shadowdom.json
+++ b/features-json/shadowdom.json
@@ -332,9 +332,6 @@
   "ucprefix":false,
   "parent":"",
   "keywords":"web components",
-  "ie_id":"shadowdom",
   "chrome_id":"4507242028072960",
-  "firefox_id":"shadow-dom",
-  "webkit_id":"feature-shadow-dom",
   "shown":true
 }

--- a/features-json/shadowdom.json
+++ b/features-json/shadowdom.json
@@ -332,6 +332,9 @@
   "ucprefix":false,
   "parent":"",
   "keywords":"web components",
+  "ie_id":"",
   "chrome_id":"4507242028072960",
+  "firefox_id":"",
+  "webkit_id":"",
   "shown":true
 }


### PR DESCRIPTION
The mapped platform status entries talk about v1, not v0.
Hopefully, it will also fix the lack of WebKit status on the v1 entry...
![image](https://user-images.githubusercontent.com/184400/40101698-e8dc71b8-58f0-11e8-9256-a6557493e076.png)
