### PR TITLE
Update overflow-wrap resources

### DIFF
--- a/features-json/wordwrap.json
+++ b/features-json/wordwrap.json
@@ -5,12 +5,8 @@
   "status":"wd",
   "links":[
     {
-      "url":"https://developer.mozilla.org/En/CSS/Word-wrap",
-      "title":"MDN Web Docs - CSS word-wrap"
-    },
-    {
-      "url":"https://www.webplatform.org/docs/css/properties/word-wrap",
-      "title":"WebPlatform Docs"
+      "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap",
+      "title":"MDN Web Docs - CSS overflow-wrap"
     },
     {
       "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=955857",


### PR DESCRIPTION
Remove WebPlatform docs (the site is deprecated) and fix the MDN URL.