### PR TITLE
Remove references to 'whitelist'

### DIFF
--- a/features-json/contentsecuritypolicy.json
+++ b/features-json/contentsecuritypolicy.json
@@ -1,6 +1,6 @@
 {
   "title":"Content Security Policy 1.0",
-  "description":"Mitigate cross-site scripting attacks by whitelisting allowed sources of script, style, and other resources.",
+  "description":"Mitigate cross-site scripting attacks by only allowing certain sources of script, style, and other resources.",
   "spec":"https://www.w3.org/TR/2012/CR-CSP-20121115/",
   "status":"cr",
   "links":[

--- a/features-json/contentsecuritypolicy2.json
+++ b/features-json/contentsecuritypolicy2.json
@@ -1,6 +1,6 @@
 {
   "title":"Content Security Policy Level 2",
-  "description":"Mitigate cross-site scripting attacks by whitelisting allowed sources of script, style, and other resources. CSP 2 adds hash-source, nonce-source, and five new directives",
+  "description":"Mitigate cross-site scripting attacks by only allowing certain sources of script, style, and other resources. CSP 2 adds hash-source, nonce-source, and five new directives",
   "spec":"https://www.w3.org/TR/CSP2/",
   "status":"rec",
   "links":[


### PR DESCRIPTION
This is a suggestion to remove the two references to `whitelist` that are currently in the database.
`blacklist`, `master`, `slave` and other unfortunate terms are not present (other than in links, which will have to be fixed externally)

This topic has been discussed a lot lately. I see this as an opportunity to move to a language that is more easily understood and more inclusive. I also want it to be a display of sympathy for all blacks. These specific changes don't do much, but in the larger picture, they are a systemic move for the better.

A few related links:
[9to5google - Chrome team moving away from the terms blacklist/whitelist](https://9to5google.com/2020/06/07/google-chrome-blacklist-blocklist-more-inclusive/)
[Twitter - Sean Metcalf reminding people to move away from old tech language](https://twitter.com/PyroTek3/status/1267903268803543041)
[Twitter - Surma on Go's decision to move away from blacklist/whitelist](https://twitter.com/DasSurma/status/1270402593790005248)
[Twitter - PHP Unit will deprecate configuration options using blacklist/whitelist](https://twitter.com/s_bergmann/status/1269917026107248641)