### PR TITLE
Update CSS cross-fade() spec URL

### DIFF
--- a/features-json/css-cross-fade.json
+++ b/features-json/css-cross-fade.json
@@ -1,8 +1,8 @@
 {
   "title":"CSS Cross-Fade Function",
   "description":"Image function to create a \"crossfade\" between images. This allows one image to transition (fade) into another based on a percentage value.",
-  "spec":"https://drafts.csswg.org/css-images-3/#cross-fade-function",
-  "status":"unoff",
+  "spec":"https://drafts.csswg.org/css-images-4/#cross-fade-function",
+  "status":"cr",
   "links":[
     {
       "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=546052",


### PR DESCRIPTION
`cross-fade()` was dropped from the CSS Images Module Level 3 spec, so https://drafts.csswg.org/css-images-3/#cross-fade-function no longer works.

`cross-fade()` is now just in the CSS Images Module Level 4 spec, https://drafts.csswg.org/css-images-4/#cross-fade-function