### PR TITLE
Broken links, missing spread param for drop-shadow

### DIFF
--- a/features-json/css-filters.json
+++ b/features-json/css-filters.json
@@ -11,19 +11,14 @@
     {
       "url":"https://www.html5rocks.com/en/tutorials/filters/understanding-css/",
       "title":"HTML5Rocks article"
-    },
-    {
-      "url":"http://dl.dropbox.com/u/3260327/angular/CSS3ImageManipulation.html",
-      "title":"Filter editor"
-    },
-    {
-      "url":"http://bennettfeely.com/filters/",
-      "title":"Filter Playground"
     }
   ],
   "bugs":[
     {
       "description":"In Edge filter won't apply if the element or it's parent has negative z-index. [See bug](https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/9318580/)."
+    },
+    {
+      "description": "Currently there are no browsers with support for spread-radius in the box-shadow filter. [See comment on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/filter-function/drop-shadow#Parameters)."
     }
   ],
   "categories":[


### PR DESCRIPTION
Removed broken links.
Added explanation about missing drop-shadow parameter spread-radius.