### PR TITLE
Update av1.json for Edge 18 support

### DIFF
--- a/features-json/av1.json
+++ b/features-json/av1.json
@@ -44,7 +44,7 @@
       "15":"n",
       "16":"n",
       "17":"n",
-      "18":"n"
+      "18":"n d #3"
     },
     "firefox":{
       "2":"n",
@@ -335,7 +335,8 @@
   "notes":"",
   "notes_by_num":{
     "1":"Can be enabled in Firefox Nightly only, via the `media.av1.enabled` flag in `about:config`",
-    "2":"Can be enabled in Chrome via the #enable-av1-decoder flag in `chrome://flags`"
+    "2":"Can be enabled in Chrome via the #enable-av1-decoder flag in `chrome://flags`",
+    "3":"Supported in Edge when the AV1 Video Extension (Beta) is installed from the Microsoft Store"
   },
   "usage_perc_y":4.17,
   "usage_perc_a":0,


### PR DESCRIPTION
Update av1.json for Edge 18 support when the [AV1 Video Extension (Beta)](https://www.microsoft.com/nl-nl/p/av1-video-extension-beta/9mvzqvxjbq9v) is installed.