### PR TITLE
Chrome adds full support for CSS appearance

### DIFF
--- a/features-json/css-appearance.json
+++ b/features-json/css-appearance.json
@@ -197,9 +197,9 @@
       "79":"a x #1",
       "80":"a x #1",
       "81":"a x #1",
-      "83":"a x #1",
-      "84":"a #1",
-      "85":"a #1"
+      "83":"y x",
+      "84":"y",
+      "85":"y"
     },
     "safari":{
       "3.1":"a x #1",
@@ -372,9 +372,9 @@
       "2.5":"a x #1"
     }
   },
-  "notes":"",
+  "notes":"WebKit, Blink, and Gecko browsers also support additional vendor specific values.",
   "notes_by_num":{
-    "1":"The appearance property is supported with the `none` value, but not `auto`. WebKit, Blink, and Gecko browsers also support additional vendor specific values.",
+    "1":"The appearance property is supported with the `none` value, but not `auto`.",
     "2":"Microsoft Edge and IE Mobile support this property with the `-webkit-` prefix, rather than `-ms-` for interop reasons.",
     "3":"-moz-appearance:none doesn't remove the dropdown arrow in select tag"
   },


### PR DESCRIPTION
In #5412 i completely failed to notice that Chromium is also adding support for the `auto` keyword in v83, making this a fully supported, unprefixed feature 🥳

I ran a manuel test to confirm it. Here is the reference:
https://www.chromestatus.com/feature/5913213940006912

They are also doing some other stuff with it, but nothing that i felt needed notes:
https://www.chromestatus.com/features#appearance (the first four entries)