### PR TITLE
Tweak SVG `spec` urls and `status`

### DIFF
--- a/features-json/svg-filters.json
+++ b/features-json/svg-filters.json
@@ -1,7 +1,7 @@
 {
   "title":"SVG filters",
   "description":"Method of using Photoshop-like effects on SVG objects including blurring and color manipulation.",
-  "spec":"https://www.w3.org/TR/SVG/filters.html",
+  "spec":"https://www.w3.org/TR/SVG11/filters.html",
   "status":"rec",
   "links":[
     {

--- a/features-json/svg-fonts.json
+++ b/features-json/svg-fonts.json
@@ -1,8 +1,8 @@
 {
   "title":"SVG fonts",
   "description":"Method of using fonts defined as SVG shapes. Removed from [SVG 2.0](https://www.w3.org/TR/SVG2/changes.html#fonts) and considered as a deprecated feature with support being removed from browsers.",
-  "spec":"https://www.w3.org/TR/SVG/fonts.html",
-  "status":"unoff",
+  "spec":"https://www.w3.org/TR/SVG11/fonts.html",
+  "status":"rec",
   "links":[
     {
       "url":"http://jeremie.patonnier.net/post/2011/02/07/Why-are-SVG-Fonts-so-different",

--- a/features-json/svg-fragment.json
+++ b/features-json/svg-fragment.json
@@ -2,7 +2,7 @@
   "title":"SVG fragment identifiers",
   "description":"Method of displaying only a part of an SVG image by defining a view ID or view box dimensions as the file's fragment identifier.",
   "spec":"https://www.w3.org/TR/SVG/linking.html#SVGFragmentIdentifiers",
-  "status":"rec",
+  "status":"cr",
   "links":[
     {
       "url":"http://www.broken-links.com/2012/08/14/better-svg-sprites-with-fragment-identifiers/",

--- a/features-json/svg-smil.json
+++ b/features-json/svg-smil.json
@@ -1,7 +1,7 @@
 {
   "title":"SVG SMIL animation",
   "description":"Method of using animation elements to animate SVG images",
-  "spec":"https://www.w3.org/TR/SVG/animate.html",
+  "spec":"https://www.w3.org/TR/SVG11/animate.html",
   "status":"rec",
   "links":[
     {

--- a/features-json/svg.json
+++ b/features-json/svg.json
@@ -2,7 +2,7 @@
   "title":"SVG (basic support)",
   "description":"Method of displaying basic Vector Graphics features using the embed or object elements. Refers to the SVG 1.1 spec.",
   "spec":"https://www.w3.org/TR/SVG/",
-  "status":"rec",
+  "status":"cr",
   "links":[
     {
       "url":"https://en.wikipedia.org/wiki/Scalable_Vector_Graphics",


### PR DESCRIPTION
At Can I use, some entries reference SVG 2 and others reference SVG 1.1. This may confuse readers.

This PR makes entries references SVG 2 as much as possible though number or entries which references SVG 1.1 increased.