### PR TITLE
Remove dead link to blog post for css-hyphens

### DIFF
--- a/features-json/css-hyphens.json
+++ b/features-json/css-hyphens.json
@@ -9,10 +9,6 @@
       "title":"MDN Web Docs - CSS hyphens"
     },
     {
-      "url":"http://blog.fontdeck.com/post/9037028497/hyphens",
-      "title":"Blog post"
-    },
-    {
       "url":"https://www.webplatform.org/docs/css/properties/hyphens",
       "title":"WebPlatform Docs"
     },


### PR DESCRIPTION
The domain name does not resolve anymore.