### PR TITLE
Remove inaccurate note and Safari support for ShadowDOM

### DIFF
--- a/features-json/shadowdomv1.json
+++ b/features-json/shadowdomv1.json
@@ -218,15 +218,15 @@
       "8":"n",
       "9":"n",
       "9.1":"n",
-      "10":"a #1",
-      "10.1":"a #1",
-      "11":"a #1",
-      "11.1":"a #1",
-      "12":"a #1",
-      "12.1":"a #1",
-      "13":"a #1",
-      "13.1":"a #1",
-      "TP":"a #1"
+      "10":"y",
+      "10.1":"y",
+      "11":"y",
+      "11.1":"y",
+      "12":"y",
+      "12.1":"y",
+      "13":"y",
+      "13.1":"y",
+      "TP":"y"
     },
     "opera":{
       "9":"n",
@@ -376,7 +376,6 @@
   },
   "notes":"",
   "notes_by_num":{
-    "1":"Certain CSS selectors do not work (`:host > .local-child`) and styling slotted content (`::slotted`) is buggy.",
     "2":"Enabled through the `dom.webcomponents.enabled` preference in `about:config`.",
     "3":"Enabled through the `dom.webcomponents.shadowdom.enabled` preference in `about:config`."
   },


### PR DESCRIPTION
I tested selectors like `:host > .foo` in several versions of Safari, including 10.0 and they all worked. I'm not sure where this comment originated from, but without automated tests or a bug reference to back up the note, it appears to be wrong.

Here are screenshots of a simple selector test working in Safari 10 on Sauce:

![Screen Shot 2020-04-07 at 2 48 06 PM](https://user-images.githubusercontent.com/522948/78722944-55c16800-78df-11ea-97bf-4033499c2817.png)
![Screen Shot 2020-04-07 at 2 48 13 PM](https://user-images.githubusercontent.com/522948/78722945-5659fe80-78df-11ea-8787-cd84e03f7855.png)

