### PR TITLE
SameSite: Chrome 80+ changes, Safari support statuses

### DIFF
--- a/features-json/same-site-cookie-attribute.json
+++ b/features-json/same-site-cookie-attribute.json
@@ -229,11 +229,11 @@
       "10.1":"n",
       "11":"n",
       "11.1":"n",
-      "12":"a #4",
-      "12.1":"a #4",
-      "13":"a #4",
-      "13.1":"a #4",
-      "TP":"y"
+      "12":"a #4 #5",
+      "12.1":"a #4 #5",
+      "13":"a #4 #5",
+      "13.1":"a #4 #5",
+      "TP":"a #5"
     },
     "opera":{
       "9":"n",
@@ -309,8 +309,8 @@
       "10.3":"n",
       "11.0-11.2":"n",
       "11.3-11.4":"n",
-      "12.0-12.1":"y",
-      "12.2-12.3":"y",
+      "12.0-12.1":"a #5",
+      "12.2-12.3":"a #5",
       "13.0-13.1":"y"
     },
     "op_mini":{
@@ -378,7 +378,8 @@
     "1":"Not shipped with the inital release but later with the 2018 June security update (Patch Tuesday) to Windows 10 RS3 (2017 Fall Creators Update) and newer. [More info](https://github.com/MicrosoftEdge/Status/issues/616).",
     "2":"Partial support because only supported in IE 11 on Windows 10 RS3 (2017 Fall Creators Update) and newer, but not in IE 11 on other Windows versions (Windows 7, ...)",
     "3":"Implemented [Incrementally Better Cookies](https://tools.ietf.org/html/draft-west-cookie-incrementalism-00) by default: Cookies without `SameSite` are treated as `Lax`, `SameSite=None` cookies without `Secure` are rejected.",
-    "4":"Partial due to the lack of support in macOS before 10.14 Mojave."
+    "4":"Partial due to the lack of support in macOS before 10.14 Mojave.",
+    "5":"Partial due to [the bug](https://bugs.webkit.org/show_bug.cgi?id=198181) that treats `SameSite=None` and invalid values as `Strict` in macOS before 10.15 Catalina and in iOS before 13."
   },
   "usage_perc_y":86.16,
   "usage_perc_a":2.04,

--- a/features-json/same-site-cookie-attribute.json
+++ b/features-json/same-site-cookie-attribute.json
@@ -34,7 +34,9 @@
     }
   ],
   "bugs":[
-    
+    {
+      "description":"On [Safari in macOS before 10.14.4 and iOS before 12.2](https://bugs.webkit.org/show_bug.cgi?id=188165#c43), some authentication flows with a cross-site identity provider might fail when `SameSite=Lax` is used. See [the explanation and a workaround.](https://brockallen.com/2019/01/11/same-site-cookies-asp-net-core-and-external-authentication-providers/)"
+    }
   ],
   "categories":[
     "Security"

--- a/features-json/same-site-cookie-attribute.json
+++ b/features-json/same-site-cookie-attribute.json
@@ -36,6 +36,9 @@
   "bugs":[
     {
       "description":"On [Safari in macOS before 10.14.4 and iOS before 12.2](https://bugs.webkit.org/show_bug.cgi?id=188165#c43), some authentication flows with a cross-site identity provider might fail when `SameSite=Lax` is used. See [the explanation and a workaround.](https://brockallen.com/2019/01/11/same-site-cookies-asp-net-core-and-external-authentication-providers/)"
+    },
+    {
+      "description":"On [Safari before 12.1.1 and iOS before 12.3](https://trac.webkit.org/changeset/241918/webkit), manually visiting a redirection link to a cross-site omits `Lax` cookies from the cross-site request. See [the bug.](https://bugs.webkit.org/show_bug.cgi?id=196375)"
     }
   ],
   "categories":[

--- a/features-json/same-site-cookie-attribute.json
+++ b/features-json/same-site-cookie-attribute.json
@@ -229,10 +229,10 @@
       "10.1":"n",
       "11":"n",
       "11.1":"n",
-      "12":"y",
-      "12.1":"y",
-      "13":"y",
-      "13.1":"y",
+      "12":"a #4",
+      "12.1":"a #4",
+      "13":"a #4",
+      "13.1":"a #4",
       "TP":"y"
     },
     "opera":{
@@ -377,7 +377,8 @@
   "notes_by_num":{
     "1":"Not shipped with the inital release but later with the 2018 June security update (Patch Tuesday) to Windows 10 RS3 (2017 Fall Creators Update) and newer. [More info](https://github.com/MicrosoftEdge/Status/issues/616).",
     "2":"Partial support because only supported in IE 11 on Windows 10 RS3 (2017 Fall Creators Update) and newer, but not in IE 11 on other Windows versions (Windows 7, ...)",
-    "3":"Implemented [Incrementally Better Cookies](https://tools.ietf.org/html/draft-west-cookie-incrementalism-00) by default: Cookies without `SameSite` are treated as `Lax`, `SameSite=None` cookies without `Secure` are rejected."
+    "3":"Implemented [Incrementally Better Cookies](https://tools.ietf.org/html/draft-west-cookie-incrementalism-00) by default: Cookies without `SameSite` are treated as `Lax`, `SameSite=None` cookies without `Secure` are rejected.",
+    "4":"Partial due to the lack of support in macOS before 10.14 Mojave."
   },
   "usage_perc_y":86.16,
   "usage_perc_a":2.04,

--- a/features-json/same-site-cookie-attribute.json
+++ b/features-json/same-site-cookie-attribute.json
@@ -27,6 +27,10 @@
     {
       "url":"https://blogs.windows.com/msedgedev/2018/05/17/samesite-cookies-microsoft-edge-internet-explorer/",
       "title":"MS Edge dev blog: \"Previewing support for same-site cookies in Microsoft Edge\""
+    },
+    {
+      "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=1551798",
+      "title":"Mozilla Bug #1551798: Prototype SameSite=Lax by default"
     }
   ],
   "bugs":[
@@ -206,7 +210,7 @@
       "77":"y",
       "78":"y",
       "79":"y",
-      "80":"y"
+      "80":"y #3"
     },
     "safari":{
       "3.1":"n",
@@ -372,7 +376,8 @@
   "notes":"This feature is backwards compatible. Browsers not supporting this feature will simply use the cookie as a regular cookie. There is no need to deliver different cookies to clients.",
   "notes_by_num":{
     "1":"Not shipped with the inital release but later with the 2018 June security update (Patch Tuesday) to Windows 10 RS3 (2017 Fall Creators Update) and newer. [More info](https://github.com/MicrosoftEdge/Status/issues/616).",
-    "2":"Partial support because only supported in IE 11 on Windows 10 RS3 (2017 Fall Creators Update) and newer, but not in IE 11 on other Windows versions (Windows 7, ...)"
+    "2":"Partial support because only supported in IE 11 on Windows 10 RS3 (2017 Fall Creators Update) and newer, but not in IE 11 on other Windows versions (Windows 7, ...)",
+    "3":"Implemented [Incrementally Better Cookies](https://tools.ietf.org/html/draft-west-cookie-incrementalism-00) by default: Cookies without `SameSite` are treated as `Lax`, `SameSite=None` cookies without `Secure` are rejected."
   },
   "usage_perc_y":86.16,
   "usage_perc_a":2.04,
@@ -380,7 +385,7 @@
   "parent":"",
   "keywords":"security,cookies,cookie,csrf",
   "ie_id":"",
-  "chrome_id":"4672634709082112",
+  "chrome_id":"4672634709082112,5088147346030592,5633521622188032",
   "firefox_id":"",
   "webkit_id":"",
   "shown":true

--- a/features-json/same-site-cookie-attribute.json
+++ b/features-json/same-site-cookie-attribute.json
@@ -31,6 +31,10 @@
     {
       "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=1551798",
       "title":"Mozilla Bug #1551798: Prototype SameSite=Lax by default"
+    },
+    {
+      "url":"https://peaceful-wing.glitch.me",
+      "title":"Same-site cookies demonstration by Rowan Merewood"
     }
   ],
   "bugs":[


### PR DESCRIPTION
This rabbit hole has kept me quite occupied for several weeks now. The changes are:
- Chrome 80 will follow [Incrementally Better Cookie](https://tools.ietf.org/html/draft-west-cookie-incrementalism-00) by default
- Changed many of the Safari support statuses to partial
  - Refer to the commit messages for the detailed rationale
  - Should be revisited when a new macOS version is released
- Added more Safari bugs and useful links