### PR TITLE
Update publickeypinning.json with Chrome 72 info

### DIFF
--- a/features-json/publickeypinning.json
+++ b/features-json/publickeypinning.json
@@ -323,7 +323,7 @@
       "7.12":"y"
     }
   },
-  "notes":"The HTTP header syntax is 'Public-Key-Pins: pin-sha256=\"base64==\"; max-age=expireTime [; includeSubdomains][; report-uri=\"reportURI\"]'.\r\n\r\nSupport in Chrome was [deprecated and removed](https://groups.google.com/a/chromium.org/forum/#!msg/blink-dev/he9tr7p3rZ8/eNMwKPmUBAAJ).",
+  "notes":"The HTTP header syntax is 'Public-Key-Pins: pin-sha256=\"base64==\"; max-age=expireTime [; includeSubdomains][; report-uri=\"reportURI\"]'.\r\n\r\nSupport in Chrome was [deprecated](https://groups.google.com/a/chromium.org/forum/#!msg/blink-dev/he9tr7p3rZ8/eNMwKPmUBAAJ) and [removed](https://blog.chromium.org/2018/12/chrome-72-beta-public-class-fields-user.html?m=1).",
   "notes_by_num":{
     
   },


### PR DESCRIPTION
Changed and added reference to Chrome HPKP support.
Chrome officially announced they will no longer support the HPKP header in version 72.