### PR TITLE
Corrected info about TLS 1.3 support in Samsung Internet 10

### DIFF
--- a/features-json/tls1-3.json
+++ b/features-json/tls1-3.json
@@ -346,7 +346,7 @@
       "7.2-7.4":"n",
       "8.2":"n",
       "9.2":"n",
-      "10.1":"n"
+      "10.1":"y"
     },
     "and_qq":{
       "1.2":"n"
@@ -364,7 +364,7 @@
     "2":"Can be enabled in Firefox by setting the `security.tls.version.max` pref to \"4\" in `about:config`.",
     "3":"Supports a draft of the TLS 1.3 specification, not the final version.",
     "4":"Can be enabled in Chrome and Opera via the `#tls13-variant` flag in `chrome://flags` or `opera://flags`.",
-    "5":"Partial support in Safari refers to being limited to macOS 10.14 Mojave and later."
+    "5":"Partial support in Safari refers to being limited to macOS 10.14 Mojave and newer."
   },
   "usage_perc_y":76.63,
   "usage_perc_a":1.99,


### PR DESCRIPTION
As written in the title, in this commit I corrected the info about TLS 1.3 support in Samsung Internet 10.

I haven't tested it, but since Samsung Internet 10 is based on Chromium 71 that supports TLS 1.3 by default, we can assume that TLS 1.3 is supported also in Samsung Internet 10. I don't think they changed the default "setting" and disabled support for such important web protocol in their browser.