### PR TITLE
iOS Safari 13.4 adds experimental support for loading lazy

### DIFF
--- a/features-json/loading-lazy-attr.json
+++ b/features-json/loading-lazy-attr.json
@@ -322,7 +322,7 @@
       "13.0-13.1":"n",
       "13.2":"n",
       "13.3":"n",
-      "13.4":"n"
+      "13.4":"n d #2"
     },
     "op_mini":{
       "all":"n"
@@ -387,7 +387,8 @@
   },
   "notes":"",
   "notes_by_num":{
-    "1":"Can be enabled via the `#enable-lazy-image-loading` and `#enable-lazy-frame-loading` feature flags"
+    "1":"Can be enabled via the `#enable-lazy-image-loading` and `#enable-lazy-frame-loading` feature flags",
+    "2":"Can be enabled in Settings under the Safari > Advanced > Experimental Features menu."
   },
   "usage_perc_y":62.71,
   "usage_perc_a":0,


### PR DESCRIPTION
`<img loading="lazy">` support can be enabled in Settings under the Safari > Advanced > Experimental Features menu since iOS safari 13.4. and is disabled by default.

https://bugs.webkit.org/show_bug.cgi?id=200764 was the ticket to track the implementation.
https://bugs.webkit.org/show_bug.cgi?id=208094 tracks when it moves from experimental to default.

![image](https://user-images.githubusercontent.com/905328/79773109-4efc1180-8331-11ea-87df-8e13526ee3d5.png)
