### PR TITLE
AV1: Updated specification URL

### DIFF
--- a/features-json/av1.json
+++ b/features-json/av1.json
@@ -1,7 +1,7 @@
 {
   "title":"AV1 video format",
   "description":"AV1 (AOMedia Video 1) is a royalty-free video format by the Alliance for Open Media, meant to succeed its predecessor VP9 and compete with the HEVC/H.265 format.",
-  "spec":"https://aomedia.googlesource.com/av1-spec/",
+  "spec":"https://github.com/AOMediaCodec/av1-spec",
   "status":"other",
   "links":[
     {


### PR DESCRIPTION
Hi, and thanks for making caniuse.com!

**Reason for update:**
- The old spec repo has silently stopped receiving updates, since 10 months ago.
  - (https://aomedia.googlesource.com/av1-spec/)
- Meanwhile, the new repo is active. (Fairly quiet now that v1.0.0 is out, but still. It's active.)
  - (https://github.com/AOMediaCodec/av1-spec)

**Note about canonical PDF vs. repo:** The specification gets rendered out to a PDF that serves as the canonical and stable spec: https://aomediacodec.github.io/av1-spec/av1-spec.pdf
  - The rest of the repo gets occasional updates, but it's unclear how/when these will be made official parts of the spec.

Let me know if you'd rather link to the PDF and I'll `git commit --amend` and force push to update this pull request.