### PR TITLE
Update Chrome support for CSS appearance

### DIFF
--- a/features-json/css-appearance.json
+++ b/features-json/css-appearance.json
@@ -1,7 +1,7 @@
 {
   "title":"CSS Appearance",
   "description":"The `appearance` property defines how elements (particularly form controls) appear by default. By setting the value to `none` the default appearance can be entirely redefined using other CSS properties.",
-  "spec":"https://drafts.csswg.org/css-ui-4/#appearance-switching",
+  "spec":"https://www.w3.org/TR/css-ui-4/#appearance-switching",
   "status":"wd",
   "links":[
     {
@@ -197,8 +197,8 @@
       "80":"a x #1",
       "81":"a x #1",
       "83":"a x #1",
-      "84":"a x #1",
-      "85":"a x #1"
+      "84":"a #1",
+      "85":"a #1"
     },
     "safari":{
       "3.1":"a x #1",


### PR DESCRIPTION
Chrome is adding unprefixed support for CSS `appearance` in v84 - yay!

This is tested with the [Caniuse test](https://tests.caniuse.com/?feat=css-appearance) and is documented:
https://www.chromestatus.com/feature/4715298156445696

I also updated the spec link. The spec status was correct, but the link was to an older specification from before it was a working draft.