### PR TITLE
Updates notes for Network Information API

### DIFF
--- a/features-json/netinfo.json
+++ b/features-json/netinfo.json
@@ -344,7 +344,7 @@
       "2.5":"a #2"
     }
   },
-  "notes":"In Chrome the API is enabled on Android only, support for other platforms [is coming](https://docs.google.com/a/chromium.org/document/d/1LTk9uVMGi4kurzcF5ellsAJReTF31fFJMHrQwSVtBjc/) . Support is also available on [Firefox OS](https://bugzilla.mozilla.org/show_bug.cgi?id=960426).",
+  "notes":"",
   "notes_by_num":{
     "1":"Supports only the `navigator.connection.type` value which doesn't match the latest spec. [see details](https://www.davidbcalhoun.com/2010/optimizing-based-on-connection-speed-using-navigator.connection-on-android-2.2-/)",
     "2":"Only supports the `type` value.",


### PR DESCRIPTION
RE: https://caniuse.com/#feat=netinfo

> In Chrome the API is enabled on Android only

This is a bit misleading as the API is available on desktop too and supports the **downlink**, **effectiveType** & **rtt** values (as point 4 in the notes mentions). You can see the output from the API here here: https://googlechrome.github.io/samples/network-information/. I think it's better to remove this statement.

> Support is also available on Firefox OS.

No longer relevant, so safe to remove.