### PR TITLE
W3C released Webauthn on March 4th, 2019

### DIFF
--- a/features-json/webauthn.json
+++ b/features-json/webauthn.json
@@ -1,8 +1,8 @@
 {
   "title":"Web Authentication API",
   "description":"The Web Authentication API is an extension of the Credential Management API that enables strong authentication with public key cryptography, enabling password-less authentication and / or secure second-factor authentication without SMS texts.",
-  "spec":"https://w3c.github.io/webauthn/",
-  "status":"cr",
+  "spec":"https://www.w3.org/TR/webauthn/",
+  "status":"rec",
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/Web_Authentication_API",


### PR DESCRIPTION
Updated status and URL after W3C released Webauthn as a standard ("W3C Recommendation")