### PR TITLE
Remove reference to non-existing article

### DIFF
--- a/features-json/css-masks.json
+++ b/features-json/css-masks.json
@@ -13,10 +13,6 @@
       "title":"HTML5 Rocks article"
     },
     {
-      "url":"http://thenittygritty.co/css-masking",
-      "title":"Detailed blog post"
-    },
-    {
       "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=1224422",
       "title":"Firefox implementation bug"
     },


### PR DESCRIPTION
Thankfully there's already a link to an archived version of this article.