### PR TITLE
Add Edge feature request to AV1

### DIFF
--- a/features-json/av1.json
+++ b/features-json/av1.json
@@ -11,6 +11,10 @@
     {
       "url":"https://bitmovin.com/demos/av1",
       "title":"Sample video"
+    },
+    {
+      "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/34544281-support-aomedia-video-1-av1",
+      "title":"Microsoft Edge feature request on UserVoice"
     }
   ],
   "bugs":[


### PR DESCRIPTION
Title :)

https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/34544281-support-aomedia-video-1-av1

Meta: That feature request is probably unnecessary, as Edge is already listed at https://aomedia.org and Microsoft is a member, but since they don't have it listed at https://developer.microsoft.com/en-us/microsoft-edge/platform/status/ maybe at least the request will lead to that…