### PR TITLE
Update opus.json

### DIFF
--- a/features-json/opus.json
+++ b/features-json/opus.json
@@ -195,10 +195,10 @@
       "9.1":"n",
       "10":"n",
       "10.1":"n",
-      "11":"n",
-      "11.1":"n",
-      "12":"n",
-      "TP":"n"
+      "11":"a #1",
+      "11.1":"a #1",
+      "12":"a #1",
+      "TP":"a #1"
     },
     "opera":{
       "9":"n",
@@ -267,9 +267,9 @@
       "9.3":"n",
       "10.0-10.2":"n",
       "10.3":"n",
-      "11.0-11.2":"n",
-      "11.3-11.4":"n",
-      "12":"n"
+      "11.0-11.2":"a #1",
+      "11.3-11.4":"a #1",
+      "12":"a #1"
     },
     "op_mini":{
       "all":"n"
@@ -327,7 +327,7 @@
   },
   "notes":"Support refers to this format's use in the `audio` element, not other conditions.\r\n\r\nFor Opera the Linux version may be able to play it when the GStreamer module is up to date and the served mime-type is 'audio/ogg'.",
   "notes_by_num":{
-    "1":"Supported only on macOS High Sierra or later"
+    "1":"Supported only when packaged in a CAF file and on macOS High Sierra/iOS 11 or later."
   },
   "usage_perc_y":69.81,
   "usage_perc_a":0,


### PR DESCRIPTION
Safari on High Sierra or later or iOS 11 or later supports opus when it's packaged in a CAF file. Source: https://hpr.dogphilosophy.net/test/index.php