### PR TITLE
[Feature-Policy] Improve keywords for 'allow' attribute

### DIFF
--- a/features-json/feature-policy.json
+++ b/features-json/feature-policy.json
@@ -328,7 +328,7 @@
   "usage_perc_a":60,
   "ucprefix":false,
   "parent":"",
-  "keywords":"feature,security,header,allow,attribute",
+  "keywords":"feature,security,header,allow,attribute,allow attribute,attribute allow",
   "ie_id":"",
   "chrome_id":"5694225681219584",
   "firefox_id":"",


### PR DESCRIPTION
My [first PR for `allow` keywords](https://github.com/Fyrd/caniuse/pull/4389) was not sufficient:

Currently, searching for "allow" gives 92 search results while "allow attribute" gives 0, this commit enables search for "allow attribute" or "attribute allow".