### PR TITLE
Add Sponsor badge to the GitHub Repo

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+patreon: caniuse


### PR DESCRIPTION
Add Sponsor badge to the GitHub Repo with link to https://www.patreon.com/join/caniuse

REF: https://help.github.com/en/articles/displaying-a-sponsor-button-in-your-repository