### PR TITLE
[wasm] Samsung Internet 7 beta note is not needed anymore

### DIFF
--- a/features-json/wasm.json
+++ b/features-json/wasm.json
@@ -304,7 +304,7 @@
     "samsung":{
       "4":"n",
       "5":"n",
-      "6.2":"n #5",
+      "6.2":"n",
       "7.2":"y"
     },
     "and_qq":{
@@ -319,8 +319,7 @@
     "1":"Can be enabled via the `javascript.options.wasm` in `about:config`",
     "2":"Can be enabled via the `#enable-webassembly` flag",
     "3":"Can be enabled via the Experimental JavaScript Features flag",
-    "4":"Disabled for Firefox 52 ESR",
-    "5":"Available in Samsung Internet 7 beta"
+    "4":"Disabled for Firefox 52 ESR"
   },
   "usage_perc_y":74.12,
   "usage_perc_a":0,


### PR DESCRIPTION
Since https://github.com/Fyrd/caniuse/commit/b602c73c0a7d651520edc727add6ed2c1fd061d4#diff-fd2aa9257c26edb4eb860eb561dcb9f9