### PR TITLE
Mention Firefox bug 1441044 for template elements

### DIFF
--- a/features-json/template.json
+++ b/features-json/template.json
@@ -18,7 +18,9 @@
     }
   ],
   "bugs":[
-    
+    {
+      "description":"Firefox may preload images inside `template` elements ([1441044](https://bugzilla.mozilla.org/show_bug.cgi?id=1441044))"
+    }
   ],
   "categories":[
     "DOM",


### PR DESCRIPTION
Firefox seems to have a fairly significant bug in the way it handles `template` elements: it may preload images inside a `template`.  This behavior is inconsistent with the specification, most existing documentation on the template element (see https://www.html5rocks.com/en/tutorials/webcomponents/template/ for example), and other browsers; it seems like it would be a good idea to note it here.