### PR TITLE
Safari fixed input events in 12.1 (radio/checkbox) and 13.1 (file)

### DIFF
--- a/features-json/input-event.json
+++ b/features-json/input-event.json
@@ -229,10 +229,10 @@
       "11":"y #4",
       "11.1":"y #4",
       "12":"y #4",
-      "12.1":"y #4",
-      "13":"y #4",
-      "13.1":"y #4",
-      "TP":"y #4"
+      "12.1":"y #6",
+      "13":"y #6",
+      "13.1":"y",
+      "TP":"y"
     },
     "opera":{
       "9":"u",
@@ -387,8 +387,9 @@
     "1":"Doesn't fire an `input` event when deleting text (via Backspace, Delete, Cut, etc.).",
     "2":"Doesn't fire an `input` event when drag-and-dropping text into an `<input>` or `<textarea>`.",
     "3":"`<select>` doesn't fire `input` events. See [MS Edge bug](https://developer.microsoft.com/microsoft-edge/platform/issues/4660045/) and [Firefox bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1024350).",
-    "4":"Doesn't fire an `input` event when (un)checking a checkbox or radio button, or when changing the selected file(s) of an `<input type=\"file\">`. See [Chrome bug](https://code.google.com/p/chromium/issues/detail?id=534245), [WebKit bug](https://bugs.webkit.org/show_bug.cgi?id=149398), and [Firefox bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1206616).",
-    "5":"Doesn't fire an `input` event when (un)checking a checkbox or radio button. See [MS Edge bug](https://connect.microsoft.com/IE/feedback/details/1883692)."
+    "4":"Doesn't fire an `input` event when (un)checking a checkbox or radio button, or when changing the selected file(s) of an `<input type=\"file\">`. See [Chrome bug](https://code.google.com/p/chromium/issues/detail?id=534245), [WebKit bug #149398](https://bugs.webkit.org/show_bug.cgi?id=149398), [WebKit bug #190223](https://bugs.webkit.org/show_bug.cgi?id=190223) and [Firefox bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1206616).",
+    "5":"Doesn't fire an `input` event when (un)checking a checkbox or radio button. See [MS Edge bug](https://connect.microsoft.com/IE/feedback/details/1883692).",
+    "6":"Doesn't fire an `input` event when changing the selected file(s) of an `<input type=\"file\">`. See [WebKit bug #149398](https://bugs.webkit.org/show_bug.cgi?id=149398) and [WebKit bug #204292](https://bugs.webkit.org/show_bug.cgi?id=204292)."
   },
   "usage_perc_y":97.22,
   "usage_perc_a":0.35,


### PR DESCRIPTION
## Starting with Safari 12.1...
...the radio inputs and checkbox inputs fire “click”, “input”, and “change” events in order when clicked:
* https://bugs.webkit.org/show_bug.cgi?id=190223
* https://trac.webkit.org/changeset/236779/webkit

Read https://webkit.org/blog/8419/release-notes-for-safari-technology-preview-67/
> "Fixed radio inputs and checkbox inputs to fire “click”, “input”, and “change” events in order when clicked"

Preview 67 was mentioned in the 12.1 blog post here (see bottom): https://webkit.org/blog/8718/new-webkit-features-in-safari-12-1/

## Starting with Safari 13.1...
...finally the file input fires an input event before the change event:
* https://bugs.webkit.org/show_bug.cgi?id=204292
* https://trac.webkit.org/changeset/252768/webkit

Read https://webkit.org/blog/9672/release-notes-for-safari-technology-preview-97/
> "Changed the file input to fire an input event before the change event"

Preview 97 was mentioned in the 13.1 blog post here (see bottom): https://webkit.org/blog/10247/new-webkit-features-in-safari-13-1/