### PR TITLE
Added notes on high-resolution timestamps

### DIFF
--- a/features-json/high-resolution-time.json
+++ b/features-json/high-resolution-time.json
@@ -327,9 +327,10 @@
       "7.12":"y"
     }
   },
-  "notes":"",
+  "notes":"The timestamp is not actually high-resolution. To mitigate security threats such as Spectre, browsers currently round the result to varying degrees.",
   "notes_by_num":{
-    
+    "1": "In Firefox, the \"privacy.reduceTimerPrecision\" preference is enabled by default and defaults to 20us in Firefox 59; in 60 it will be 2ms.",
+    "2": "In Firefox, the \"privacy.resistFingerprinting\" preference changes the precision to 100ms or the value of \"privacy.resistFingerprinting.reduceTimerPrecision.microseconds\", whichever is larger."
   },
   "usage_perc_y":93.94,
   "usage_perc_a":0,


### PR DESCRIPTION
* High-resolution timestamps can be rounded
* Firefox has multiple settings that have a major affect on High-resolution timestamps