### PR TITLE
Add template literal bug in Safari 12

### DIFF
--- a/features-json/template-literals.json
+++ b/features-json/template-literals.json
@@ -14,7 +14,9 @@
     }
   ],
   "bugs":[
-    
+    {
+      "description":"Safari 12 [sometimes garbage collects](https://bugs.webkit.org/show_bug.cgi?id=190756) the cached TemplateStrings used by Tagged Template Literals"
+    }
   ],
   "categories":[
     "JS",
@@ -200,9 +202,9 @@
       "10.1":"y",
       "11":"y",
       "11.1":"y",
-      "12":"y",
-      "12.1":"y",
-      "TP":"y"
+      "12":"a",
+      "12.1":"a",
+      "TP":"a"
     },
     "opera":{
       "9":"n",
@@ -275,8 +277,8 @@
       "10.3":"y",
       "11.0-11.2":"y",
       "11.3-11.4":"y",
-      "12.0-12.1":"y",
-      "12.2":"y"
+      "12.0-12.1":"a",
+      "12.2":"a"
     },
     "op_mini":{
       "all":"n"


### PR DESCRIPTION
Safari 12 has a [bug](https://bugs.webkit.org/show_bug.cgi?id=190756) that breaks caching of `TemplateStrings`.

Re: https://github.com/kangax/compat-table/pull/1424