### PR TITLE
Dynamic import() status should be "other"

### DIFF
--- a/features-json/es6-module-dynamic-import.json
+++ b/features-json/es6-module-dynamic-import.json
@@ -1,8 +1,8 @@
 {
   "title":"JavaScript modules: dynamic import()",
   "description":"Loading JavaScript modules dynamically using the import() syntax",
-  "spec":"https://github.com/tc39/proposal-dynamic-import/blob/master/HTML%20Integration.md",
-  "status":"unoff",
+  "spec":"https://github.com/tc39/proposal-dynamic-import",
+  "status":"other",
   "links":[
     {
       "url":"https://tc39.github.io/proposal-dynamic-import/",
@@ -15,6 +15,10 @@
     {
       "url":"https://developers.google.com/web/updates/2017/11/dynamic-import",
       "title":"Dynamic import()"
+    },
+    {
+      "url":"https://html.spec.whatwg.org/multipage/webappapis.html#integration-with-the-javascript-module-system",
+      "title":"Integration with the HTML specification"
     },
     {
       "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=1342012",


### PR DESCRIPTION
The underpinnings [have been merged](https://github.com/whatwg/html/pull/3044) into the [HTML Spec](https://html.spec.whatwg.org/multipage/webappapis.html#integration-with-the-javascript-module-system).
"other" matches the existing stage-XX ECMAScript features on caniuse.