### PR TITLE
Update css-placeholder.json

### DIFF
--- a/features-json/css-placeholder.json
+++ b/features-json/css-placeholder.json
@@ -5,10 +5,6 @@
   "status":"wd",
   "links":[
     {
-      "url":"http://msdn.microsoft.com/en-us/library/ie/hh772745(v=vs.85).aspx",
-      "title":"MSDN article"
-    },
-    {
       "url":"https://css-tricks.com/snippets/css/style-placeholder-text/",
       "title":"CSS-Tricks article with all prefixes"
     },


### PR DESCRIPTION
MSDN article now redirects to MDN's :placeholder-shown article