### PR TITLE
Correct TLS support for Opera

### DIFF
--- a/features-json/tls1-3.json
+++ b/features-json/tls1-3.json
@@ -236,19 +236,19 @@
       "38":"n",
       "39":"n",
       "40":"n",
-      "41":"n",
-      "42":"n d",
-      "43":"y",
-      "44":"y",
-      "45":"y",
-      "46":"y",
-      "47":"y",
-      "48":"y",
-      "49":"y",
-      "50":"y",
-      "51":"y",
-      "52":"y",
-      "53":"y"
+      "41":"n d #4",
+      "42":"n d #4",
+      "43":"n d #4",
+      "44":"n d #4",
+      "45":"n d #4",
+      "46":"n d #4",
+      "47":"n d #4",
+      "48":"n d #4",
+      "49":"n d #4",
+      "50":"n d #4",
+      "51":"n d #4",
+      "52":"n d #4",
+      "53":"n d #4"
     },
     "ios_saf":{
       "3.2":"n",
@@ -325,7 +325,8 @@
   "notes_by_num":{
     "1":"Can be enabled by setting \"TLS 1.3\" to \"Enabled (Draft)\" at `chrome://flags/tls13-variant`.",
     "2":"Can be enabled by setting \"Maximum TLS version enabled\" to \"TLS 1.3\"at `chrome://flags/`. Support is reported to have be currently enabled as of version 56 for 1/10th of all users.",
-    "3":"Enabled on the regular version of Firefox 53, but [not the ESR version](https://groups.google.com/forum/#!topic/mozilla.dev.platform/sfeqeMkyxCI)."
+    "3":"Enabled on the regular version of Firefox 53, but [not the ESR version](https://groups.google.com/forum/#!topic/mozilla.dev.platform/sfeqeMkyxCI).",
+    "4":"Can be enabled by using `--ssl-version-max=tls1.3` command line argument from version between 41 or by setting \"TLS 1.3\" to \"Enabled (Draft 23)\" at `opera://flags/#tls13-variant` from version 54."
   },
   "usage_perc_y":63.28,
   "usage_perc_a":0.41,

--- a/features-json/tls1-3.json
+++ b/features-json/tls1-3.json
@@ -326,7 +326,7 @@
     "1":"Can be enabled by setting \"TLS 1.3\" to \"Enabled (Draft)\" at `chrome://flags/tls13-variant`.",
     "2":"Can be enabled by setting \"Maximum TLS version enabled\" to \"TLS 1.3\"at `chrome://flags/`. Support is reported to have be currently enabled as of version 56 for 1/10th of all users.",
     "3":"Enabled on the regular version of Firefox 53, but [not the ESR version](https://groups.google.com/forum/#!topic/mozilla.dev.platform/sfeqeMkyxCI).",
-    "4":"Can be enabled by using `--ssl-version-max=tls1.3` command line argument from version between 41 or by setting \"TLS 1.3\" to \"Enabled (Draft 23)\" at `opera://flags/#tls13-variant` from version 54."
+    "4":"Can be enabled by using `--ssl-version-max=tls1.3` command line argument from version 41 or by setting \"TLS 1.3\" to \"Enabled (Draft 23)\" at `opera://flags/#tls13-variant` from version 54."
   },
   "usage_perc_y":63.28,
   "usage_perc_a":0.41,


### PR DESCRIPTION
Opera does not yet support TLS1.3 by default.
41.0.2323.0 possible with command line switch https://forums.opera.com/topic/16519/new-opera-developer-41/13
54.0.2920.0 has added a flag: https://blogs.opera.com/desktop/changelog-for-54/