### PR TITLE
Update Mask and Clip Path support for Edge 18

### DIFF
--- a/features-json/css-clip-path.json
+++ b/features-json/css-clip-path.json
@@ -40,7 +40,7 @@
       "15":"n",
       "16":"n",
       "17":"n",
-      "18":"a #4"
+      "18":"n d #4 #5"
     },
     "firefox":{
       "2":"n",
@@ -333,7 +333,8 @@
     "1":"Partial support refers to only supporting the `url()` syntax.",
     "2":"Partial support refers to supporting shapes and the `url(#foo)` syntax for inline SVG, but not shapes in external SVGs.",
     "3":"Supports shapes behind the `layout.css.clip-path-shapes.enabled` flag",
-    "4":"While Edge doesn't seem to recognize any `<basic-shape>` function, it does allow you to use `polygon()` in HTML and SVG"
+    "4":"Partial support can be enabled on MS Edge with the Enable CSS Clip-Path Flag",
+    "5":"While Edge doesn't seem to recognize any `<basic-shape>` function, it does allow you to use `polygon()` in HTML and SVG"
   },
   "usage_perc_y":4.19,
   "usage_perc_a":84,

--- a/features-json/css-clip-path.json
+++ b/features-json/css-clip-path.json
@@ -333,7 +333,7 @@
     "1":"Partial support refers to only supporting the `url()` syntax.",
     "2":"Partial support refers to supporting shapes and the `url(#foo)` syntax for inline SVG, but not shapes in external SVGs.",
     "3":"Supports shapes behind the `layout.css.clip-path-shapes.enabled` flag",
-    "4":"While Edge doesn't seem to recognize any `<basic-shape>` function, it does allow you to use the `polygon()` function for use in HTML and SVG"
+    "4":"While Edge doesn't seem to recognize any `<basic-shape>` function, it does allow you to use `polygon()` in HTML and SVG"
   },
   "usage_perc_y":4.19,
   "usage_perc_a":84,

--- a/features-json/css-clip-path.json
+++ b/features-json/css-clip-path.json
@@ -40,7 +40,7 @@
       "15":"n",
       "16":"n",
       "17":"n",
-      "18":"n"
+      "18":"a #4"
     },
     "firefox":{
       "2":"n",
@@ -332,7 +332,8 @@
   "notes_by_num":{
     "1":"Partial support refers to only supporting the `url()` syntax.",
     "2":"Partial support refers to supporting shapes and the `url(#foo)` syntax for inline SVG, but not shapes in external SVGs.",
-    "3":"Supports shapes behind the `layout.css.clip-path-shapes.enabled` flag"
+    "3":"Supports shapes behind the `layout.css.clip-path-shapes.enabled` flag",
+    "4":"While Edge doesn't seem to recognize any `<basic-shape>` function, it does allow you to use the `polygon()` function for use in HTML and SVG"
   },
   "usage_perc_y":4.19,
   "usage_perc_a":84,

--- a/features-json/css-masks.json
+++ b/features-json/css-masks.json
@@ -52,7 +52,7 @@
       "15":"n",
       "16":"n",
       "17":"n d #4 #5",
-      "18":"a #6"
+      "18":"a #6 #7"
     },
     "firefox":{
       "2":"n",
@@ -347,7 +347,8 @@
     "3":"Partial support refers to supporting the mask-box-image shorthand but not the longhand properties",
     "4":"Can be enabled in MS edge behind the \"Enable CSS Masking\" flag.",
     "5":"Partial support refers to supporting mask-image and mask-size",
-    "6":"Partial support refers to supporting mask-image, mask-size, mask-position, and the mask shorthand"
+    "6":"Partial support refers to supporting mask-image, mask-size, mask-position, mask-repeat and mask-composite",
+    "7":"Edge also recognizes and suporrts all the `-webkit-` prefixed equilavants of the unprefixed properties for site compability"
   },
   "usage_perc_y":4.2,
   "usage_perc_a":84.6,

--- a/features-json/css-masks.json
+++ b/features-json/css-masks.json
@@ -348,7 +348,7 @@
     "4":"Can be enabled in MS edge behind the \"Enable CSS Masking\" flag.",
     "5":"Partial support refers to supporting mask-image and mask-size",
     "6":"Partial support refers to supporting mask-image, mask-size, mask-position, mask-repeat and mask-composite",
-    "7":"Edge also recognizes and suporrts all the `-webkit-` prefixed equilavants of the unprefixed properties for site compability"
+    "7":"Edge also recognizes and supports all the `-webkit-` prefixed equivalents of the unprefixed properties for site compatibility"
   },
   "usage_perc_y":4.2,
   "usage_perc_a":84.6,


### PR DESCRIPTION
Found that properties recognized by Edge 18 in Masking are a bit different. And also a pic is given to proven that `polygon()` in Clip Path for HTML/SVG **is** supported
![image](https://user-images.githubusercontent.com/30199227/49329425-60e7e380-f587-11e8-94dd-2f43929e56c6.png)
