### PR TITLE
Add Chrome support for CSS3 image-orientation

### DIFF
--- a/features-json/css-image-orientation.json
+++ b/features-json/css-image-orientation.json
@@ -204,8 +204,8 @@
       "78":"n",
       "79":"n",
       "80":"n",
-      "81":"n",
-      "82":"n"
+      "81":"y",
+      "82":"y"
     },
     "safari":{
       "3.1":"n",
@@ -381,7 +381,7 @@
   "parent":"",
   "keywords":"image-orientation,from-image,flip",
   "ie_id":"",
-  "chrome_id":"",
+  "chrome_id":"6313474512650240",
   "firefox_id":"",
   "webkit_id":"",
   "shown":true


### PR DESCRIPTION
Chome is enabling this feature by default in v81

https://www.chromestatus.com/feature/6313474512650240