### PR TITLE
WebM: Safari's WebRTC-only VP8 support

### DIFF
--- a/features-json/webm.json
+++ b/features-json/webm.json
@@ -214,8 +214,8 @@
       "11":"p",
       "11.1":"p",
       "12":"p",
-      "12.1":"p",
-      "TP":"p"
+      "12.1":"a #1",
+      "TP":"a #1"
     },
     "opera":{
       "9":"n",
@@ -290,7 +290,7 @@
       "11.0-11.2":"n",
       "11.3-11.4":"n",
       "12.0-12.1":"n",
-      "12.2":"n"
+      "12.2":"a #1"
     },
     "op_mini":{
       "all":"n"
@@ -352,7 +352,7 @@
   },
   "notes":"Will work in IE9+ and Safari/MacOSX provided the user has the WebM codecs installed. Partial support indicates that at least one codec is supported but not all. MS Edge supports VP9 from MSE sources, also progressive sources are not supported by Edge.",
   "notes_by_num":{
-    
+    "1":"Only supports [VP8 used in WebRTC.](https://webkit.org/blog/8672/on-the-road-to-webrtc-1-0-including-vp8/)"
   },
   "usage_perc_y":76.49,
   "usage_perc_a":3.77,


### PR DESCRIPTION
Safari 12.1 / iOS 12.2 introduced support for [VP8 but only when used in WebRTC.](https://webkit.org/blog/8672/) 

Couldn't come up with a better phrasing than this. Edits are welcomed.