### PR TITLE
Link to firefox svg naturalWidth bug

### DIFF
--- a/features-json/img-naturalwidth-naturalheight.json
+++ b/features-json/img-naturalwidth-naturalheight.json
@@ -14,7 +14,9 @@
     }
   ],
   "bugs":[
-    
+    {
+      "description": "Firefox returns `0` for svg images without explicit dimensions. [See bug](https://bugzilla.mozilla.org/show_bug.cgi?id=700533)"
+    }
   ],
   "categories":[
     "DOM",


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1328124