### PR TITLE
Add chrome bug tracker url for css-has selector

### DIFF
--- a/features-json/css-has.json
+++ b/features-json/css-has.json
@@ -11,6 +11,10 @@
     {
       "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=418039",
       "title":"Firefox support bug"
+    },
+    {
+      "url":"https://bugs.chromium.org/p/chromium/issues/detail?id=669058",
+      "title":"Chrome bug to track implementation"
     }
   ],
   "bugs":[


### PR DESCRIPTION
Hi!

I found the chrome bug tracker url for this long wanted feature and it only has 12 stars.
Perhaps, to be on caniuse links will help its visibility.

Cheers,
Thomas.