### PR TITLE
Remove duplicate `input type="color"` tutorial

### DIFF
--- a/features-json/input-color.json
+++ b/features-json/input-color.json
@@ -23,10 +23,6 @@
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/color",
       "title":"MDN web docs"
-    },
-    {
-      "url":"https://www.html5tutorial.info/html5-color.php",
-      "title":"Tutorial"
     }
   ],
   "bugs":[


### PR DESCRIPTION
Just something I noticed while looking up browser support.