### PR TITLE
Default media playback controls blocked in Safari with strict CSP

### DIFF
--- a/features-json/audio.json
+++ b/features-json/audio.json
@@ -39,6 +39,9 @@
   ],
   "bugs":[
     {
+      "description":"The default [media playback controls are not displayed](https://www.ctrl.blog/entry/safari-csp-media-controls) with a strict Content-Security-Policy in Safari 11 and 12 unless you allow loading images from data URIs. (`img-src data:`, like `unsafe-inline`)."
+    },
+    {
       "description":"Volume is read-only on iOS."
     },
     {

--- a/features-json/video.json
+++ b/features-json/video.json
@@ -30,7 +30,9 @@
     }
   ],
   "bugs":[
-    
+    {
+      "description":"The default [media playback controls are not displayed](https://www.ctrl.blog/entry/safari-csp-media-controls) with a strict Content-Security-Policy in Safari 11 and 12 unless you allow loading images from data URIs. (`img-src data:`, like `unsafe-inline`)."
+    }
   ],
   "categories":[
     "HTML5"


### PR DESCRIPTION
Affects Safari 11 and 12 for iOS 11 and 12 and macOS.