### PR TITLE
Firefox will soon support Link Preload

### DIFF
--- a/features-json/link-rel-preload.json
+++ b/features-json/link-rel-preload.json
@@ -382,7 +382,7 @@
       "2.5":"n"
     }
   },
-  "notes":"Firefox plans to enable this by default in a version after 78",
+  "notes":"Firefox has newly rewritten their implementation and plans to enable it by default in a version closely succeeding 78",
   "notes_by_num":{
     "1":"Only cachable resources can be preloaded. This includes the following `as` values: script, style, image, video, audio, track, fetch, and font (note font/collection is not supported).",
     "2":"Can be enabled via the \"Experimental Features\" developer menu",

--- a/features-json/link-rel-preload.json
+++ b/features-json/link-rel-preload.json
@@ -382,7 +382,7 @@
       "2.5":"n"
     }
   },
-  "notes":"",
+  "notes":"Firefox plans to enable this by default in a version after 78",
   "notes_by_num":{
     "1":"Only cachable resources can be preloaded. This includes the following `as` values: script, style, image, video, audio, track, fetch, and font (note font/collection is not supported).",
     "2":"Can be enabled via the \"Experimental Features\" developer menu",


### PR DESCRIPTION
Firefox is planning support by default for link preloading:

https://groups.google.com/forum/#!msg/mozilla.dev.platform/MShUZ4VTa6s/E4XFYfL5AQA
> ** Release plan **
> - I'm about to enable it in this cycle, Firefox 78, for all users of
> Nightly and then let it ride to Early Beta only.
> - After PI and PE is done with good results we plan to do a gradual
> release on Beta and Release using a study. 

This PR adds a note about it. I will also open a draft PR for the final changes when we know which exact version will be adding support.