### PR TITLE
Add note about `replace()` on classList for IE11

### DIFF
--- a/features-json/classlist.json
+++ b/features-json/classlist.json
@@ -46,7 +46,7 @@
       "8":"p",
       "9":"p",
       "10":"a #1 #2 #3",
-      "11":"a #1 #2 #3 #4"
+      "11":"a #1 #2 #3 #4 #5"
     },
     "edge":{
       "12":"y",
@@ -353,7 +353,8 @@
     "1":"Does not have support for `classList` on SVG or MathML elements.",
     "2":"Does not support the second parameter for the `toggle` method",
     "3":"Does not support multiple parameters for the `add()` & `remove()` methods",
-    "4":"Does not support assign to `classList`"
+    "4":"Does not support assign to `classList`",
+    "5":"Does not support the `replace()` method"
   },
   "usage_perc_y":89.89,
   "usage_perc_a":5.23,


### PR DESCRIPTION
I found out that IE11 does not support `classList.replace()`, so I figured I'd let others know 😄. I don't have IE10 available to test on.

Not sure if this relates to #3326 specifically.