### PR TITLE
css-display-contents: make links clickable

### DIFF
--- a/features-json/css-display-contents.json
+++ b/features-json/css-display-contents.json
@@ -343,8 +343,8 @@
   "notes":"",
   "notes_by_num":{
     "1":"Enabled in Chrome through the \"experimental Web Platform features\" flag in chrome://flags",
-    "2":"Partial support refers to severe implementation bug that renders the content inaccessible. https://hiddedevries.nl/en/blog/2018-04-21-more-accessible-markup-with-display-contents",
-    "3":"Safari support is buggy, see https://bugs.webkit.org/show_bug.cgi?id=188259 & https://bugs.webkit.org/show_bug.cgi?id=193567"
+    "2":"Partial support refers to [severe implementation bug](https://hiddedevries.nl/en/blog/2018-04-21-more-accessible-markup-with-display-contents) that renders the content inaccessible.",
+    "3":"Safari support is buggy, see [WebKit bug 188259](https://bugs.webkit.org/show_bug.cgi?id=188259) & [WebKit bug 193567](https://bugs.webkit.org/show_bug.cgi?id=193567)"
   },
   "usage_perc_y":3.56,
   "usage_perc_a":73.65,


### PR DESCRIPTION
I understand Markdown links are supported based on https://github.com/Fyrd/caniuse/blob/master/features-json/css-snappoints.json