### PR TITLE
Removed doubled note in support table concerning HTTP/2

### DIFF
--- a/features-json/http2.json
+++ b/features-json/http2.json
@@ -343,8 +343,7 @@
   "notes_by_num":{
     "1":"Partial support in Internet Explorer refers to being limited to Windows 10.",
     "2":"Partial support in Safari refers to being limited to OS X 10.11 El Capitan and newer.",
-    "3":"Only supports HTTP/2 if the server supports protocol negotiation via ALPN.",
-    "4":"Only supports HTTP2 if servers support protocol negotiation via ALPN"
+    "3":"Only supports HTTP/2 if the server supports protocol negotiation via ALPN."
   },
   "usage_perc_y":88.65,
   "usage_perc_a":2.57,


### PR DESCRIPTION
As the title says, in this commit I removed the doubled note in support table concerning HTTP/2.