### PR TITLE
TLS 1.3 is now the latest TLS version

### DIFF
--- a/features-json/tls1-2.json
+++ b/features-json/tls1-2.json
@@ -1,6 +1,6 @@
 {
   "title":"TLS 1.2",
-  "description":"The latest version of the Transport Layer Security (TLS) protocol. Allows for data/message confidentiality, and message authentication codes for message integrity and as a by-product message authentication.",
+  "description":"Version 1.2 of the Transport Layer Security (TLS) protocol. Allows for data/message confidentiality, and message authentication codes for message integrity and as a by-product message authentication.",
   "spec":"https://tools.ietf.org/html/rfc5246",
   "status":"other",
   "links":[

--- a/features-json/tls1-3.json
+++ b/features-json/tls1-3.json
@@ -1,7 +1,7 @@
 {
   "title":"TLS 1.3",
-  "description":"An upcoming version of the Transport Layer Security (TLS) protocol. Removes weaker elliptic curves and hash functions.",
-  "spec":"https://tools.ietf.org/html/draft-ietf-tls-tls13-21",
+  "description":"The latest version of the Transport Layer Security (TLS) protocol. Removes weaker elliptic curves and hash functions.",
+  "spec":"https://tools.ietf.org/html/rfc8446",
   "status":"other",
   "links":[
     {


### PR DESCRIPTION
Update TLS 1.3 spec link to https://tools.ietf.org/html/rfc8446