### PR TITLE
Fix MDN querySelectorAll link

### DIFF
--- a/features-json/queryselector.json
+++ b/features-json/queryselector.json
@@ -9,7 +9,7 @@
       "title":"MDN Web Docs - querySelector"
     },
     {
-      "url":"https://developer.mozilla.org/En/DOM/Element.querySelectorAll",
+      "url":"https://developer.mozilla.org/en/DOM/Element.querySelectorAll",
       "title":"MDN Web Docs - querySelectorAll"
     },
     {


### PR DESCRIPTION
The redirect is case sensitive.