### PR TITLE
Updated info about AV1 support in Firefox 65.0 and 66.0

### DIFF
--- a/features-json/av1.json
+++ b/features-json/av1.json
@@ -13,12 +13,16 @@
       "title":"Sample video from Bitmovin"
     },
     {
+      "url":"https://www.facebook.com/330716120785217/videos/330723190784510/",
+      "title":"Sample video from Facebook"
+    },
+    {
       "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/34544281-support-aomedia-video-1-av1",
       "title":"Microsoft Edge feature request on UserVoice"
     },
     {
-      "url":"https://www.facebook.com/330716120785217/videos/330723190784510/",
-      "title":"Sample video from Facebook"
+      "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=1452683",
+      "title":"Firefox implementation bug"
     }
   ],
   "bugs":[
@@ -44,7 +48,7 @@
       "15":"n",
       "16":"n",
       "17":"n",
-      "18":"n d #4"
+      "18":"n d #5"
     },
     "firefox":{
       "2":"n",
@@ -112,8 +116,8 @@
       "62":"n d #1",
       "63":"n d #2",
       "64":"n d #2",
-      "65":"y",
-      "66":"y"
+      "65":"a #2 #3",
+      "66":"a #2 #3"
     },
     "chrome":{
       "4":"n",
@@ -179,9 +183,9 @@
       "64":"n",
       "65":"n",
       "66":"n",
-      "67":"n d #3",
-      "68":"n d #3",
-      "69":"n d #3",
+      "67":"n d #4",
+      "68":"n d #4",
+      "69":"n d #4",
       "70":"y",
       "71":"y",
       "72":"y",
@@ -337,10 +341,11 @@
   },
   "notes":"",
   "notes_by_num":{
-    "1":"Can be enabled in Firefox Nightly only, via the `media.av1.enabled` flag in `about:config`",
-    "2":"Can be enabled in Firefox (Nightly, Beta/Developer Edition, and Release), via the `media.av1.enabled` flag in `about:config`",
-    "3":"Can be enabled in Chrome via the #enable-av1-decoder flag in `chrome://flags`",
-    "4":"Supported in Edge when the AV1 Video Extension (Beta) is installed from the Microsoft Store"
+    "1":"Can be enabled in Firefox Nightly only via the `media.av1.enabled` flag in `about:config`",
+    "2":"Can be enabled in (all editions of) Firefox via the `media.av1.enabled` flag in `about:config`",
+    "3":"Enabled by default only for Windows users",
+    "4":"Can be enabled in Chrome via the #enable-av1-decoder flag in `chrome://flags`",
+    "5":"Supported in Edge when the AV1 Video Extension (Beta) is installed from the Microsoft Store"
   },
   "usage_perc_y":25.22,
   "usage_perc_a":0,


### PR DESCRIPTION
As the title says, I updated the information about AV1 support in Firefox version 65.0 and 66.0.

I'm not sure, whether the support for AV1 will "ride the trains" into release channel, or maybe it will stay in beta for a longer time, but since #4713 was merged, these information should be specified ASAP that AV1 is enabled by default ONLY for Windows users (for now).

Reference:
https://bugzilla.mozilla.org/show_bug.cgi?id=1452146