### PR TITLE
Normalize ECMA-262 features' `spec`, `categories`, and `status`

### DIFF
--- a/features-json/array-find-index.json
+++ b/features-json/array-find-index.json
@@ -1,7 +1,7 @@
 {
   "title":"Array.prototype.findIndex",
   "description":"The `findIndex()` method returns the index of the first element in the array that satisfies the provided testing function.",
-  "spec":"https://www.ecma-international.org/ecma-262/6.0/#sec-array.prototype.findindex",
+  "spec":"https://tc39.es/ecma262/#sec-array.prototype.findindex",
   "status":"other",
   "links":[
     {

--- a/features-json/array-find.json
+++ b/features-json/array-find.json
@@ -1,7 +1,7 @@
 {
   "title":"Array.prototype.find",
   "description":"The `find()` method returns the value of the first item in the array based on the result of the provided testing function.",
-  "spec":"https://www.ecma-international.org/ecma-262/6.0/#sec-array.prototype.find",
+  "spec":"https://tc39.es/ecma262/#sec-array.prototype.find",
   "status":"other",
   "links":[
     {

--- a/features-json/array-includes.json
+++ b/features-json/array-includes.json
@@ -1,7 +1,7 @@
 {
   "title":"Array.prototype.includes",
   "description":"Determines whether or not an array includes the given value, returning a boolean value (unlike `indexOf`).",
-  "spec":"https://tc39.github.io/ecma262/#sec-array.prototype.includes",
+  "spec":"https://tc39.es/ecma262/#sec-array.prototype.includes",
   "status":"other",
   "links":[
     {

--- a/features-json/arrow-functions.json
+++ b/features-json/arrow-functions.json
@@ -1,7 +1,7 @@
 {
   "title":"Arrow functions",
   "description":"Function shorthand using `=>` syntax and lexical `this` binding.",
-  "spec":"https://www.ecma-international.org/ecma-262/6.0/#sec-arrow-function-definitions",
+  "spec":"https://tc39.es/ecma262/#sec-arrow-function-definitions",
   "status":"other",
   "links":[
     {

--- a/features-json/async-functions.json
+++ b/features-json/async-functions.json
@@ -1,7 +1,7 @@
 {
   "title":"Async functions",
   "description":"Async functions make it possible to treat functions returning Promise objects as if they were synchronous.",
-  "spec":"https://tc39.github.io/ecmascript-asyncawait/",
+  "spec":"https://tc39.es/ecma262/#sec-async-function-definitions",
   "status":"other",
   "links":[
     {

--- a/features-json/async-iterations-and-generators.json
+++ b/features-json/async-iterations-and-generators.json
@@ -1,7 +1,7 @@
 {
   "title":"Async iterators and generators",
   "description":"Async iterators provide generic data access for asynchronous data sources, and provide a new async function* syntax that implements this protocol.",
-  "spec":"https://github.com/tc39/proposal-async-iteration",
+  "spec":"https://tc39.es/ecma262/#sec-async-generator-function-definitions",
   "status":"other",
   "links":[
     

--- a/features-json/bigint.json
+++ b/features-json/bigint.json
@@ -1,13 +1,9 @@
 {
   "title":"BigInt",
   "description":"Arbitrary-precision integers in JavaScript.",
-  "spec":"https://tc39.github.io/proposal-bigint/",
-  "status":"pr",
+  "spec":"https://tc39.es/ecma262/#sec-bigint-objects",
+  "status":"other",
   "links":[
-    {
-      "url":"https://github.com/tc39/proposal-bigint",
-      "title":"GitHub repository"
-    },
     {
       "url":"https://developers.google.com/web/updates/2018/05/bigint",
       "title":"Blog article from Google Developer"
@@ -29,7 +25,7 @@
     
   ],
   "categories":[
-    "JS API"
+    "JS"
   ],
   "stats":{
     "ie":{

--- a/features-json/const.json
+++ b/features-json/const.json
@@ -1,7 +1,7 @@
 {
   "title":"const",
   "description":"Declares a constant with block level scope",
-  "spec":"https://www.ecma-international.org/ecma-262/6.0/#sec-let-and-const-declarations",
+  "spec":"https://tc39.es/ecma262/#sec-let-and-const-declarations",
   "status":"other",
   "links":[
     {

--- a/features-json/es6-class.json
+++ b/features-json/es6-class.json
@@ -1,7 +1,7 @@
 {
   "title":"ES6 classes",
   "description":"ES6 classes are syntactical sugar to provide a much simpler and clearer syntax to create objects and deal with inheritance.",
-  "spec":"https://www.ecma-international.org/ecma-262/6.0/#sec-class-definitions",
+  "spec":"https://tc39.es/ecma262/#sec-class-definitions",
   "status":"other",
   "links":[
     {

--- a/features-json/es6-generators.json
+++ b/features-json/es6-generators.json
@@ -1,7 +1,7 @@
 {
   "title":"ES6 Generators",
   "description":"ES6 Generators are special functions that can be used to control the iteration behavior of a loop. Generators are defined using a `function*` declaration.",
-  "spec":"https://www.ecma-international.org/ecma-262/6.0/#sec-generator-function-definitions",
+  "spec":"https://tc39.es/ecma262/#sec-generator-function-definitions",
   "status":"other",
   "links":[
     {
@@ -17,7 +17,7 @@
     
   ],
   "categories":[
-    "Other"
+    "JS"
   ],
   "stats":{
     "ie":{

--- a/features-json/es6-module-dynamic-import.json
+++ b/features-json/es6-module-dynamic-import.json
@@ -1,11 +1,11 @@
 {
   "title":"JavaScript modules: dynamic import()",
   "description":"Loading JavaScript modules dynamically using the import() syntax",
-  "spec":"https://github.com/tc39/proposal-dynamic-import",
+  "spec":"https://tc39.es/ecma262/#sec-import-calls",
   "status":"other",
   "links":[
     {
-      "url":"https://tc39.github.io/proposal-dynamic-import/",
+      "url":"https://tc39.es/ecma262/#sec-import-calls",
       "title":"Counterpart ECMAScript specification for import() syntax"
     },
     {

--- a/features-json/es6-module.json
+++ b/features-json/es6-module.json
@@ -25,7 +25,7 @@
       "title":"Blog post: Native ECMAScript modules - the first overview"
     },
     {
-      "url":"https://tc39.github.io/ecma262/#sec-modules",
+      "url":"https://tc39.es/ecma262/#sec-modules",
       "title":"Counterpart ECMAScript specification for import/export syntax"
     },
     {

--- a/features-json/es6-number.json
+++ b/features-json/es6-number.json
@@ -1,7 +1,7 @@
 {
   "title":"ES6 Number",
   "description":"Extensions to the `Number` built-in object in ES6, including constant properties `EPSILON`, `MIN_SAFE_INTEGER`, and `MAX_SAFE_INTEGER`, and methods ` isFinite`, `isInteger`, `isSafeInteger`, and `isNaN`.",
-  "spec":"https://www.ecma-international.org/ecma-262/6.0/#sec-number-objects",
+  "spec":"https://tc39.es/ecma262/#sec-number-objects",
   "status":"other",
   "links":[
     {

--- a/features-json/es6-string-includes.json
+++ b/features-json/es6-string-includes.json
@@ -1,7 +1,7 @@
 {
   "title":"String.prototype.includes",
   "description":"The includes() method determines whether one string may be found within another string, returning true or false as appropriate.",
-  "spec":"http://www.ecma-international.org/ecma-262/6.0/#sec-string.prototype.includes",
+  "spec":"https://tc39.es/ecma262/#sec-string.prototype.includes",
   "status":"other",
   "links":[
     {

--- a/features-json/es6.json
+++ b/features-json/es6.json
@@ -1,7 +1,7 @@
 {
   "title":"ECMAScript 2015 (ES6)",
   "description":"Support for the ECMAScript 2015 specification. Features include Promises, Modules, Classes, Template Literals, Arrow Functions, Let and Const, Default Parameters, Generators, Destructuring Assignment, Rest & Spread, Map/Set & WeakMap/WeakSet and many more.",
-  "spec":"https://www.ecma-international.org/ecma-262/6.0/",
+  "spec":"https://tc39.es/ecma262/",
   "status":"other",
   "links":[
     {

--- a/features-json/js-regexp-lookbehind.json
+++ b/features-json/js-regexp-lookbehind.json
@@ -1,8 +1,8 @@
 {
   "title":"Lookbehind in JS regular expressions",
   "description":"Zero-width assertion that ensures a pattern is preceded by another pattern in a JavaScript regular expression.",
-  "spec":"https://tc39.github.io/proposal-regexp-lookbehind/",
-  "status":"unoff",
+  "spec":"https://tc39.es/ecma262/#sec-assertion",
+  "status":"other",
   "links":[
     {
       "url":"http://2ality.com/2017/05/regexp-lookbehind-assertions.html",

--- a/features-json/let.json
+++ b/features-json/let.json
@@ -1,7 +1,7 @@
 {
   "title":"let",
   "description":"Declares a variable with block level scope",
-  "spec":"https://www.ecma-international.org/ecma-262/6.0/#sec-let-and-const-declarations",
+  "spec":"https://tc39.es/ecma262/#sec-let-and-const-declarations",
   "status":"other",
   "links":[
     {

--- a/features-json/object-entries.json
+++ b/features-json/object-entries.json
@@ -1,7 +1,7 @@
 {
   "title":"Object.entries",
   "description":"The `Object.entries()` method creates a multi-dimensional array of key value pairs from the given object.",
-  "spec":"https://www.ecma-international.org/ecma-262/8.0/#sec-object.entries",
+  "spec":"https://tc39.es/ecma262/#sec-object.entries",
   "status":"other",
   "links":[
     {

--- a/features-json/object-values.json
+++ b/features-json/object-values.json
@@ -1,7 +1,7 @@
 {
   "title":"Object.values method",
   "description":"The `Object.values()` method returns an array of a given object's own enumerable property values.",
-  "spec":"https://www.ecma-international.org/ecma-262/8.0/#sec-object.values",
+  "spec":"https://tc39.es/ecma262/#sec-object.values",
   "status":"other",
   "links":[
     {

--- a/features-json/pad-start-end.json
+++ b/features-json/pad-start-end.json
@@ -1,7 +1,7 @@
 {
   "title":"String.prototype.padStart(), String.prototype.padEnd()",
   "description":"The `padStart()` and `padEnd()` methods pad the current string with a given string (eventually repeated) so that the resulting string reaches a given length. The pad is applied from the start (left) of the current string for `padStart()`, and applied from the end (right) of the current string for `padEnd()`.",
-  "spec":"https://www.ecma-international.org/ecma-262/8.0/index.html#sec-string.prototype.padend",
+  "spec":"https://tc39.es/ecma262/#sec-string.prototype.padend",
   "status":"other",
   "links":[
     {

--- a/features-json/private-class-fields.json
+++ b/features-json/private-class-fields.json
@@ -2,7 +2,7 @@
   "title":"Private class fields",
   "description":"<description>",
   "spec":"https://tc39.es/proposal-class-fields/",
-  "status":"wd",
+  "status":"unoff",
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes#Private_field_declarations",
@@ -11,14 +11,17 @@
     {
       "url":"https://v8.dev/featnres/class-fields#private-class-fields",
       "title":"V8 Feature Article"
+    },
+    {
+      "url":"https://github.com/tc39/proposal-class-fields",
+      "title":"TC39 Feature Draft"
     }
   ],
   "bugs":[
     
   ],
   "categories":[
-    "JS",
-    "JS API"
+    "JS"
   ],
   "stats":{
     "ie":{

--- a/features-json/private-methods-and-accessors.json
+++ b/features-json/private-methods-and-accessors.json
@@ -2,7 +2,7 @@
   "title":"Public class fields",
   "description":"<description>",
   "spec":"https://tc39.es/proposal-private-methods/",
-  "status":"wd",
+  "status":"unoff",
   "links":[
     {
       "url":"https://github.com/tc39/proposal-private-methods",
@@ -13,8 +13,7 @@
     
   ],
   "categories":[
-    "JS",
-    "JS API"
+    "JS"
   ],
   "stats":{
     "ie":{

--- a/features-json/promise-finally.json
+++ b/features-json/promise-finally.json
@@ -1,7 +1,7 @@
 {
   "title":"Promise.prototype.finally",
   "description":"When the promise is settled, whether fulfilled or rejected, the specified callback function is executed.",
-  "spec":"https://tc39.github.io/ecma262/#sec-promise.prototype.finally",
+  "spec":"https://tc39.es/ecma262/#sec-promise.prototype.finally",
   "status":"other",
   "links":[
     {

--- a/features-json/promises.json
+++ b/features-json/promises.json
@@ -1,7 +1,7 @@
 {
   "title":"Promises",
   "description":"A promise represents the eventual result of an asynchronous operation.",
-  "spec":"https://www.ecma-international.org/ecma-262/6.0/#sec-promise-objects",
+  "spec":"https://tc39.es/ecma262/#sec-promise-objects",
   "status":"other",
   "links":[
     {

--- a/features-json/proxy.json
+++ b/features-json/proxy.json
@@ -1,7 +1,7 @@
 {
   "title":"Proxy object",
   "description":"The Proxy object allows custom behavior to be defined for fundamental operations. Useful for logging, profiling, object visualization, etc.",
-  "spec":"https://www.ecma-international.org/ecma-262/6.0/#sec-proxy-object-internal-methods-and-internal-slots",
+  "spec":"https://tc39.es/ecma262/#sec-proxy-objects",
   "status":"other",
   "links":[
     {

--- a/features-json/public-class-fields.json
+++ b/features-json/public-class-fields.json
@@ -2,7 +2,7 @@
   "title":"Public class fields",
   "description":"<description>",
   "spec":"https://tc39.es/proposal-class-fields/",
-  "status":"wd",
+  "status":"unoff",
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes#Public_field_declarations",
@@ -11,14 +11,17 @@
     {
       "url":"https://v8.dev/features/class-fields#public-class-fields",
       "title":"V8 Feature Article"
+    },
+    {
+      "url":"https://github.com/tc39/proposal-class-fields",
+      "title":"TC39 Feature Draft"
     }
   ],
   "bugs":[
     
   ],
   "categories":[
-    "JS",
-    "JS API"
+    "JS"
   ],
   "stats":{
     "ie":{

--- a/features-json/replace-all.json
+++ b/features-json/replace-all.json
@@ -31,6 +31,10 @@
     {
       "url":"https://gist.github.com/developit/1a40a6fee65361d1182aaa22ab8c334c",
       "title":"developit polyfill"
+    },
+    {
+      "url":"https://github.com/tc39/proposal-string-replaceall/",
+      "title":"TC39 Feature Draft"
     }
   ],
   "bugs":[

--- a/features-json/rest-parameters.json
+++ b/features-json/rest-parameters.json
@@ -1,7 +1,7 @@
 {
   "title":"Rest parameters",
   "description":"Allows representation of an indefinite number of arguments as an array.",
-  "spec":"https://www.ecma-international.org/ecma-262/6.0/#sec-function-definitions",
+  "spec":"https://tc39.es/ecma262/#sec-function-definitions",
   "status":"other",
   "links":[
     {

--- a/features-json/sharedarraybuffer.json
+++ b/features-json/sharedarraybuffer.json
@@ -1,7 +1,7 @@
 {
   "title":"Shared Array Buffer",
   "description":"Type of ArrayBuffer that can be shared across Workers.",
-  "spec":"https://tc39.github.io/ecmascript_sharedmem/shmem.html",
+  "spec":"https://tc39.es/ecma262/#sec-sharedarraybuffer-objects",
   "status":"other",
   "links":[
     {

--- a/features-json/symbols.json
+++ b/features-json/symbols.json
@@ -1,7 +1,7 @@
 {
   "title":"Symbols",
   "description":"Object property value with enforced uniqueness",
-  "spec":"https://www.ecma-international.org/ecma-262/6.0/#sec-symbol-objects",
+  "spec":"https://tc39.es/ecma262/#sec-symbol-objects",
   "status":"other",
   "links":[
     {

--- a/features-json/template-literals.json
+++ b/features-json/template-literals.json
@@ -1,7 +1,7 @@
 {
   "title":"ES6 Template Literals (Template Strings)",
   "description":"Template literals are string literals allowing embedded expressions. You can use multi-line strings and string interpolation features with them. Formerly known as template strings.",
-  "spec":"https://www.ecma-international.org/ecma-262/6.0/#sec-template-literals",
+  "spec":"https://tc39.es/ecma262/#sec-template-literals",
   "status":"other",
   "links":[
     {

--- a/features-json/typedarrays.json
+++ b/features-json/typedarrays.json
@@ -1,7 +1,7 @@
 {
   "title":"Typed Arrays",
   "description":"JavaScript typed arrays provide a mechanism for accessing raw binary data much more efficiently. Includes: `Int8Array`, `Uint8Array`, `Uint8ClampedArray`, `Int16Array`, `Uint16Array`, `Int32Array`, `Uint32Array`, `Float32Array` & `Float64Array`\r\n",
-  "spec":"https://www.ecma-international.org/ecma-262/6.0/#sec-typedarray-objects",
+  "spec":"https://tc39.es/ecma262/#sec-typedarray-objects",
   "status":"other",
   "links":[
     {


### PR DESCRIPTION
Normalize ECMAScript (ECMA-262) features' `spec`, `categories`, and `status`

- Use https://ts39.es/ecma262/ for `spec` url

    https://www.ecma-international.org/publications/standards/Ecma-262.htm says

    > The latest drafts are available at: https://tc39.github.io/ecma262/. Reporters should generally only file bugs if the bug is still present in the latest drafts.

    Thus referencing https://ts39.es/ecma262/ is better suited for developers who read specifications.

- Update `spec` url to point https://ts39.es/ecma262/ for [finished proposal](https://github.com/tc39/proposals/blob/master/finished-proposals.md)
- Make `categories` be `[ "JS" ]` as they are JavaScript features
- Make `status` be `other` (mainline features) of `unoff` (proposals) regarding CONTRIBUTING.md
