### PR TITLE
Safari 12 requires prefix for backface-visibility

### DIFF
--- a/features-json/transforms3d.json
+++ b/features-json/transforms3d.json
@@ -357,7 +357,7 @@
   "notes":"",
   "notes_by_num":{
     "1":"Partial support in IE refers to not supporting [the transform-style: preserve-3d property](http://msdn.microsoft.com/en-us/library/ie/hh673529%28v=vs.85%29.aspx#the_ms_transform_style_property). This prevents nesting 3D transformed elements.",
-    "2":"Safari 9, 10 & 11 are reported to still require a prefix for the related `backface-visibility` property."
+    "2":"Safari 9, 10, 11, & 12 are reported to still require a prefix for the related `backface-visibility` property."
   },
   "usage_perc_y":90.65,
   "usage_perc_a":2.78,


### PR DESCRIPTION
In Safari, version 12.0 (14606.1.36.1.9), this line of code has no effect, and you can still see the "backface".

`backface-visibility: hidden;`

However, when I use the prefix for Safari, as seen below, the "backface" is now hidden.

`-webkit-backface-visibility: hidden;`

Safari, version 12, still requires the prefix.
