### PR TITLE
ResizeObserver: Add additional polyfill for latest specification.

### DIFF
--- a/features-json/resizeobserver.json
+++ b/features-json/resizeobserver.json
@@ -14,7 +14,11 @@
     },
     {
       "url":"https://github.com/que-etc/resize-observer-polyfill",
-      "title":"Polyfill"
+      "title":"Polyfill based on initial specification"
+    },
+    {
+      "url":"https://github.com/juggle/resize-observer",
+      "title":"Polyfill based on latest specification which includes support for observer options"
     },
     {
       "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=1272409",


### PR DESCRIPTION
As the original polyfill does not support the latest version of the specification and doesn't seem to be maintained as much recently. I'd like to propose this additional polyfill, which adds support for `box-size` options.