### PR TITLE
Remove old note on Safari support for WebP

### DIFF
--- a/features-json/webp.json
+++ b/features-json/webp.json
@@ -411,7 +411,7 @@
       "2.5":"p"
     }
   },
-  "notes":"[Safari](https://www.cnet.com/news/apple-ios-macos-tests-googles-webp-graphics-to-speed-up-web) is experimenting with supporting WebP images.",
+  "notes":"",
   "notes_by_num":{
     "1":"Partial support refers to not supporting lossless, alpha and animated WebP images.",
     "2":"Partial support refers to not supporting animated WebP images."


### PR DESCRIPTION
Now that Safari is adding support (🥳), i don't see any reason to link to a four year old speculative article.