### PR TITLE
Update Web Animations data for Safari

### DIFF
--- a/features-json/web-animation.json
+++ b/features-json/web-animation.json
@@ -230,8 +230,8 @@
       "12":"n d #4",
       "12.1":"n d #4",
       "13":"n d #4",
-      "13.1":"a",
-      "TP":"a"
+      "13.1":"y #5",
+      "TP":"y #5"
     },
     "opera":{
       "9":"n",
@@ -312,11 +312,11 @@
       "11.0-11.2":"n d #4",
       "11.3-11.4":"n d #4",
       "12.0-12.1":"n d #4",
-      "12.2-12.4":"a",
-      "13.0-13.1":"a",
-      "13.2":"a",
-      "13.3":"a",
-      "13.4":"a"
+      "12.2-12.4":"n d #4",
+      "13.0-13.1":"n d #4",
+      "13.2":"n d #4",
+      "13.3":"n d #4",
+      "13.4":"y #5"
     },
     "op_mini":{
       "all":"n"
@@ -384,7 +384,8 @@
     "1":"Partial support refers to basic support of `element.animate()`",
     "2":"Partial support refers to basic support of `element.animate()` and [playback control of AnimationPlayer](https://www.chromestatus.com/features/5633748733263872)",
     "3":"Partial support in Firefox is detailed in [Are we animated yet?](https://birtles.github.io/areweanimatedyet/)",
-    "4":"Can be enabled via the \"Experimental Features\" developer menu"
+    "4":"Can be enabled via the \"Experimental Features\" developer menu",
+    "5":"Does not support [composite modes](https://drafts.csswg.org/web-animations-1/#effect-composition)"
   },
   "usage_perc_y":0.22,
   "usage_perc_a":88.33,


### PR DESCRIPTION
The latest releases of Safari (13.1 on macOS and for iOS 13.4) now support the full Web Animations API, going beyond simply `Element.animate()`, and exposing CSS Animations and CSS Transitions as Web Animations objects using `Document.getAnimations()` and `Element.getAnimations()`. Previous versions only supported Web Animations as an experimental feature.

This is my first PR for caniuse.com, so I hope it is useful. I wasn't sure whether the level of support in Safari, which is the entire API save for one feature – [effect composition](https://drafts.csswg.org/web-animations-1/#effect-composition) – warranted an `a` or `y` level of support. I went with `y` in an optimistic manner, but please advise if maintainers of this repository think that is incorrect.