### PR TITLE
Update note that Firefox on Linux will support prefers-reduced-motion

### DIFF
--- a/features-json/prefers-reduced-motion.json
+++ b/features-json/prefers-reduced-motion.json
@@ -319,7 +319,7 @@
   },
   "notes":"",
   "notes_by_num":{
-    "1":"Currently expected to land in Firefox for Windows in Firefox 63, for MacOS it might be delayed to Firefox 64."
+    "1":"Currently expected to land in Firefox for Windows and Linux in Firefox 63, for MacOS it might be delayed to Firefox 64."
   },
   "usage_perc_y":11.04,
   "usage_perc_a":0,


### PR DESCRIPTION
Previously, the note said Firefox 63 would support `prefers-reduced-motion` but only on Windows.

According to this bug, it's implemented on Linux too:

https://bugzilla.mozilla.org/show_bug.cgi?id=1478519

I tested it and it seems to work as expected.