### PR TITLE
Update custom-elements.json

### DIFF
--- a/features-json/custom-elements.json
+++ b/features-json/custom-elements.json
@@ -350,7 +350,7 @@
       "7.12":"y"
     }
   },
-  "notes":"Will be deprecated as of Chrome 70 and intended to be removed in Chrome 73",
+  "notes":"Will be deprecated as of Chrome 70 and intended to be removed in Chrome 73.",
   "notes_by_num":{
     "1":"Enabled through the \"dom.webcomponents.enabled\" preference in about:config",
     "2":"Enabled through the \"dom.webcomponents.customelements.enabled\" preference in about:config"

--- a/features-json/custom-elements.json
+++ b/features-json/custom-elements.json
@@ -350,7 +350,7 @@
       "7.12":"y"
     }
   },
-  "notes":"",
+  "notes":"Will be deprecated as of Chrome 70 and intended to be removed in Chrome 73",
   "notes_by_num":{
     "1":"Enabled through the \"dom.webcomponents.enabled\" preference in about:config",
     "2":"Enabled through the \"dom.webcomponents.customelements.enabled\" preference in about:config"


### PR DESCRIPTION
According to chromestatus.com, Chrome intends to deprecate CustomElements V0 at M70, following by an intension to remove them at M73. See [here](https://www.chromestatus.com/feature/4642138092470272) for more info about this.