### PR TITLE
Improved info about Picture in Picture support

### DIFF
--- a/features-json/picture-in-picture.json
+++ b/features-json/picture-in-picture.json
@@ -5,24 +5,24 @@
   "status":"unoff",
   "links":[
     {
-      "url":"https://developers.google.com/web/updates/2018/10/watch-video-using-picture-in-picture",
-      "title":"Intro"
-    },
-    {
       "url":"https://googlechrome.github.io/samples/picture-in-picture/",
-      "title":"Samples"
-    },
-    {
-      "url":"https://github.com/WICG/picture-in-picture/blob/master/implementation-status.md",
-      "title":"Implementation Status"
+      "title":"Sample video"
     },
     {
       "url":"https://developer.apple.com/documentation/webkitjs/adding_picture_in_picture_to_your_safari_media_controls",
       "title":"Safari equivalent API"
     },
     {
-      "url":"https://www.trishtech.com/2017/12/pop-out-videos-on-any-website-in-opera-browser/",
-      "title":"Pop-Out Opera feature"
+      "url":"https://blogs.opera.com/desktop/2016/04/opera-beta-update-video-pop/",
+      "title":"Opera equivalent Video Pop Out feature"
+    },
+    {
+      "url":"https://github.com/WICG/picture-in-picture/blob/master/implementation-status.md",
+      "title":"Implementation Status"
+    },
+    {
+      "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=1519885",
+      "title":"Firefox implementation bug"
     }
   ],
   "bugs":[
@@ -119,7 +119,7 @@
       "65":"n",
       "66":"n",
       "67":"n",
-      "68":"n"
+      "68":"n d #1"
     },
     "chrome":{
       "4":"n",
@@ -187,7 +187,7 @@
       "66":"n",
       "67":"n",
       "68":"n",
-      "69":"n d",
+      "69":"n d #2",
       "70":"y",
       "71":"y",
       "72":"y",
@@ -209,13 +209,13 @@
       "8":"n",
       "9":"n",
       "9.1":"n",
-      "10":"a d #1",
-      "10.1":"a d #1",
-      "11":"a d #1",
-      "11.1":"a d #1",
-      "12":"a d #1",
-      "12.1":"a d #1",
-      "TP":"a d #1"
+      "10":"a #3",
+      "10.1":"a #3",
+      "11":"a #3",
+      "11.1":"a #3",
+      "12":"a #3",
+      "12.1":"a #3",
+      "TP":"a #3"
     },
     "opera":{
       "9":"n",
@@ -251,28 +251,28 @@
       "34":"n",
       "35":"n",
       "36":"n",
-      "37":"a d #2",
-      "38":"a #2",
-      "39":"a #2",
-      "40":"a #2",
-      "41":"a #2",
-      "42":"a #2",
-      "43":"a #2",
-      "44":"a #2",
-      "45":"a #2",
-      "46":"a #2",
-      "47":"a #2",
-      "48":"a #2",
-      "49":"a #2",
-      "50":"a #2",
-      "51":"a #2",
-      "52":"a #2",
-      "53":"a #2",
-      "54":"a #2",
-      "55":"a #2",
-      "56":"a #2",
-      "57":"a #2",
-      "58":"a #2"
+      "37":"a #4",
+      "38":"a #4",
+      "39":"a #4",
+      "40":"a #4",
+      "41":"a #4",
+      "42":"a #4",
+      "43":"a #4",
+      "44":"a #4",
+      "45":"a #4",
+      "46":"a #4",
+      "47":"a #4",
+      "48":"a #4",
+      "49":"a #4",
+      "50":"a #4",
+      "51":"a #4",
+      "52":"a #4",
+      "53":"a #4",
+      "54":"a #4",
+      "55":"a #4",
+      "56":"a #4",
+      "57":"a #4",
+      "58":"a #4"
     },
     "ios_saf":{
       "3.2":"n",
@@ -283,14 +283,14 @@
       "7.0-7.1":"n",
       "8":"n",
       "8.1-8.4":"n",
-      "9.0-9.2":"n",
-      "9.3":"n",
-      "10.0-10.2":"a d #1",
-      "10.3":"a d #1",
-      "11.0-11.2":"a d #1",
-      "11.3-11.4":"a d #1",
-      "12.0-12.1":"a d #1",
-      "12.2":"a d #1"
+      "9.0-9.2":"a #3",
+      "9.3":"a #3",
+      "10.0-10.2":"a #3",
+      "10.3":"a #3",
+      "11.0-11.2":"a #3",
+      "11.3-11.4":"a #3",
+      "12.0-12.1":"a #3",
+      "12.2":"a #3"
     },
     "op_mini":{
       "all":"n"
@@ -321,10 +321,10 @@
       "46":"n"
     },
     "and_chr":{
-      "71":"a #3"
+      "71":"a #5"
     },
     "and_ff":{
-      "64":"a #3"
+      "64":"a #5"
     },
     "ie_mob":{
       "10":"n",
@@ -352,9 +352,11 @@
   },
   "notes":"",
   "notes_by_num":{
-    "1":"Apple provides an equivalent proprietary API for Picture-in-Picture.",
-    "2":"Opera allows users to use Picture-in-Picture for all playing videos (JS API not available)",
-    "3":"Automatically plays video in Picture-in-Picture when user hits Home Screen button and video is fullscreen (Android >= Oreo required)"
+    "1":"Can be enabled in Firefox Nightly only via the `media.videocontrols.picture-in-picture.enabled` pref in `about:config`.",
+    "2":"Can be enabled in Chrome via the `#enable-picture-in-picture` & `#enable-surfaces-for-videos` flags in `chrome://flags`.",
+    "3":"Apple provides an equivalent proprietary API for Picture-in-Picture. Only macOS 10.12 Sierra & iOS 9 and newer support this API.",
+    "4":"Opera provides an equivalent proprietary feature named Video Pop Out, which allows users to use Picture-in-Picture mode for all playing videos.",
+    "5":"Automatically plays fullscreen videos in Picture-in-Picture mode after user hits Home Screen button. Only Android 8.0 Oreo and newer provide appropriate API for Picture-in-Picture."
   },
   "usage_perc_y":28.09,
   "usage_perc_a":46.84,


### PR DESCRIPTION
**In this commit I did the following:**
* corrected and improved information about Picture in Picture support in web browsers
* changed links in "Links" section.

**Sources:**
* [Picture in Picture in Firefox Nightly](https://www.bleepingcomputer.com/news/software/mozilla-adding-a-picture-in-picture-mode-to-firefox/)
* [Picture in Picture in Chrome 69](https://techdows.com/2018/09/chrome-picture-in-picture-mode-vs-opera-video-pop-out.html)
* [Video Pop Out in Opera 37](https://blogs.opera.com/desktop/2016/05/ad-blocker-opera-for-windows-mac-free)
* [iOS 9 multitasking features](https://wccftech.com/ios-9-multitasking-features)
* [Picture in Picture on macOS 10.12 Sierra](https://support.apple.com/en-us/HT206997)