### PR TITLE
Update CSS Scroll snap points polyfills

### DIFF
--- a/features-json/css-snappoints.json
+++ b/features-json/css-snappoints.json
@@ -14,7 +14,11 @@
     },
     {
       "url":"https://github.com/ckrack/scrollsnap-polyfill",
-      "title":"Polyfill"
+      "title":"Polyfill - based on an [older version](https://www.w3.org/TR/2015/WD-css-snappoints-1-20150326/) of the spec"
+    },
+    {
+        "url":"https://www.npmjs.com/package/css-scroll-snap-polyfill",
+        "title":"Polyfill - based on the [current version](https://www.w3.org/TR/css-scroll-snap-1/) of the spec"
     }
   ],
   "bugs":[


### PR DESCRIPTION
The currently linked polyfill implements some of the older spec's features.
This PR adds a link to a more current polyfill, and mentions the difference in specifications followed between the two.

Disclaimer: I have not personally tested that the currently linked polyfill by @ckrack is not conform to today's spec. However, the last "development/feature" commit (i.e. that's not a `package.json` update) is from 2016, *before* the current revision of the snap points (dated at [14 December 2017](https://www.w3.org/TR/css-scroll-snap-1/)). Furthermore, the "more current" polyfill I've added to the links asserts on its [npm page](https://www.npmjs.com/package/css-scroll-snap-polyfill#limitations) this difference in implemented spec.