### PR TITLE
Update Firefox support link for CSS math functions

### DIFF
--- a/features-json/css-math-functions.json
+++ b/features-json/css-math-functions.json
@@ -9,7 +9,7 @@
       "title":"Test case on JSFiddle"
     },
     {
-      "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=1452609",
+      "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=css-min-max",
       "title":"Firefox support bug"
     },
     {


### PR DESCRIPTION
Previous bug was closed as `INVALID`.