### PR TITLE
Added Safari bug description for Beacon API

### DIFF
--- a/features-json/beacon.json
+++ b/features-json/beacon.json
@@ -12,6 +12,9 @@
   "bugs":[
     {
       "description":"Chrome [has a bug](https://bugs.chromium.org/p/chromium/issues/detail?id=490015) with sendBeacon and arbitrary content-type."
+    },
+    {
+      "description":"Safari 11.1 - 12 and iOS Safari 11.3 - 12.1 [have a bug](https://bugs.webkit.org/show_bug.cgi?id=188329) with sendBeacon in a pageHide event listener."
     }
   ],
   "categories":[


### PR DESCRIPTION
As described extensively in the [link](https://bugs.webkit.org/show_bug.cgi?id=188329): Desktop Safari 11.1 - 12 and iOS Safari 11.3 - 12.1 have bug with sendBeacon which throws error when it is used in a pagehide event callback. This issue has been fixed in iOS 12.2 and macOS 10.14.4.

This change proposes adding this bug information under bugs array in beacon.json