### PR TITLE
[details.json] Add note on Safari font-size bug

### DIFF
--- a/features-json/details.json
+++ b/features-json/details.json
@@ -221,9 +221,9 @@
       "9":"y #2",
       "9.1":"y #2",
       "10":"y #2",
-      "10.1":"y",
-      "11":"y",
-      "11.1":"y",
+      "10.1":"y #4",
+      "11":"y #4",
+      "11.1":"y #4",
       "12":"y",
       "12.1":"y",
       "TP":"y"
@@ -295,9 +295,9 @@
       "8.1-8.4":"y",
       "9.0-9.2":"y",
       "9.3":"y",
-      "10.0-10.2":"y",
-      "10.3":"y",
-      "11.0-11.2":"y",
+      "10.0-10.2":"y #4",
+      "10.3":"y #4",
+      "11.0-11.2":"y #4",
       "11.3-11.4":"y",
       "12.0-12.1":"y",
       "12.2":"y"
@@ -361,7 +361,8 @@
   "notes_by_num":{
     "1":"Enabled in Firefox through the `dom.details_element.enabled` flag",
     "2":"'toggle' event is not supported",
-    "3":"<summary> is not keyboard accessible"
+    "3":"<summary> is not keyboard accessible",
+    "4":"Some versions of Safari display smaller font-size than intended when using `rem` units with system fonts. (See: https://colloq.io/blog/safaris-detailssummary-rem-font-size-issue)"
   },
   "usage_perc_y":87.47,
   "usage_perc_a":0,


### PR DESCRIPTION
Resolves #4785.

A review of affected Safari versions would be appreciated. But I think I've got it close enough unless I'm mistaken.

[The webkit bug](https://bugs.webkit.org/show_bug.cgi?id=173876) only mentions macOS 10.13.
However, this blog post: https://colloq.io/blog/safaris-detailssummary-rem-font-size-issue mentions Safari 10.1/11.1.

If anyone have more details on the affected versions of Safari that'd be helpful. I personally tested [this](https://csswizardry.net/demos/safari-details-text/) on iphone Safari 12.1.2 and a tablet w/ Safari 9.3, with no issues regarding the font-sizes.

