### PR TITLE
Fix bugzilla link for :focus-visible

### DIFF
--- a/features-json/css-focus-visible.json
+++ b/features-json/css-focus-visible.json
@@ -25,7 +25,7 @@
       "title":"Microsoft Edge implementation suggestion"
     },
     {
-      "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=1437901&GoAheadAndLogIn=1",
+      "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=1437901",
       "title":"Bugzilla: Add :focus-visible (former :focus-ring)"
     },
     {


### PR DESCRIPTION
The old link always forced you to login, the fixed link works anonymously.