### PR TITLE
Remove duplicate html5tutorial.info link

### DIFF
--- a/features-json/input-color.json
+++ b/features-json/input-color.json
@@ -23,10 +23,6 @@
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/color",
       "title":"MDN web docs"
-    },
-    {
-      "url":"https://www.html5tutorial.info/html5-color.php",
-      "title":"Tutorial"
     }
   ],
   "bugs":[


### PR DESCRIPTION
The `http://www.html5tutorial.info/html5-color.php` link existed twice.