### PR TITLE
Update meta-theme-color.json

### DIFF
--- a/features-json/meta-theme-color.json
+++ b/features-json/meta-theme-color.json
@@ -183,13 +183,13 @@
       "70":"n",
       "71":"n",
       "72":"n",
-      "73":"n",
-      "74":"n",
-      "75":"n",
-      "76":"n",
-      "77":"n",
-      "78":"n",
-      "79":"n"
+      "73":"a #1",
+      "74":"a #1",
+      "75":"a #1",
+      "76":"a #1",
+      "77":"a #1",
+      "78":"a #1",
+      "79":"a #1"
     },
     "safari":{
       "3.1":"n",
@@ -352,7 +352,7 @@
   },
   "notes":"Also supported in the (now discontinued) Firefox OS, but not Firefox for other OSes.",
   "notes_by_num":{
-    
+    "1": "Chrome Desktop does support the theme-color meta tag when the page is in PWA-standalone mode. According to this post: https://developers.google.com/web/progressive-web-apps/desktop, PWA on desktop in chrome has been present since version 73 on all platforms, assumingly theme-color as well."
   },
   "usage_perc_y":38.44,
   "usage_perc_a":0,


### PR DESCRIPTION
Theme Color supported partially in Chrome: PWA standalone mode. Added note for this.