### PR TITLE
[web-app-manifest.json] Add to resources: GoogleChromeLabs PWACompat (polyfill)

### DIFF
--- a/features-json/web-app-manifest.json
+++ b/features-json/web-app-manifest.json
@@ -7,6 +7,10 @@
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/Manifest",
       "title":"MDN Web Docs - Web App Manifest"
+    },
+    {
+      "url":"https://github.com/GoogleChromeLabs/pwacompat",
+      "title":"PWACompat (polyfill) - A library that brings the Web App Manifest to non-compliant browsers"
     }
   ],
   "bugs":[


### PR DESCRIPTION
https://github.com/GoogleChromeLabs/pwacompat/blob/master/README.md


I might've used the term polyfill incorrectly:
Because although the library helps to create `<meta>`/`<link>` elements with the corresponding (if available) icons/meta data for legacy browsers that don't support the web app manifest, it doesn't give non-compliant browsers all the features - for example there is no equivalent `<meta>` property of a webmanifests `"display": "fullscreen"` etc.)