### PR TITLE
inherit issue with `<details>` in Chrome

### DIFF
--- a/features-json/css3-boxsizing.json
+++ b/features-json/css3-boxsizing.json
@@ -43,6 +43,9 @@
     },
     {
       "description":"In IE8, the min-width property applies to `content-box` even if `box-sizing` is set to `border-box`."
+    },
+    {
+      "description":"The `inherit` value doesn't work for elements inside `details`, this could lead to unexpected behaviour when box sizing is used in an universal selector, see https://bugs.chromium.org/p/chromium/issues/detail?id=589475"
     }
   ],
   "categories":[

--- a/features-json/css3-boxsizing.json
+++ b/features-json/css3-boxsizing.json
@@ -45,7 +45,7 @@
       "description":"In IE8, the min-width property applies to `content-box` even if `box-sizing` is set to `border-box`."
     },
     {
-      "description":"The `inherit` value doesn't work for elements inside `details`, this could lead to unexpected behaviour when box sizing is used in an universal selector, see https://bugs.chromium.org/p/chromium/issues/detail?id=589475"
+      "description":"The `inherit` value doesn't work on elements inside `details`, this could lead to unexpected behaviour when `box-sizing: inherit` is used in an universal selector, see https://bugs.chromium.org/p/chromium/issues/detail?id=589475"
     }
   ],
   "categories":[

--- a/features-json/css3-boxsizing.json
+++ b/features-json/css3-boxsizing.json
@@ -45,7 +45,7 @@
       "description":"In IE8, the min-width property applies to `content-box` even if `box-sizing` is set to `border-box`."
     },
     {
-      "description":"The `inherit` value doesn't work on elements inside `details`, this could lead to unexpected behaviour when `box-sizing: inherit` is used in an universal selector, see https://bugs.chromium.org/p/chromium/issues/detail?id=589475"
+      "description":"In Chrome, the `inherit` value doesn't work on elements inside `details`, this could lead to unexpected behaviour when `box-sizing: inherit` is used in an universal selector, see https://bugs.chromium.org/p/chromium/issues/detail?id=589475"
     }
   ],
   "categories":[


### PR DESCRIPTION
This is not necessarily an issue with `box-sizing` but it is an issue which occurs when this snippet is used:

```css
html {
  box-sizing: border-box;
}

*,
::before,
::after {
  box-sizing: inherit;
}

```


Because that technique is used quite a lot, it might be worth mentioning this in the bugs section?