### PR TITLE
AudioContext.createMediaElementSource(): Remove mentioned Safari bug

### DIFF
--- a/features-json/audio-api.json
+++ b/features-json/audio-api.json
@@ -26,9 +26,7 @@
     }
   ],
   "bugs":[
-    {
-      "description":"Safari does not appear to support `createMediaElementSource`"
-    }
+
   ],
   "categories":[
     "JS API"


### PR DESCRIPTION
Safari fully supports `AudioContext.createMediaElementSource()` [since version 6](https://developer.mozilla.org/en-US/docs/Web/API/AudioContext/createMediaElementSource#Browser_compatibility).