### PR TITLE
Wayback archives for broken links in CSS filters (css-filters.json)

### DIFF
--- a/features-json/css-filters.json
+++ b/features-json/css-filters.json
@@ -13,11 +13,11 @@
       "title":"HTML5Rocks article"
     },
     {
-      "url":"http://dl.dropbox.com/u/3260327/angular/CSS3ImageManipulation.html",
+      "url":"http://web.archive.org/web/20160219005748/https://dl.dropboxusercontent.com/u/3260327/angular/CSS3ImageManipulation.html",
       "title":"Filter editor"
     },
     {
-      "url":"http://bennettfeely.com/filters/",
+      "url":"http://web.archive.org/web/20160310041612/http://bennettfeely.com/filters/",
       "title":"Filter Playground"
     }
   ],


### PR DESCRIPTION
CSS Filters (css-filters.json) -> Resources: 
1. Changed dead link in Resources to archived Wayback link 
2. Changed dead link in Resources to archived Wayback link

**Link 1:** 
Title: Filter editor
URL: http://dl.dropbox.com/u/3260327/angular/CSS3ImageManipulation.html
Issue: 404 error 

This article is archived here: http://web.archive.org/web/20160219005748/https://dl.dropboxusercontent.com/u/3260327/angular/CSS3ImageManipulation.html

I have written to the author and queried if he will ever make the original page available again.

**Link 2:**
Title: Filter Playground
URL: http://bennettfeely.com/filters/
Issue: 404 error

This article is archived here:
http://web.archive.org/web/20160310041612/http://bennettfeely.com/filters/

This link is also linked internally on  Mr Bennet Feely's own website (found here: https://bennettfeely.com/image-effects/) however it is also results in a dead link. I have written to Mr Bennet Feely to query if the page will be restored.