### PR TITLE
Mojave and later support TLS 1.3

### DIFF
--- a/features-json/tls1-3.json
+++ b/features-json/tls1-3.json
@@ -354,7 +354,7 @@
     "2":"Can be enabled in Firefox by setting the `security.tls.version.max` pref to \"4\" in `about:config`.",
     "3":"Supports a draft of the TLS 1.3 specification, not the final version.",
     "4":"Can be enabled in Chrome and Opera via the `#tls13-variant` flag in `chrome://flags` or `opera://flags`.",
-    "5":"Partial support in Safari refers to being limited to macOS 10.14 Mojave."
+    "5":"Partial support in Safari refers to being limited to macOS 10.14 Mojave and later."
   },
   "usage_perc_y":73.5,
   "usage_perc_a":1.58,


### PR DESCRIPTION
Minor update on the note about Safari TLS 1.3 support being limited to Mojave and later.