### PR TITLE
MediaQueryList.addEventListener Safari and IE bug

### DIFF
--- a/features-json/matchmedia.json
+++ b/features-json/matchmedia.json
@@ -22,7 +22,9 @@
     }
   ],
   "bugs":[
-    
+    {
+      "description":"MediaQueryList.addEventListener [doesn't work in Safari and IE](https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList#Browser_compatibility)"
+    }
   ],
   "categories":[
     "DOM",


### PR DESCRIPTION
MediaQueryList.addEventListener [doesn't work in Safari and IE](https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList#Browser_compatibility)

Related discussions: https://github.com/microsoft/TypeScript/issues/32210, https://github.com/ReactTraining/react-media/pull/135, https://github.com/mdn/browser-compat-data/pull/3674