### PR TITLE
Update prefers-reduced-motion.json

### DIFF
--- a/features-json/prefers-reduced-motion.json
+++ b/features-json/prefers-reduced-motion.json
@@ -102,8 +102,8 @@
       "60":"n",
       "61":"n",
       "62":"n",
-      "63":"a #1",
-      "64":"a #1"
+      "63":"y",
+      "64":"y"
     },
     "chrome":{
       "4":"n",
@@ -322,9 +322,7 @@
     }
   },
   "notes":"",
-  "notes_by_num":{
-    "1":"Currently expected to land in Firefox for Windows and Linux in Firefox 63, for MacOS it might be delayed to Firefox 64."
-  },
+  "notes_by_num":{},
   "usage_perc_y":11.62,
   "usage_perc_a":0,
   "ucprefix":false,


### PR DESCRIPTION
Feature landed in Firefox 63:
https://bugzilla.mozilla.org/show_bug.cgi?id=1365045
https://bugzilla.mozilla.org/show_bug.cgi?id=1475462
https://bugzilla.mozilla.org/show_bug.cgi?id=1478519