### PR TITLE
 Downgrade SVG fragments support for IE

### DIFF
--- a/features-json/svg-fragment.json
+++ b/features-json/svg-fragment.json
@@ -335,7 +335,7 @@
   "notes":"",
   "notes_by_num":{
     "1":"Partial support refers to support inside `<img>` but not as CSS `background-image`",
-    "2":"Partial support refers to lack of the external fragments support"
+    "2":"Partial support refers to lack of external fragments support"
   },
   "usage_perc_y":89.78,
   "usage_perc_a":2.09,

--- a/features-json/svg-fragment.json
+++ b/features-json/svg-fragment.json
@@ -335,7 +335,7 @@
   "notes":"",
   "notes_by_num":{
     "1":"Partial support refers to support inside `<img>` but not as CSS `background-image`",
-    "2":"Partial support refers tolack of the external fragments support"
+    "2":"Partial support refers to lack of the external fragments support"
   },
   "usage_perc_y":89.78,
   "usage_perc_a":2.09,

--- a/features-json/svg-fragment.json
+++ b/features-json/svg-fragment.json
@@ -33,9 +33,9 @@
       "6":"n",
       "7":"n",
       "8":"n",
-      "9":"y",
-      "10":"y",
-      "11":"y"
+      "9":"a #2",
+      "10":"a #2",
+      "11":"a #2"
     },
     "edge":{
       "12":"y",
@@ -334,7 +334,8 @@
   },
   "notes":"",
   "notes_by_num":{
-    "1":"Partial support refers to support inside `<img>` but not as CSS `background-image`"
+    "1":"Partial support refers to support inside `<img>` but not as CSS `background-image`",
+    "2":"Partial support refers tolack of the external fragments support"
   },
   "usage_perc_y":89.78,
   "usage_perc_a":2.09,


### PR DESCRIPTION
IE can't load SVG fragments from external resources, which means it only provides partial support for them.