### PR TITLE
xhr2.json: update stale w3c link

### DIFF
--- a/features-json/xhr2.json
+++ b/features-json/xhr2.json
@@ -1,6 +1,6 @@
 {
   "title":"XMLHttpRequest advanced features",
-  "description":"Adds more functionality to XHR (aka AJAX) requests like file uploads, transfer progress information and the ability to send form data. Previously known as [XMLHttpRequest Level 2](https://www.w3.org/TR/2012/WD-XMLHttpRequest-20120117/), these features now appear simply in the XMLHttpRequest spec.",
+  "description":"Adds more functionality to XHR (aka AJAX) requests like file uploads, transfer progress information and the ability to send form data. Previously known as [XMLHttpRequest Level 2](https://www.w3.org/TR/XMLHttpRequest/), these features now appear simply in the XMLHttpRequest spec.",
   "spec":"https://xhr.spec.whatwg.org/",
   "status":"ls",
   "links":[


### PR DESCRIPTION
If you follow thie original link, you get a warning:

    This version is outdated!
    For the latest version, please look at
    https://www.w3.org/TR/XMLHttpRequest/.

Replace the old link with the new one now that this is a standard.