### PR TITLE
SharedArrayBuffer enabled on Firefox Nightly 73+

### DIFF
--- a/features-json/sharedarraybuffer.json
+++ b/features-json/sharedarraybuffer.json
@@ -110,7 +110,7 @@
       "71":"n d #1",
       "72":"n d #1",
       "73":"n d #1",
-      "74":"n d #1"
+      "74":"n d #1 #2"
     },
     "chrome":{
       "4":"n",
@@ -359,7 +359,8 @@
   },
   "notes":"",
   "notes_by_num":{
-    "1":"Has support, but was disabled across browsers in January 2018 due to Spectre & Meltdown vulnerabilities."
+    "1":"Has support, but was disabled across browsers in January 2018 due to Spectre & Meltdown vulnerabilities.",
+    "2":"Enabled by default in Nightly, but not in Beta/Developer/Release yet."
   },
   "usage_perc_y":30.68,
   "usage_perc_a":0,


### PR DESCRIPTION
See https://wiki.developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/Planned_changes

I tested it on Linux with current Firefox Nightly 74, and it seems to work with the demo on MDN:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer

Firefox Beta 73 does not have it enabled by default, even though Nightly 73 apparently had it,
so it's Nightly only for now. Thus I only put the footnote for 74 since Nightly 73 is no longer available.