### PR TITLE
Reword & include Safari 13 in backface-visibility prefix requirement note

### DIFF
--- a/features-json/transforms3d.json
+++ b/features-json/transforms3d.json
@@ -409,7 +409,7 @@
   "notes":"",
   "notes_by_num":{
     "1":"Partial support in IE refers to not supporting [the transform-style: preserve-3d property](http://msdn.microsoft.com/en-us/library/ie/hh673529%28v=vs.85%29.aspx#the_ms_transform_style_property). This prevents nesting 3D transformed elements.",
-    "2":"Safari 9, 10, 11, & 12 are reported to still require a prefix for the related `backface-visibility` property."
+    "2":"Safari 9 - 13 still require a prefix for the related `backface-visibility` property."
   },
   "usage_perc_y":96.37,
   "usage_perc_a":1.49,

--- a/features-json/transforms3d.json
+++ b/features-json/transforms3d.json
@@ -409,7 +409,7 @@
   "notes":"",
   "notes_by_num":{
     "1":"Partial support in IE refers to not supporting [the transform-style: preserve-3d property](http://msdn.microsoft.com/en-us/library/ie/hh673529%28v=vs.85%29.aspx#the_ms_transform_style_property). This prevents nesting 3D transformed elements.",
-    "2":"Safari 9 - 13 still require a prefix for the related `backface-visibility` property."
+    "2":"Safari 9 - 13 still require a prefix for the related `backface-visibility` property. [WebKit Bug 170983](https://bugs.webkit.org/show_bug.cgi?id=170983) requests prefix removal."
   },
   "usage_perc_y":96.37,
   "usage_perc_a":1.49,


### PR DESCRIPTION
Added <https://bugs.webkit.org/show_bug.cgi?id=170983> as well.

Safari TP 106:

![image](https://user-images.githubusercontent.com/2644614/82357080-e1f99b80-9a04-11ea-8b0b-816660dff836.png)

Safari on iOS 13.4.1:

![A03A2C76-2075-46FF-BFBB-261C09A2D1E2](https://user-images.githubusercontent.com/2644614/82356933-9941e280-9a04-11ea-9183-8a0fdc1ec7e0.png)