### PR TITLE
Add version note to "Known Issues" for Edge

### DIFF
--- a/features-json/webp.json
+++ b/features-json/webp.json
@@ -43,7 +43,7 @@
   ],
   "bugs":[
     {
-      "description":"WebP images displays as a broken image icon in [Microsoft Edge in Application Guard mode](https://www.ctrl.blog/entry/windows-webp-appguard) even when an alternative image source format is available."
+      "description":"WebP images displays as a broken image icon in [Microsoft Edge v18 in Application Guard mode](https://www.ctrl.blog/entry/windows-webp-appguard) even when an alternative image source format is available."
     }
   ],
   "categories":[


### PR DESCRIPTION
Note only applies to 18, as 79 is now Chromium-based.