### PR TITLE
Add Chrome/Edge support note for CSS "image-orientation"

### DIFF
--- a/features-json/css-image-orientation.json
+++ b/features-json/css-image-orientation.json
@@ -49,8 +49,8 @@
       "18":"n",
       "79":"n",
       "80":"n",
-      "81":"y",
-      "83":"y"
+      "81":"y #2",
+      "83":"y #2"
     },
     "firefox":{
       "2":"n",
@@ -211,11 +211,11 @@
       "78":"n",
       "79":"n",
       "80":"n",
-      "81":"y",
-      "83":"y",
-      "84":"y",
-      "85":"y",
-      "86":"y"
+      "81":"y #2",
+      "83":"y #2",
+      "84":"y #2",
+      "85":"y #2",
+      "86":"y #2"
     },
     "safari":{
       "3.1":"n",
@@ -390,7 +390,8 @@
   },
   "notes":"Opening the image in a new tab in Chrome results in the image shown in the orientation according to the EXIF data.",
   "notes_by_num":{
-    "1":"Partial support in iOS refers to the browser using EXIF data by default, though it does not actually support the property."
+    "1":"Partial support in iOS refers to the browser using EXIF data by default, though it does not actually support the property.",
+    "2":"Chrome/Edge has [a bug](https://bugs.chromium.org/p/chromium/issues/detail?id=1082669) where the browser is not maintaining the image’s aspect ratio when `object-fit: cover` and `image-orientation: from-image` are used together."
   },
   "usage_perc_y":47.85,
   "usage_perc_a":15.05,


### PR DESCRIPTION
In Chrome and Edge, the image’s aspect ratio is not maintained when
`object-fit: cover` and `image-orientation: from-image` are used
together:

https://bugs.chromium.org/p/chromium/issues/detail?id=1082669