### PR TITLE
[link-rel-prerender.json] Update notes on Chrome implementation

### DIFF
--- a/features-json/link-rel-prerender.json
+++ b/features-json/link-rel-prerender.json
@@ -14,9 +14,7 @@
     }
   ],
   "bugs":[
-    {
-      "description":"Chrome intends to [deprecate and remove](https://groups.google.com/a/chromium.org/forum/#!msg/blink-dev/0nSxuuv9bBw/EMfaclV-AwAJ) support for prerender in the future."
-    }
+
   ],
   "categories":[
     "DOM"
@@ -323,7 +321,7 @@
       "7.12":"y"
     }
   },
-  "notes":"",
+  "notes":"Chrome treats the prerender hint as a [NoState Prefetch](https://developers.google.com/web/updates/2018/07/nostate-prefetch) instead, and unlike a full prerender it wont execute JavaScript or render any part of the page in advance.",
   "notes_by_num":{
     
   },


### PR DESCRIPTION
This PR removes the easily misinterpreted [intent-to-deprecate](https://groups.google.com/a/chromium.org/forum/#!topic/blink-dev/0nSxuuv9bBw): `<link rel="prerender">` in Chrome. Chrome still allows (confirmed in https://github.com/w3c/resource-hints/issues/67#issuecomment-275049299) for web authors to markup pages to prerender - however, treats is as a [NoState Prefetch](https://developers.google.com/web/updates/2018/07/nostate-prefetch) instead.