### PR TITLE
Firefox Android & Samsung Browser supports prefers-reduced-motion media query

### DIFF
--- a/features-json/prefers-reduced-motion.json
+++ b/features-json/prefers-reduced-motion.json
@@ -352,7 +352,7 @@
       "81":"y"
     },
     "and_ff":{
-      "68":"n"
+      "68":"y"
     },
     "ie_mob":{
       "10":"n",
@@ -369,7 +369,7 @@
       "8.2":"n",
       "9.2":"n",
       "10.1":"n",
-      "11.1-11.2":"n"
+      "11.1-11.2":"y"
     },
     "and_qq":{
       "10.4":"n"
@@ -383,7 +383,6 @@
   },
   "notes":"",
   "notes_by_num":{
-    "1":"Currently expected to land in Firefox for Windows and Linux in Firefox 63, for MacOS it might be delayed to Firefox 64."
   },
   "usage_perc_y":84.35,
   "usage_perc_a":0,
@@ -391,7 +390,7 @@
   "parent":"",
   "keywords":"no-preference",
   "ie_id":"",
-  "chrome_id":"",
+  "chrome_id":"5597964353404928",
   "firefox_id":"",
   "webkit_id":"",
   "shown":true


### PR DESCRIPTION
The newest versions of Firefox for Android and Samsung Browser supports the `prefers-reduced-motion` media query.

This is tested manually with the [caniuse test](https://tests.caniuse.com/prefers-reduced-motion), and it makes sense when you look at what engine version they're based on.

Also just removed a comment that isn't used and added the Chrome ID.