### PR TITLE
Fix typos in webvr notes by rewording

### DIFF
--- a/features-json/webvr.json
+++ b/features-json/webvr.json
@@ -357,12 +357,12 @@
       "2.5":"n"
     }
   },
-  "notes":"Not every computer or smartphone could run WebVR appication. For smartphones, you need a gyroscope and for computers must be VR-ready also the needed sotfware (Oculus client or (Steam VR and VivePort)) and drivers must been installed on the computer. In this situations, you've the best experiance to use WebVR applications.",
+  "notes":"For a WebVR experience a head mounted display (VR HMD) is required.",
   "notes_by_num":{
     "1":"Available and enabled by default only in Firefox Windows. Enabled in Nightly for iOS. Work in progress for GNU/Linux.",
     "2":"Enabled behind the WebVR & \"Gamepad Extensions\" flags under `chrome://flags`. Currently builds use an older version of the (still changing) specification and supports only the Oculus Rift and the HTC vive on Windows VR-ready computers.",
     "3":"[In development](https://blogs.windows.com/msedgedev/2016/09/09/webvr-in-development-edge/#3lMW05DTZXbXcK46.97) in the latest Edge builds and supports only [Windows Mixed Reality](https://developer.microsoft.com/en-us/windows/mixed-reality).",
-    "4":"Supports only Samsung Galaxy devices with the Samgung Gear VR",
+    "4":"Supports only Samsung Galaxy devices with the Samsung Gear VR",
     "5":"Supports only Google Daydream on [daydream-ready devices](https://vr.google.com/daydream/smartphonevr/phones/) and Google Cardboards"
   },
   "usage_perc_y":39.24,


### PR DESCRIPTION
Reworded to remove product names, as more than one manufacturer of VR HMDs exist.