### PR TITLE
Clarify IE limitation for blob urls

### DIFF
--- a/features-json/bloburls.json
+++ b/features-json/bloburls.json
@@ -342,7 +342,7 @@
   },
   "notes":"",
   "notes_by_num":{
-    "1":"Created blob url can't be used in object or iframe"
+    "1":"Created blob url can't be used as object or iframe src"
   },
   "usage_perc_y":96.54,
   "usage_perc_a":0,


### PR DESCRIPTION
- the blob url can still be referenced inside the iframed document, just not as the iframe src (apparently)