### PR TITLE
Add new resource

### DIFF
--- a/features-json/css-resize.json
+++ b/features-json/css-resize.json
@@ -15,7 +15,11 @@
     {
       "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6513977-css-resize-property",
       "title":"Microsoft Edge feature request on UserVoice"
-    }
+    },
+    {
+      "url":"https://catalin.red/css-resize-none-is-bad-for-ux/",
+      "title":"CSS resize none on textarea is bad for UX"
+    }    
   ],
   "bugs":[
     


### PR DESCRIPTION
This is a shameless plug but I got a lot of positive feedback on this [resize none on textarea is bad for UX](https://catalin.red/css-resize-none-is-bad-for-ux/) article lately and I'm happy to see that people unanimously agree with the fact that `resize: none;` for `textarea` is not a good idea:

- > Removing the default resizeability of a `<textarea>` is generally user-hurting vanity. Even if the resized textarea "breaks" the site layout, too bad, the user is trying to do something very important on this site right now and you should not let anything get in the way of that. 
[source](https://css-tricks.com/resize-none-on-textareas-is-bad-ux/)

- > yup, let the users resize if they want to, it's better to have your nice design break a little than to frustrate users who can't fill the form properly
[source](https://twitter.com/WalterStephanie/status/1223236902431621120)

- > I’d take it a step further and say removing textarea resizing isn’t just bad for UX, but accessibility as well. Visually impaired users that have their font size punched up run out of space quickly.
[source](https://twitter.com/mattradel/status/1223048160957927424)

- > For whatever you do with <textarea>s, don’t use `resize: none`. It’s as bad UX as `:focus { outline: 0 }`.
[source](https://twitter.com/jonkantner/status/1223239469031141377)

- > You shouldn't use resize: none; for textarea
[source](https://twitter.com/justmarkup/status/1228214651814416386)

- [more tweets](https://twitter.com/search?q=%20catalin.red%2Fcss-resize-none-is-bad-for-ux&src=typed_query&f=live)

Hope this helps, thank you!