### PR TITLE
Firefox 73: WebVR requires a secure context

### DIFF
--- a/features-json/webvr.json
+++ b/features-json/webvr.json
@@ -388,7 +388,7 @@
   },
   "notes":"For a WebVR experience a head mounted display (VR HMD) is required.",
   "notes_by_num":{
-    "1":"Available and enabled by default only in Firefox Windows. Enabled in Nightly for iOS.",
+    "1":"Available and enabled by default only in Firefox Windows. Enabled in Nightly for iOS. Firefox 73+ [requires a secure context using HTTPS](https://developer.mozilla.org/en-US/docs/Web/API/WebVR_API#API_availability)",
     "2":"Enabled behind the WebVR & \"Gamepad Extensions\" flags under `chrome://flags`. Currently builds use an older version of the (still changing) specification and supports only the Oculus Rift and the HTC vive on Windows VR-ready computers.",
     "3":"[In development](https://blogs.windows.com/msedgedev/2016/09/09/webvr-in-development-edge/#3lMW05DTZXbXcK46.97) in the latest Edge builds and supports only [Windows Mixed Reality](https://developer.microsoft.com/en-us/windows/mixed-reality).",
     "4":"Supports only Samsung Galaxy devices with the Samsung Gear VR",


### PR DESCRIPTION
<https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/73>:

> The deprecated [WebVR API](https://developer.mozilla.org/en-US/docs/Web/API/WebVR_API)---which has been supplanted by [WebXR](https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API), which supports both [augmented](https://en.wikipedia.org/wiki/Augmented_reality) and [virtual reality](https://en.wikipedia.org/wiki/Virtual_reality) applications---now [requires a secure context](https://developer.mozilla.org/en-US/docs/Web/API/WebVR_API#API_availability) using the [HTTPS](https://developer.mozilla.org/en-US/docs/Glossary/HTTPS) protocol to operate. This is due to the availability of sensitive input sources that may include private information ([bug 1381645](https://bugzilla.mozilla.org/show_bug.cgi?id=1381645)).

Would be probably more accurate to add an additional note to Firefox 73+ giving the added information, but since its deprecated anyway and support is dwindling…