### PR TITLE
Safari `-webkit-background-clip: text`

### DIFF
--- a/features-json/background-img-opts.json
+++ b/features-json/background-img-opts.json
@@ -356,7 +356,7 @@
       "2.5":"y"
     }
   },
-  "notes":"Firefox, Chrome and Safari support the unofficial `-webkit-background-clip: text` (only with prefix)",
+  "notes":"Firefox, Chrome and Safari support the unofficial `-webkit-background-clip: text` (only with prefix). Safari does not support `-webkit-background-clip: text;` for `<button>` elements. But you can put `<span>` inside `<button>` to get the same result.",
   "notes_by_num":{
     "1":"Partial support in Opera Mini refers to not supporting background sizing or background attachments. However Opera Mini 7.5 supports background sizing (including cover and contain values).",
     "2":"Partial support in Safari 6 refers to not supporting background sizing offset from edges syntax.",


### PR DESCRIPTION
All versions of Safari doesn't support `-webkit-background-clip: text` for buttons. But you can put a span inside button to achieve the same result. Codepen example https://codepen.io/guoyunhe/pen/byjOeN