### PR TITLE
Add a polyfill for the download attribute in IE11

### DIFF
--- a/features-json/download.json
+++ b/features-json/download.json
@@ -13,6 +13,10 @@
       "title":"Demo: creating a text file and downloading it."
     },
     {
+      "url": "https://github.com/jelmerdemaat/dwnld-attr-polyfill",
+      "title": "IE11 polyfill"
+    },
+    {
       "url":"https://bugs.webkit.org/show_bug.cgi?id=102914",
       "title":"WebKit feature request bug"
     }
@@ -367,7 +371,7 @@
   },
   "notes":"",
   "notes_by_num":{
-    
+
   },
   "usage_perc_y":82.65,
   "usage_perc_a":0,


### PR DESCRIPTION
This PR adds a polyfill for the a[download] functionality for IE11. More info:

https://github.com/jelmerdemaat/dwnld-attr-polyfill