### PR TITLE
Fix data for IE & Edge

### DIFF
--- a/features-json/bloburls.json
+++ b/features-json/bloburls.json
@@ -27,17 +27,17 @@
       "7":"n",
       "8":"n",
       "9":"n",
-      "10":"y",
-      "11":"y"
+      "10":"y #1",
+      "11":"y #1"
     },
     "edge":{
       "12":"y #1",
       "13":"y #1",
       "14":"y #1",
-      "15":"y #1",
-      "16":"y #1",
-      "17":"y #1",
-      "18":"y #1"
+      "15":"y",
+      "16":"y",
+      "17":"y",
+      "18":"y"
     },
     "firefox":{
       "2":"n",
@@ -315,7 +315,7 @@
   },
   "notes":"",
   "notes_by_num":{
-    "1":"Created blob url can't be used in object or iframe (see [issue](https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/5411066/))"
+    "1": "Created blob url can't be used in object or iframe"
   },
   "usage_perc_y":94.43,
   "usage_perc_a":0,


### PR DESCRIPTION
Blob URL as iframe "src" does work in Edge since v15 and did never work in IE.
Can try this pen: https://codepen.io/grimen/pen/lBuiG
The issue for Edge concerns PDF blob urls only (https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/5411066/)