### PR TITLE
Android Pie web views support rrggbbaa hex color notation

### DIFF
--- a/features-json/css-rrggbbaa.json
+++ b/features-json/css-rrggbbaa.json
@@ -327,7 +327,7 @@
       "7.12":"n d #1"
     }
   },
-  "notes":"Support in Android WebView is currently disabled due to [this issue](https://bugs.chromium.org/p/chromium/issues/detail?id=618472)",
+  "notes":"Only supported in Android WebViews in apps that target Android Pie, due to [this issue](https://bugs.chromium.org/p/chromium/issues/detail?id=618472)",
   "notes_by_num":{
     "1":"Can be enabled via the \"Experimental web platform features\" flag."
   },


### PR DESCRIPTION
Source: https://bugs.chromium.org/p/chromium/issues/detail?id=618472