### PR TITLE
Update lazyload.json w/ link to the new standard

### DIFF
--- a/features-json/lazyload.json
+++ b/features-json/lazyload.json
@@ -1,6 +1,6 @@
 {
   "title":"Resource Hints: Lazyload",
-  "description":"Gives a hint to the browser to lower the loading priority of a resource.",
+  "description":"Gives a hint to the browser to lower the loading priority of a resource. Please note that this is a legacy attribute, see the [`loading`](https://caniuse.com/#feat=loading-lazy-attr) attribute for the new standardized API.",
   "spec":"https://w3c.github.io/web-performance/specs/ResourcePriorities/Overview.html",
   "status":"unoff",
   "links":[

--- a/features-json/lazyload.json
+++ b/features-json/lazyload.json
@@ -7,10 +7,6 @@
     {
       "url":"https://msdn.microsoft.com/en-us/ie/dn369270(v=vs.94)",
       "title":"lazyload attribute | lazyload property"
-    },
-    {
-      "url":"https://github.com/whatwg/html/issues/2806",
-      "title":"Discussion on standardization"
     }
   ],
   "bugs":[
@@ -341,7 +337,7 @@
       "2.5":"n"
     }
   },
-  "notes":"",
+  "notes":"This is a legacy attribute, see the [`loading`](https://caniuse.com/#feat=loading-lazy-attr) attribute for the new standardized API.",
   "notes_by_num":{
     
   },

--- a/features-json/lazyload.json
+++ b/features-json/lazyload.json
@@ -337,7 +337,7 @@
       "2.5":"n"
     }
   },
-  "notes":"This is a legacy attribute, see the [`loading`](https://caniuse.com/#feat=loading-lazy-attr) attribute for the new standardized API.",
+  "notes":"",
   "notes_by_num":{
     
   },


### PR DESCRIPTION
The [legacy `lazyload`](https://caniuse.com/#feat=lazyload) attribute has poor implementations amongst browsers and I don't think there are any good reasons for developers to use it.

To avoid confusion I have updated the feature description with a link to the new [`loading`](https://caniuse.com/#feat=loading-lazy-attr) attribute.

Is it clear enough?...