### PR TITLE
ServiceWorkers are now a Candidate Recommendation

### DIFF
--- a/features-json/serviceworkers.json
+++ b/features-json/serviceworkers.json
@@ -1,8 +1,8 @@
 {
   "title":"Service Workers",
   "description":"Method that enables applications to take advantage of persistent background processing, including hooks to enable bootstrapping of web applications while offline.",
-  "spec":"https://slightlyoff.github.io/ServiceWorker/spec/service_worker/",
-  "status":"wd",
+  "spec":"https://w3c.github.io/ServiceWorker/",
+  "status":"cr",
   "links":[
     {
       "url":"https://www.html5rocks.com/en/tutorials/service-worker/introduction/",


### PR DESCRIPTION
Most of the SW spec is now a candidate recommendation: https://www.w3.org/TR/service-workers/ 🥳

I also updated the link, since it's moved.