### PR TITLE
Normalize ECMA-402 features' `spec` and `categories`

### DIFF
--- a/features-json/internationalization.json
+++ b/features-json/internationalization.json
@@ -1,7 +1,7 @@
 {
   "title":"Internationalization API",
   "description":"Locale-sensitive collation (string comparison), number formatting, and date and time formatting.",
-  "spec":"https://www.ecma-international.org/ecma-402/1.0/",
+  "spec":"https://tc39.es/ecma402/",
   "status":"other",
   "links":[
     {
@@ -29,7 +29,7 @@
     
   ],
   "categories":[
-    "JS API"
+    "JS"
   ],
   "stats":{
     "ie":{

--- a/features-json/intl-pluralrules.json
+++ b/features-json/intl-pluralrules.json
@@ -17,7 +17,7 @@
     
   ],
   "categories":[
-    "JS API"
+    "JS"
   ],
   "stats":{
     "ie":{

--- a/features-json/localecompare.json
+++ b/features-json/localecompare.json
@@ -1,7 +1,7 @@
 {
   "title":"localeCompare()",
   "description":"The `localeCompare()` method returns a number indicating whether a reference string comes before or after or is the same as the given string in sort order.",
-  "spec":"https://www.ecma-international.org/ecma-402/2.0/#sec-13.1.1",
+  "spec":"https://tc39.es/ecma402/#sup-String.prototype.localeCompare",
   "status":"other",
   "links":[
     {


### PR DESCRIPTION
Normalize ECMAScript Internationalization API (ECMA-402) features' `spec` and `categories`.

- Use https://ts39.es/ecma402/ for `spec` url
- Make `categories` be `[ "JS" ]` as they are JavaScript features

    ECMA-402 supersedes several functions of ECMAScript (ECMA-262) so that it should be considered as JS core features.
