### PR TITLE
Updated notes section in Shadow DOM v1

### DIFF
--- a/features-json/shadowdomv1.json
+++ b/features-json/shadowdomv1.json
@@ -339,11 +339,11 @@
       "7.12":"n"
     }
   },
-  "notes":"Shadow DOM v0 was implemented in Chrome/Opera but other browser vendors are implementing v1.",
+  "notes":"",
   "notes_by_num":{
     "1":"Certain CSS selectors do not work (`:host > .local-child`) and styling slotted content (`::slotted`) is buggy.",
-    "2":"Enabled through the \"dom.webcomponents.enabled\" preference in about:config",
-    "3":"Enabled through the \"dom.webcomponents.shadowdom.enabled\" preference in about:config"
+    "2":"Enabled through the `dom.webcomponents.enabled` preference in `about:config`.",
+    "3":"Enabled through the `dom.webcomponents.shadowdom.enabled` preference in `about:config`."
   },
   "usage_perc_y":74.12,
   "usage_perc_a":12.81,


### PR DESCRIPTION
I removed info that Shadow DOM v0 is being implemented by Chrome and Opera, unlike other browsers, since it is no longer true.