### PR TITLE
Fix KeyboardEvent spec URLs

### DIFF
--- a/features-json/keyboardevent-charcode.json
+++ b/features-json/keyboardevent-charcode.json
@@ -1,7 +1,7 @@
 {
   "title":"KeyboardEvent.charCode",
   "description":"A legacy `KeyboardEvent` property that gives the Unicode codepoint number of a character key pressed during a `keypress` event.",
-  "spec":"https://w3c.github.io/uievents/#widl-KeyboardEvent-charCode",
+  "spec":"https://w3c.github.io/uievents/#dom-keyboardevent-charcode",
   "status":"unoff",
   "links":[
     {

--- a/features-json/keyboardevent-code.json
+++ b/features-json/keyboardevent-code.json
@@ -1,7 +1,7 @@
 {
   "title":"KeyboardEvent.code",
   "description":"A `KeyboardEvent` property representing the physical key that was pressed, ignoring the keyboard layout and ignoring whether any modifier keys were active.",
-  "spec":"https://www.w3.org/TR/uievents/#widl-KeyboardEvent-code",
+  "spec":"https://www.w3.org/TR/uievents/#dom-keyboardevent-code",
   "status":"wd",
   "links":[
     {

--- a/features-json/keyboardevent-getmodifierstate.json
+++ b/features-json/keyboardevent-getmodifierstate.json
@@ -1,7 +1,7 @@
 {
   "title":"KeyboardEvent.getModifierState()",
   "description":"`KeyboardEvent` method that returns the state (whether the key is pressed/locked or not) of the given modifier key.",
-  "spec":"https://www.w3.org/TR/uievents/#widl-KeyboardEvent-getModifierState",
+  "spec":"https://www.w3.org/TR/uievents/#dom-keyboardevent-getmodifierstate",
   "status":"wd",
   "links":[
     {

--- a/features-json/keyboardevent-location.json
+++ b/features-json/keyboardevent-location.json
@@ -1,7 +1,7 @@
 {
   "title":"KeyboardEvent.location",
   "description":"A `KeyboardEvent` property that indicates the location of the key on the input device. Useful when there are more than one physical key for the same logical key (e.g. left or right \"Control\" key; main or numpad \"1\" key).",
-  "spec":"https://www.w3.org/TR/uievents/#widl-KeyboardEvent-location",
+  "spec":"https://www.w3.org/TR/uievents/#dom-keyboardevent-location",
   "status":"wd",
   "links":[
     {

--- a/features-json/keyboardevent-which.json
+++ b/features-json/keyboardevent-which.json
@@ -1,7 +1,7 @@
 {
   "title":"KeyboardEvent.which",
   "description":"A legacy `KeyboardEvent` property that is equivalent to either `KeyboardEvent.keyCode` or `KeyboardEvent.charCode` depending on whether the key is alphanumeric.",
-  "spec":"https://w3c.github.io/uievents/#widl-KeyboardEvent-which",
+  "spec":"https://w3c.github.io/uievents/#dom-uievent-which",
   "status":"unoff",
   "links":[
     {


### PR DESCRIPTION
In general, spec URLs with fragment IDs starting with `#widl-` no longer work in current specs. They need to be updated to equivalent URLs that instead start with `#dom-` and that are all-lowercase.

This change updates the URLs for features related to `KeyboardEvent`.