### PR TITLE
macOS 10.14.4 has TLS 1.3 support by default

### DIFF
--- a/features-json/tls1-3.json
+++ b/features-json/tls1-3.json
@@ -206,8 +206,8 @@
       "11":"n",
       "11.1":"n",
       "12":"n",
-      "12.1":"n",
-      "TP":"n"
+      "12.1":"y #5",
+      "TP":"y #5"
     },
     "opera":{
       "9":"n",
@@ -344,7 +344,8 @@
     "1":"Can be enabled by setting \"TLS 1.3\" to \"Enabled (Draft)\" at `chrome://flags/tls13-variant`.",
     "2":"Can be enabled by setting \"Maximum TLS version enabled\" to \"TLS 1.3\"at `chrome://flags/`. Support is reported to have be currently enabled as of version 56 for 1/10th of all users.",
     "3":"Enabled on the regular version of Firefox 53, but [not the ESR version](https://groups.google.com/forum/#!topic/mozilla.dev.platform/sfeqeMkyxCI).",
-    "4":"Can be enabled by using `--ssl-version-max=tls1.3` command line argument from version 41 or by setting \"TLS 1.3\" to \"Enabled (Draft 23)\" at `opera://flags/#tls13-variant` from version 54."
+    "4":"Can be enabled by using `--ssl-version-max=tls1.3` command line argument from version 41 or by setting \"TLS 1.3\" to \"Enabled (Draft 23)\" at `opera://flags/#tls13-variant` from version 54.",
+    "5":"Support enabled by default starting with macOS 10.14.4"
   },
   "usage_perc_y":70.42,
   "usage_perc_a":0.21,


### PR DESCRIPTION
Fixes #4677