### PR TITLE
Firefox 66 has scroll anchoring

### DIFF
--- a/features-json/css-overflow-anchor.json
+++ b/features-json/css-overflow-anchor.json
@@ -105,8 +105,8 @@
       "63":"n",
       "64":"n",
       "65":"n",
-      "66":"n",
-      "67":"n"
+      "66":"y",
+      "67":"y"
     },
     "chrome":{
       "4":"n",
@@ -333,7 +333,7 @@
       "7.12":"y"
     }
   },
-  "notes":"Mozilla has discussed a similar feature in [Bug 43114](https://bugzilla.mozilla.org/show_bug.cgi?id=43114).",
+  "notes":"",
   "notes_by_num":{
     
   },


### PR DESCRIPTION
According to:

https://bugzilla.mozilla.org/show_bug.cgi?id=1305957

https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/66