### PR TITLE
flexbox-gap: Chrome 84+ by default

### DIFF
--- a/features-json/flexbox-gap.json
+++ b/features-json/flexbox-gap.json
@@ -210,8 +210,8 @@
       "80":"n",
       "81":"n",
       "83":"n",
-      "84":"n d #1",
-      "85":"n d #1"
+      "84":"y",
+      "85":"y"
     },
     "safari":{
       "3.1":"n",
@@ -385,9 +385,7 @@
     }
   },
   "notes":"",
-  "notes_by_num":{
-    "1":"Can be enabled in Chrome via the `#enable-experimental-web-platform-features` flag in `chrome://flags`"
-  },
+  "notes_by_num":{},
   "usage_perc_y":3.79,
   "usage_perc_a":0,
   "ucprefix":false,


### PR DESCRIPTION
<https://bugs.chromium.org/p/chromium/issues/detail?id=762679#c41>

> [css-flexbox] Enable gaps by default
>
> Enabling for chrome 84 will be at least one more finch CL.

<https://www.chromestatus.com/feature/6031643502444544>

~Draft pull request because its not yet available without the flag.~

Chrome Canary 85.0.4153.0:

![image](https://user-images.githubusercontent.com/2644614/82738680-c1e61700-9d39-11ea-8d95-461a2ccf39cf.png)

---

Chrome Beta is still at 83 unfortunately:

![image](https://user-images.githubusercontent.com/2644614/82738776-9d3e6f00-9d3a-11ea-932b-f55a3376a40e.png)
