### PR TITLE
Mention that WebGL2 in Safari is far from usable

### DIFF
--- a/features-json/webgl2.json
+++ b/features-json/webgl2.json
@@ -338,7 +338,7 @@
     "1":"Can be enabled in Firefox by setting the about:config preference webgl.enable-prototype-webgl2 to true",
     "2":"WebGL2 context is accessed from \"experimental-webgl2\" rather than \"webgl2\"",
     "3":"Can be enabled in Chrome by passing the \"--enable-unsafe-es3-apis\" flag when starting the browser through the command line",
-    "4":"Can be enabled via the \"Experimental Features\" developer menu",
+    "4":"Has an option to enable via the \"Experimental Features\" developer menu but fails 77% of the WebGL2 conformance tests make it nearly unusable and has not seen any development activity in over 3 years",
     "5":"Enabled by default for Nightly and Dev Edition"
   },
   "usage_perc_y":67.76,


### PR DESCRIPTION
Someone at Apple 4 years ago added a flag for WebGL2 but they didn't actually implement anything except a stub that returns a WebGL1 context when WebGL2 is requested and allowed GLSL ES 3.0 shaders. You can look in the WebKit source code and see there is no actual implementation. 99% of the added WebGL2 functionality is missing. You can try to run the [conformance tests](https://www.khronos.org/registry/webgl/sdk/tests/webgl-conformance-tests.html?version=2.0.1) and see that except for a few WebGL1 tests they pass almost nothing.

Here's the results of running the WebGL2 conformance tests on Safari Tech Preview 76 (12.2)

```
Passed 624/2733 tests (22.83%), 83619/275358 subtests (30.37%) 
Failed 1857/2733 tests (67.95%), 191184/275358 subtests (69.43%) 
Timeout 252/2733 tests (9.22%)
```

```
WebGL Conformance Test Results
Version 2.0.1
Generated on: Thu Mar 07 2019 10:44:14 GMT+0900 (JST)

-------------------

User Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_3) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.2 Safari/605.1.15
WebGL VENDOR: WebKit
WebGL VERSION: WebGL 2.0
WebGL RENDERER: WebKit WebGL
Unmasked VENDOR: NVIDIA Corporation
Unmasked RENDERER: NVIDIA GeForce GT 750M OpenGL Engine
WebGL R/G/B/A/Depth/Stencil bits (default config): 0/0/0/0/0/0

-------------------

Test Summary: FAIL (2733 tests):
275358 subtests ran in 81603.86 seconds
PASSED: 624 tests, 83619 subtests
NOT PASSED: 2109 tests, 191739 subtests
FAILED: 1857 tests, 191184 subtests
TIMED OUT: 252 tests, 555 subtests
SKIPPED: 0 tests, 0 subtests

-------------------
```