### PR TITLE
General updates to Media Source Extensions

### DIFF
--- a/features-json/mediasource.json
+++ b/features-json/mediasource.json
@@ -2,7 +2,7 @@
   "title":"Media Source Extensions",
   "description":"API allowing media data to be accessed from HTML `video` and `audio` elements.",
   "spec":"https://www.w3.org/TR/media-source/",
-  "status":"cr",
+  "status":"rec",
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/API/MediaSource#Browser_compatibility",
@@ -11,10 +11,6 @@
     {
       "url":"https://msdn.microsoft.com/en-us/library/dn594470%28v=vs.85%29.aspx",
       "title":"MSDN article"
-    },
-    {
-      "url":"http://html5-demos.appspot.com/static/media-source.html",
-      "title":"MediaSource demo"
     }
   ],
   "bugs":[
@@ -32,7 +28,7 @@
       "8":"n",
       "9":"n",
       "10":"n",
-      "11":"a #2"
+      "11":"a #1"
     },
     "edge":{
       "12":"y",
@@ -73,23 +69,23 @@
       "22":"n",
       "23":"n",
       "24":"n",
-      "25":"n d #1",
-      "26":"n d #1",
-      "27":"n d #1",
-      "28":"n d #1",
-      "29":"n d #1",
-      "30":"n d #1",
-      "31":"n d #1",
-      "32":"n d #1",
-      "33":"n d #1",
-      "34":"n d #1",
-      "35":"n d #1",
-      "36":"n d #1",
-      "37":"n d #1",
-      "38":"n d #1",
-      "39":"n d #1",
-      "40":"n d #1",
-      "41":"n d #1",
+      "25":"n d",
+      "26":"n d",
+      "27":"n d",
+      "28":"n d",
+      "29":"n d",
+      "30":"n d",
+      "31":"n d",
+      "32":"n d",
+      "33":"n d",
+      "34":"n d",
+      "35":"n d",
+      "36":"n d",
+      "37":"n d",
+      "38":"n d",
+      "39":"n d",
+      "40":"n d",
+      "41":"n d",
       "42":"y",
       "43":"y",
       "44":"y",
@@ -317,10 +313,10 @@
       "11.3-11.4":"n",
       "12.0-12.1":"n",
       "12.2-12.4":"n",
-      "13.0-13.1":"a #4",
-      "13.2":"a #4",
-      "13.3":"a #4",
-      "13.4-13.5":"a #4"
+      "13.0-13.1":"a #2",
+      "13.2":"a #2",
+      "13.3":"a #2",
+      "13.4-13.5":"a #2"
     },
     "op_mini":{
       "all":"n"
@@ -364,14 +360,14 @@
       "12.12":"y"
     },
     "samsung":{
-      "4":"n #3",
-      "5.0-5.4":"n #3",
-      "6.2-6.4":"n #3",
-      "7.2-7.4":"n #3",
-      "8.2":"n #3",
-      "9.2":"n #3",
-      "10.1":"n #3",
-      "11.1":"n #3"
+      "4":"n",
+      "5.0-5.4":"n",
+      "6.2-6.4":"n",
+      "7.2-7.4":"n",
+      "8.2":"n",
+      "9.2":"y",
+      "10.1":"y",
+      "11.1":"y"
     },
     "and_qq":{
       "10.4":"y"
@@ -385,10 +381,8 @@
   },
   "notes":"",
   "notes_by_num":{
-    "1":"Requires the `media.mediasource.enabled` flag to be enabled, support is limited to a whitelist including the YouTube, Netflix, and Dailymotion websites",
-    "2":"Partial support in IE11 refers to only working in Windows 8+",
-    "3":"Due to compatibility issues, MediaSource Extensions are currently disabled by default in Samsung Internet.",
-    "4":"Fully supported only in iPadOS 13 and later."
+    "1":"Partial support in IE11 refers to only working in Windows 8+",
+    "2":"Fully supported only in iPadOS 13 and later."
   },
   "usage_perc_y":79.08,
   "usage_perc_a":12.31,


### PR DESCRIPTION
Some general updates to MSE:
- Spec is now a W3C Recommendation
- Removed broken links
- Removed old notes on partial support
- Added support in Samsung Internet 9+

I was able to test and confirm support in Samsung Internet all the way back to v9 ([test 1](https://tests.caniuse.com/mediasource), [test 2](https://html5test.com)).
#4406 shows no support up until v7.2, which means only v8 might be wrong 🤷‍♀️