### PR TITLE
Remove npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,8 +1,0 @@
-.gitignore
-.gitattributes
-
-.travis.yml
-validator/
-
-Contributing.md
-sample-data.json


### PR DESCRIPTION
npmignore is only needed to publish npm packages