### PR TITLE
Safari adds experimental support for Link Prefetch

### DIFF
--- a/features-json/link-rel-prefetch.json
+++ b/features-json/link-rel-prefetch.json
@@ -227,8 +227,8 @@
       "12":"n",
       "12.1":"n",
       "13":"n",
-      "13.1":"n",
-      "TP":"n"
+      "13.1":"n d #1",
+      "TP":"n d #1"
     },
     "opera":{
       "9":"n",
@@ -315,7 +315,7 @@
       "13.0-13.1":"n",
       "13.2":"n",
       "13.3":"n",
-      "13.4":"n"
+      "13.4":"n d #1"
     },
     "op_mini":{
       "all":"n"
@@ -380,7 +380,7 @@
   },
   "notes":"",
   "notes_by_num":{
-    
+    "1":"Can be enabled in Safari as ´LinkPrefetch´ in the developer menu"
   },
   "usage_perc_y":78.64,
   "usage_perc_a":0,


### PR DESCRIPTION
I have tested this with the [Caniuse test](https://tests.caniuse.com/link-rel-prefetch). Please note that i only have access to Safari 12.1 and 13.1, as well as Safari IOS 13.5. Any data outside of those exact versions are just solid guesses.