### PR TITLE
Add experimental support for AVIF as of firefox 77

### DIFF
--- a/features-json/avif.json
+++ b/features-json/avif.json
@@ -23,6 +23,10 @@
     {
       "url":"https://bugs.webkit.org/show_bug.cgi?id=207750",
       "title":"Safari support bug"
+    },
+    {
+      "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=1625363",
+      "title":"Mozilla support bug"
     }
   ],
   "bugs":[
@@ -131,7 +135,7 @@
       "74":"n",
       "75":"n",
       "76":"n",
-      "77":"n"
+      "77":"n d #1"
     },
     "chrome":{
       "4":"n",
@@ -389,7 +393,7 @@
   },
   "notes":"",
   "notes_by_num":{
-    
+    "1":"Can be enabled in Firefox via the `image.avif.enabled` flag in `about:config`"
   },
   "usage_perc_y":0,
   "usage_perc_a":0,


### PR DESCRIPTION
It's disabled by default but Mozilla has added experimental AVIF image support that will be included in the release of Firefox 77 - it's already included in the Firefox nighties. It can be enabled via the `image.avif.enabled` flag in `about:config`

https://bugzilla.mozilla.org/show_bug.cgi?id=1625363