### PR TITLE
Update spec for box-sizing

### DIFF
--- a/features-json/css3-boxsizing.json
+++ b/features-json/css3-boxsizing.json
@@ -1,8 +1,8 @@
 {
   "title":"CSS3 Box-sizing",
   "description":"Method of specifying whether or not an element's borders and padding should be included in size units",
-  "spec":"https://www.w3.org/TR/css3-ui/#box-sizing",
-  "status":"cr",
+  "spec":"https://www.w3.org/TR/css-sizing/#box-sizing",
+  "status":"wd",
   "links":[
     {
       "url":"https://developer.mozilla.org/En/CSS/Box-sizing",


### PR DESCRIPTION
The most up to date spec for box-sizing is no longer css-ui, but css-sizing.