### PR TITLE
[css-masks]: Remove link to defunct website

### DIFF
--- a/features-json/css-masks.json
+++ b/features-json/css-masks.json
@@ -13,10 +13,6 @@
       "title":"HTML5 Rocks article"
     },
     {
-      "url":"http://thenittygritty.co/css-masking",
-      "title":"Detailed blog post"
-    },
-    {
       "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=1224422",
       "title":"Firefox implementation bug"
     },


### PR DESCRIPTION
The website is not working anymore, it sends you to domain parking pages or even worse scammy "Install ad blocker on Chrome now!" pages.