### PR TITLE
Added new payments pref in Firefox

### DIFF
--- a/features-json/payment-request.json
+++ b/features-json/payment-request.json
@@ -350,7 +350,7 @@
     "6":"Can be enabled via the `dom.payments.request.enabled` flag in \"about:config\" flag since 55.",
     "7":"Missing support for PaymentResponse.prototype.retry() method",
     "8":"Enabled by default in Nightly, but \"browser.search.region\" pref in \"about:config\" must be set to 'US'",
-    "9":"Enabled by default in Nightly, but \"dom.payments.request.supportedRegions\" pref in \"about:config\" must be set to \"US,CA\".",
+    "9":"Enabled by default in Nightly, but \"dom.payments.request.supportedRegions\" pref in \"about:config\" must be set to \"US,CA\"."
   },
   "usage_perc_y":0,
   "usage_perc_a":74.74,

--- a/features-json/payment-request.json
+++ b/features-json/payment-request.json
@@ -120,7 +120,7 @@
       "62":"n d #6",
       "63":"n d #6",
       "64":"a d #8",
-      "65":"a d #8"
+      "65":"a d #9"
     },
     "chrome":{
       "4":"n",
@@ -349,7 +349,8 @@
     "5":"Unlike Desktop Chrome, support has been in Chrome for Android since version 53.",
     "6":"Can be enabled via the `dom.payments.request.enabled` flag in \"about:config\" flag since 55.",
     "7":"Missing support for PaymentResponse.prototype.retry() method",
-    "8":"Enabled by default in Nightly, but \"browser.search.region\" flag in \"about:config\" must be set to 'US'"
+    "8":"Enabled by default in Nightly, but \"browser.search.region\" pref in \"about:config\" must be set to 'US'",
+    "9":"Enabled by default in Nightly, but \"dom.payments.request.supportedRegions\" pref in \"about:config\" must be set to \"US,CA\".",
   },
   "usage_perc_y":0,
   "usage_perc_a":74.74,

--- a/features-json/payment-request.json
+++ b/features-json/payment-request.json
@@ -120,7 +120,7 @@
       "62":"n d #6",
       "63":"n d #6",
       "64":"a d #8",
-      "65":"a d #9"
+      "65":"a d #8"
     },
     "chrome":{
       "4":"n",
@@ -349,8 +349,7 @@
     "5":"Unlike Desktop Chrome, support has been in Chrome for Android since version 53.",
     "6":"Can be enabled via the `dom.payments.request.enabled` flag in \"about:config\" flag since 55.",
     "7":"Missing support for PaymentResponse.prototype.retry() method",
-    "8":"Enabled by default in Nightly, but \"browser.search.region\" pref in \"about:config\" must be set to 'US'",
-    "9":"Enabled by default in Nightly, but \"dom.payments.request.supportedRegions\" pref in \"about:config\" must be set to \"US,CA\"."
+    "8":"Enabled by default in Nightly, but \"dom.payments.request.supportedRegions\" pref in \"about:config\" must be set to \"US,CA\"."
   },
   "usage_perc_y":0,
   "usage_perc_a":74.74,


### PR DESCRIPTION
Firefox introduced a new pref "dom.payments.request.supportedRegions", which takes a list of country codes. Only CA and US are supported right now.