### PR TITLE
Update Date.prototype.toLocaleDateString spec URL

### DIFF
--- a/features-json/date-tolocaledatestring.json
+++ b/features-json/date-tolocaledatestring.json
@@ -1,7 +1,7 @@
 {
   "title":"Date.prototype.toLocaleDateString",
   "description":"Date method to generate a language sensitive representation of a given date, formatted based on a specified locale and options.",
-  "spec":"https://tc39.github.io/ecma402/#sec-Date.prototype.toLocaleDateString",
+  "spec":"https://tc39.es/ecma402/#sup-date.prototype.tolocaledatestring",
   "status":"other",
   "links":[
     {


### PR DESCRIPTION
https://tc39.github.io/ecma402/#sec-Date.prototype.toLocaleDateString no longer works (no such anchor). https://tc39.es/ecma402/#sup-date.prototype.tolocaledatestring works.