### PR TITLE
SameSite cookie attribute for Edge/IE11 on Win10 RS3+

### DIFF
--- a/features-json/same-site-cookie-attribute.json
+++ b/features-json/same-site-cookie-attribute.json
@@ -19,7 +19,15 @@
     {
       "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/17140412-support-samesite-cookie-option",
       "title":"Microsoft Edge feature request on UserVoice"
-    }
+    },
+    {
+      "url":"https://developer.microsoft.com/en-us/microsoft-edge/platform/status/samesitecookies/",
+      "title":"Microsoft Edge Browser Status"
+    },
+    {
+      "url":"https://blogs.windows.com/msedgedev/2018/05/17/samesite-cookies-microsoft-edge-internet-explorer/",
+      "title":"MS Edge dev blog: \"Previewing support for same-site cookies in Microsoft Edge\""
+    },
   ],
   "bugs":[
     
@@ -35,16 +43,16 @@
       "8":"n",
       "9":"n",
       "10":"n",
-      "11":"n"
+      "11":"a #1 #2"
     },
     "edge":{
       "12":"n",
       "13":"n",
       "14":"n",
       "15":"n",
-      "16":"n",
-      "17":"n",
-      "18":"n"
+      "16":"y #1",
+      "17":"y #1",
+      "18":"y"
     },
     "firefox":{
       "2":"n",
@@ -322,7 +330,8 @@
   },
   "notes":"This feature is backwards compatible. Browsers not supporting this feature will simply use the cookie as a regular cookie. There is no need to deliver different cookies to clients.",
   "notes_by_num":{
-    
+    "1":"Not shipped with the inital release but later with the 2018 June security update (Patch Tuesday) to Windows 10 RS3 (2017 Fall Creators Update) and newer. [More info](https://github.com/MicrosoftEdge/Status/issues/616).",
+    "2":"Partial support because only supported in IE 11 on Windows 10 RS3 (2017 Fall Creators Update) and newer, but not in IE 11 on other Windows versions (Windows 7, ...)"
   },
   "usage_perc_y":62.28,
   "usage_perc_a":0,

--- a/features-json/same-site-cookie-attribute.json
+++ b/features-json/same-site-cookie-attribute.json
@@ -27,7 +27,7 @@
     {
       "url":"https://blogs.windows.com/msedgedev/2018/05/17/samesite-cookies-microsoft-edge-internet-explorer/",
       "title":"MS Edge dev blog: \"Previewing support for same-site cookies in Microsoft Edge\""
-    },
+    }
   ],
   "bugs":[
     


### PR DESCRIPTION
Rolled out already via Windows 10 June Security update - to Windows 10 RS3+ builds (16299+) (which is 2017 Fall Creators Update an newer).

See
https://github.com/MicrosoftEdge/Status/issues/616
https://developer.microsoft.com/en-us/microsoft-edge/platform/status/samesitecookies/