### PR TITLE
Remove duplicate links in webp.json

### DIFF
--- a/features-json/webp.json
+++ b/features-json/webp.json
@@ -9,18 +9,6 @@
       "title":"Official website"
     },
     {
-      "url":"http://antimatter15.github.io/weppy/demo.html",
-      "title":"Polyfill for browsers with WebM support"
-    },
-    {
-      "url":"http://libwebpjs.appspot.com/",
-      "title":"Decoder in JS"
-    },
-    {
-      "url":"http://webpjs.appspot.com/",
-      "title":"Polyfill for browsers with or without WebM support (i.e. IE6-IE9, Safari/iOS version 6.1 and below; Firefox versions 24 and bel"
-    },
-    {
       "url":"https://developers.google.com/speed/webp/faq#which_web_browsers_natively_support_webp",
       "title":"Official website FAQ - Which web browsers natively support WebP?"
     },


### PR DESCRIPTION
- http://antimatter15.github.io/weppy/demo.html redirects to http://antimatter15.com/weppy/demo.html, which is already listed
- https://libwebpjs.appspot.com is listed twice
- https://webpjs.appspot.com is listed twice