### PR TITLE
Update css-sel3.json

### DIFF
--- a/features-json/css-sel3.json
+++ b/features-json/css-sel3.json
@@ -35,7 +35,7 @@
       "description":"iOS 9 has a bug in WebViews (not Safari) with the [CSS sibling selector](https://forums.developer.apple.com/thread/16449)"
     },
     {
-      "description":"IE11/Edge have issues with [last-of-type with custom elements](https://stackoverflow.com/questions/38666233/last-of-type-doesnt-work-with-custom-elements-in-ie11-and-edge#38669965)"
+      "description":"IE11 has issues with [last-of-type with custom elements](https://stackoverflow.com/questions/38666233/last-of-type-doesnt-work-with-custom-elements-in-ie11-and-edge#38669965)"
     }
   ],
   "categories":[

--- a/features-json/css-sel3.json
+++ b/features-json/css-sel3.json
@@ -33,6 +33,9 @@
     },
     {
       "description":"iOS 9 has a bug in WebViews (not Safari) with the [CSS sibling selector](https://forums.developer.apple.com/thread/16449)"
+    },
+    {
+      "description":"IE11/Edge have issues with [last-of-type with custom elements](https://stackoverflow.com/questions/38666233/last-of-type-doesnt-work-with-custom-elements-in-ie11-and-edge#38669965)"
     }
   ],
   "categories":[


### PR DESCRIPTION
Updated to include information about IE11 failures with `last-of-type` CSS3 selector with custom elements

See [StackOverflow Discussion](https://stackoverflow.com/questions/38666233/last-of-type-doesnt-work-with-custom-elements-in-ie11-and-edge#38669965)

Fixed in [Edge](https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/5249985/)