### PR TITLE
Safari does not support A2HS in WebViews

### DIFF
--- a/features-json/web-app-manifest.json
+++ b/features-json/web-app-manifest.json
@@ -399,7 +399,7 @@
     "1":"The installation events, `appinstalled` and `beforeinstallprompt`, are not supported.",
     "2":"The installation events, `appinstalled` and `beforeinstallprompt`, are not supported on all platforms.",
     "3":"A manifest could be used to list apps in the Microsoft Store, which would use Edge as a back-end.",
-    "4":"Safari on IOS does not support A2HS in WebViews like Chrome and Firefox"
+    "4":"Safari on iOS does not support A2HS in WebViews like Chrome and Firefox"
   },
   "usage_perc_y":83,
   "usage_perc_a":0,

--- a/features-json/web-app-manifest.json
+++ b/features-json/web-app-manifest.json
@@ -324,14 +324,14 @@
       "10.0-10.2":"n",
       "10.3":"n",
       "11.0-11.2":"n",
-      "11.3-11.4":"y #1",
-      "12.0-12.1":"y #1",
-      "12.2-12.4":"y #1",
-      "13.0-13.1":"y #1",
-      "13.2":"y #1",
-      "13.3":"y #1",
-      "13.4-13.5":"y #1",
-      "14.0":"y #1"
+      "11.3-11.4":"a #1 #4",
+      "12.0-12.1":"a #1 #4",
+      "12.2-12.4":"a #1 #4",
+      "13.0-13.1":"a #1 #4",
+      "13.2":"a #1 #4",
+      "13.3":"a #1 #4",
+      "13.4-13.5":"a #1 #4",
+      "14.0":"a #1 #4"
     },
     "op_mini":{
       "all":"n"
@@ -398,7 +398,8 @@
   "notes_by_num":{
     "1":"The installation events, `appinstalled` and `beforeinstallprompt`, are not supported.",
     "2":"The installation events, `appinstalled` and `beforeinstallprompt`, are not supported on all platforms.",
-    "3":"A manifest could be used to list apps in the Microsoft Store, which would use Edge as a back-end."
+    "3":"A manifest could be used to list apps in the Microsoft Store, which would use Edge as a back-end.",
+    "4":"Safari on IOS does not support A2HS in WebViews like Chrome and Firefox"
   },
   "usage_perc_y":83,
   "usage_perc_a":0,


### PR DESCRIPTION
It just occured to me that Safari on iOS doesn't support A2HS in WebViews. In most browsers, that's not a big deal, but in Safari it means no third party browser can support the feature, leaving a large chunk of `saf_ios` traffic without support. I think it should be marked `Partial support` because of this.