### PR TITLE
Replace IE10 / IE11 testing link

### DIFF
--- a/features-json/indexeddb.json
+++ b/features-json/indexeddb.json
@@ -365,7 +365,7 @@
   },
   "notes":"",
   "notes_by_num":{
-    "1":"Partial support in IE 10 & 11 refers to a number of subfeatures [not being supported](https://codepen.io/cemerick/pen/Itymi). Edge does not support IndexedDB inside blob web workers. [See issue](https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/5942817/)",
+    "1":"Partial support in IE 10 & 11 refers to a number of subfeatures [not being supported](https://indexdb-support-test.glitch.me/). Edge does not support IndexedDB inside blob web workers. [See issue](https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/5942817/)",
     "2":"Partial support in Safari & iOS 8 & 9 refers to [seriously buggy behavior](http://www.raymondcamden.com/2014/09/25/IndexedDB-on-iOS-8-Broken-Bad/) as well as complete lack of support in WebViews."
   },
   "usage_perc_y":90.87,


### PR DESCRIPTION
The "not being supported" link which is found in the notes about IE10 / IE11 points to codepen. Codepen does not support IE11, therefore this link isn't useful to see what is supported by IE11. This commit replaces that link with one that points to glitch.com (I have copied the test script from codepen to glitch.) Glitch's 'view' feature loads the source as is, and will work in IE11. The glitch version can be used to see support in IE11.

# Before
![image](https://user-images.githubusercontent.com/35559/57709809-ada50f80-7639-11e9-9794-64b8a03c266e.png)
and when accepting the warning:
![image](https://user-images.githubusercontent.com/35559/57709823-b564b400-7639-11e9-8119-a7d656510a50.png)
And when trying to view it in 'full' mode:
![image](https://user-images.githubusercontent.com/35559/57709869-d0372880-7639-11e9-9338-b9147e59043f.png)

# After
![image](https://user-images.githubusercontent.com/35559/57709783-a0882080-7639-11e9-868a-eac208c58498.png)
