### PR TITLE
Update font-variant-alternates spec URL

### DIFF
--- a/features-json/font-variant-alternates.json
+++ b/features-json/font-variant-alternates.json
@@ -1,8 +1,8 @@
 {
   "title":"CSS font-variant-alternates",
   "description":"Controls the usage of alternate glyphs associated to alternative names defined in @font-feature-values for certain types of OpenType fonts.",
-  "spec":"https://www.w3.org/TR/css-fonts-3/#propdef-font-variant-alternates",
-  "status":"cr",
+  "spec":"https://drafts.csswg.org/css-fonts-4/#propdef-font-variant-alternates",
+  "status":"wd",
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-alternates",


### PR DESCRIPTION
`font-variant-alternates` was dropped from the CSS Fonts Module Level 3 spec, so https://www.w3.org/TR/css-fonts-3/#propdef-font-variant-alternates no longer works.

`font-variant-alternates` is now just in the CSS Fonts Module Level 4 spec, https://drafts.csswg.org/css-fonts-4/#propdef-font-variant-alternates