### PR TITLE
Update Array.p.flat/Array.p.flatMap spec URL

### DIFF
--- a/features-json/array-flat.json
+++ b/features-json/array-flat.json
@@ -1,8 +1,8 @@
 {
   "title":"flat & flatMap array methods",
   "description":"Methods to flatten any sub-arrays found in an array by concatenating their elements.",
-  "spec":"https://tc39.github.io/proposal-flatMap/#sec-Array.prototype.flat",
-  "status":"unoff",
+  "spec":"https://tc39.es/ecma262/#sec-array.prototype.flat",
+  "status":"other",
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat",


### PR DESCRIPTION
`Array.prototype.flat` and `Array.prototype.flatMap` are now part of the ECMAScript spec.