### PR TITLE
Point out Mozilla's position on WebUSB spec

### DIFF
--- a/features-json/webusb.json
+++ b/features-json/webusb.json
@@ -9,7 +9,7 @@
       "title":"Google Developers article"
     },
     {
-      "url":"https://mozilla.github.io/standards-positions/#webusb"
+      "url":"https://mozilla.github.io/standards-positions/#webusb",
       "title": "Mozilla Specification Positions: Harmful"
     }
   ],

--- a/features-json/webusb.json
+++ b/features-json/webusb.json
@@ -7,6 +7,10 @@
     {
       "url":"https://developers.google.com/web/updates/2016/03/access-usb-devices-on-the-web",
       "title":"Google Developers article"
+    },
+    {
+      "url":"https://mozilla.github.io/standards-positions/#webusb"
+      "title": "Mozilla Specification Positions: Harmful"
     }
   ],
   "bugs":[


### PR DESCRIPTION
Helpful in the light of eg: https://news.ycombinator.com/item?id=22228879