### PR TITLE
Node.innerText => HTMLElement.innerText

### DIFF
--- a/features-json/innertext.json
+++ b/features-json/innertext.json
@@ -1,11 +1,11 @@
 {
-  "title":"Node.innerText",
+  "title":"HTMLElement.innerText",
   "description":"A property representing the text within a DOM element and its descendants. As a getter, it approximates the text the user would get if they highlighted the contents of the element with the cursor and then copied to the clipboard.",
   "spec":"https://html.spec.whatwg.org/multipage/dom.html#the-innertext-idl-attribute",
   "status":"ls",
   "links":[
     {
-      "url":"https://developer.mozilla.org/en-US/docs/Web/API/Node/innerText",
+      "url":"https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/innerText",
       "title":"MDN Web Docs - innerText"
     },
     {
@@ -366,7 +366,7 @@
       "2.5":"y"
     }
   },
-  "notes":"This test only checks that the property exists and works correctly in a very simple case.\r\n[This blog post by kangax](http://perfectionkills.com/the-poor-misunderstood-innerText/) explains the history of this property, gives much more detailed cross-browser compatibility information, and gives a detailed strawman specification for the property.\r\n`Node.innerText` is similar to, but has some important differences from, the standard [`Node.textContent`](https://caniuse.com/#feat=textcontent) property.",
+  "notes":"This test only checks that the property exists and works correctly in a very simple case.\r\n[This blog post by kangax](http://perfectionkills.com/the-poor-misunderstood-innerText/) explains the history of this property, gives much more detailed cross-browser compatibility information, and gives a detailed strawman specification for the property.\r\n`HTMLElement.innerText` is similar to, but has some important differences from, the standard [`Node.textContent`](https://caniuse.com/#feat=textcontent) property.",
   "notes_by_num":{
     
   },

--- a/features-json/textcontent.json
+++ b/features-json/textcontent.json
@@ -348,7 +348,7 @@
       "2.5":"y"
     }
   },
-  "notes":"`Node.textContent` is somewhat similar to, but has important differences from, [`Node.innerText`](https://caniuse.com/#feat=innertext).",
+  "notes":"`Node.textContent` is somewhat similar to, but has important differences from, [`HTMLElement.innerText`](https://caniuse.com/#feat=innertext).",
   "notes_by_num":{
     
   },


### PR DESCRIPTION
Hi developers!

I'm very new to contribute to caniuse. I modified `Node.innerText` to `HTMLElement.innerText` because the following reason. According to <https://html.spec.whatwg.org>, `HTMLElement` has `innerText` not `Node`.

## `interface HTMLElement`
![image](https://user-images.githubusercontent.com/10933561/67357040-07214b00-f597-11e9-9eb2-4eb48b330428.png)


- `interface HTMLElement`: <https://html.spec.whatwg.org/multipage/dom.html#htmlelement>)
- `interface Node`: <https://dom.spec.whatwg.org/#interface-node>

In MDN, <https://developer.mozilla.org/en-US/docs/Web/API/Node/innerText> redirects to <https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/innerText> too.
