### PR TITLE
Add Firefox support bug URLs for extended-system-fonts

### DIFF
--- a/features-json/extended-system-fonts.json
+++ b/features-json/extended-system-fonts.json
@@ -7,6 +7,22 @@
     {
       "url":"https://webkit.org/blog/10247/new-webkit-features-in-safari-13-1/",
       "title":"WebKit Safari 13.1 announcement"
+    },
+    {
+      "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=1598879",
+      "title":"ui-serif Firefox support bug"
+    },
+    {
+      "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=1598880",
+      "title":"ui-sans-serif Firefox support bug"
+    },
+    {
+      "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=1598881",
+      "title":"ui-monospace Firefox support bug"
+    },
+    {
+      "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=1598883",
+      "title":"ui-rounded Firefox support bug"
     }
   ],
   "bugs":[


### PR DESCRIPTION
Missing from #5342 0:-)