### PR TITLE
Lazy-load: new blog post, keywords and Chrome flag

### DIFF
--- a/features-json/loading-lazy-attr.json
+++ b/features-json/loading-lazy-attr.json
@@ -5,6 +5,10 @@
   "status":"unoff",
   "links":[
     {
+      "url":"https://web.dev/native-lazy-loading",
+      "title":"Native lazy-loading for the web"
+    },
+    {
       "url":"https://addyosmani.com/blog/lazy-loading/",
       "title":"Blog post"
     },
@@ -363,13 +367,13 @@
   },
   "notes":"",
   "notes_by_num":{
-    "1":"Can be enabled via the `#enable-lazy-image-loading` feature flag"
+    "1":"Can be enabled via the `#enable-lazy-image-loading` and `#enable-lazy-frame-loading` feature flags"
   },
   "usage_perc_y":0,
   "usage_perc_a":0,
   "ucprefix":false,
   "parent":"",
-  "keywords":"lazyload,loading=\"lazy\"",
+  "keywords":"lazy-loading,lazyloading,loading=\"lazy\",loading=\"eager\",loading=\"auto\",loading,attribute,lazily,lazy image loading,lazy img loading,iframe loading,native lazyload",
   "ie_id":"",
   "chrome_id":"5645767347798016",
   "firefox_id":"",


### PR DESCRIPTION
Adding link to new informational article: https://web.dev/native-lazy-loading
&plus; `#enable-lazy-frame-loading` flag and some relevant keywords.