### PR TITLE
Add a ponyfill for the reportValidity function in constraint validation

### DIFF
--- a/features-json/constraint-validation.json
+++ b/features-json/constraint-validation.json
@@ -5,6 +5,10 @@
   "status":"ls",
   "links":[
     {
+      "url":"https://github.com/jelmerdemaat/report-validity",
+      "title":"`reportValidity()` ponyfill"
+    },
+    {
       "url":"https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/HTML5/Constraint_validation",
       "title":"MDN article on constraint validation"
     },
@@ -14,7 +18,7 @@
     }
   ],
   "bugs":[
-    
+
   ],
   "categories":[
     "JS API"


### PR DESCRIPTION
I created a [ponyfill](https://ponyfill.com/) that adds the `reportValidity` functionality in non-supporting browsers.

For more information, check the GitHub and demo page: https://github.com/jelmerdemaat/report-validity.

I added it to the `constraint-validation.json` file. 