### PR TITLE
Fix correct link to Mozilla/Bugzilla bug for :focus-visible

### DIFF
--- a/features-json/css-focus-visible.json
+++ b/features-json/css-focus-visible.json
@@ -25,8 +25,8 @@
       "title":"Microsoft Edge implementation suggestion"
     },
     {
-      "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=1437901",
-      "title":"Bugzilla: Add :focus-visible (former :focus-ring)"
+      "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=1445482",
+      "title":"Bugzilla: implement :focus-visible pseudo-class (rename/alias :-moz-focusring)"
     },
     {
       "url":"https://bugs.webkit.org/show_bug.cgi?id=30523",


### PR DESCRIPTION
The current link leads to a bug for missing _developer documentation_ on `:focus-visible`, and has been closed since MDN added docs.

This change updates the URL and tile to match the implementation bug instead.