### PR TITLE
Add info about Safari display: contents bugs

### DIFF
--- a/features-json/css-display-contents.json
+++ b/features-json/css-display-contents.json
@@ -206,9 +206,9 @@
       "10":"n",
       "10.1":"n",
       "11":"n",
-      "11.1":"a #2",
-      "12":"a #2",
-      "TP":"a #2"
+      "11.1":"a #2 #3",
+      "12":"a #2 #3",
+      "TP":"a #2 #3"
     },
     "opera":{
       "9":"n",
@@ -340,7 +340,8 @@
   "notes":"",
   "notes_by_num":{
     "1":"Enabled in Chrome through the \"experimental Web Platform features\" flag in chrome://flags",
-    "2":"Partial support refers to severe implementation bug that renders the content inaccessible. https://hiddedevries.nl/en/blog/2018-04-21-more-accessible-markup-with-display-contents"
+    "2":"Partial support refers to severe implementation bug that renders the content inaccessible. https://hiddedevries.nl/en/blog/2018-04-21-more-accessible-markup-with-display-contents",
+    "3":"Safari support is buggy, see https://bugs.webkit.org/show_bug.cgi?id=188259 & https://bugs.webkit.org/show_bug.cgi?id=193567"
   },
   "usage_perc_y":3.6,
   "usage_perc_a":72.95,


### PR DESCRIPTION
Safari support is buggy, see
* Toggling `display: contents` to `display: none` fails to hide the element https://bugs.webkit.org/show_bug.cgi?id=188259
* `::before`/`::after` elements not filling their grid cell when container has display: contents  https://bugs.webkit.org/show_bug.cgi?id=193567