### PR TITLE
Add links to AV1 & AVIF for Safari support

### DIFF
--- a/features-json/av1.json
+++ b/features-json/av1.json
@@ -23,6 +23,10 @@
     {
       "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=1452683",
       "title":"Firefox implementation bug"
+    },
+    {
+      "url":"https://bugs.webkit.org/show_bug.cgi?id=207547",
+      "title":"Safari implementation bug"
     }
   ],
   "bugs":[

--- a/features-json/avif.json
+++ b/features-json/avif.json
@@ -13,6 +13,10 @@
       "title":"Chrome support bug"
     },
     {
+      "url":"https://bugs.webkit.org/show_bug.cgi?id=207750",
+      "title":"Safari support bug"
+    },
+    {
       "url":"https://github.com/Kagami/avif.js",
       "title":"Polyfill"
     },


### PR DESCRIPTION
For convenience:
- AV1: https://bugs.webkit.org/show_bug.cgi?id=207547
- AVIF: https://bugs.webkit.org/show_bug.cgi?id=207750