### PR TITLE
Updates to WebXR

### DIFF
--- a/features-json/webxr.json
+++ b/features-json/webxr.json
@@ -124,9 +124,9 @@
       "74":"n",
       "75":"n",
       "76":"n",
-      "77":"n",
-      "78":"n",
-      "79":"n"
+      "77":"n d #2",
+      "78":"n d #2",
+      "79":"n d #2"
     },
     "chrome":{
       "4":"n",
@@ -387,7 +387,8 @@
   },
   "notes":"",
   "notes_by_num":{
-    "1":"This API is very extensive. Many of its features are still in development and/or don't have finalised specs yet."
+    "1":"This API is very extensive. Many of its features are still in development and/or don't have finalised specs yet.",
+    "2":"Can be enabled in Firefox behind the `dom.vr.webxr.enabled`flag."
   },
   "usage_perc_y":0,
   "usage_perc_a":63.02,

--- a/features-json/webxr.json
+++ b/features-json/webxr.json
@@ -11,6 +11,10 @@
     {
       "url":"https://immersive-web.github.io/webxr-samples/",
       "title":"Immersive Web - WebXR Samples"
+    },
+    {
+      "url":"https://bugs.webkit.org/show_bug.cgi?id=208988",
+      "title":"Safari implementation bug"
     }
   ],
   "bugs":[

--- a/features-json/webxr.json
+++ b/features-json/webxr.json
@@ -7,6 +7,10 @@
     {
       "url":"https://developer.mozilla.org/docs/Web/API/WebXR_Device_API",
       "title":"MDN Web Docs - WebXR Device API"
+    },
+    {
+      "url":"https://immersive-web.github.io/webxr-samples/",
+      "title":"Immersive Web - WebXR Samples"
     }
   ],
   "bugs":[

--- a/features-json/webxr.json
+++ b/features-json/webxr.json
@@ -10,7 +10,7 @@
     },
     {
       "url":"https://immersive-web.github.io/webxr-samples/",
-      "title":"Immersive Web - WebXR Samples"
+      "title":"Immersive Web - WebXR samples"
     },
     {
       "url":"https://bugs.webkit.org/show_bug.cgi?id=208988",
@@ -388,7 +388,7 @@
   "notes":"",
   "notes_by_num":{
     "1":"This API is very extensive. Many of its features are still in development and/or don't have finalised specs yet.",
-    "2":"Can be enabled in Firefox behind the `dom.vr.webxr.enabled`flag."
+    "2":"Can be enabled in Firefox behind the `dom.vr.webxr.enabled` flag."
   },
   "usage_perc_y":0,
   "usage_perc_a":63.02,


### PR DESCRIPTION
A few additions to the WebXR table:

The Immersive Web sample pages are great for developers getting into WebXR.

Apple has opened a support bug for WebXR.

Enabling `dom.vr.webxr.enabled` in Firefox 77+ will now expose a fully functional WebXR API on all platforms (manually tested).
The flag has been here for a while, but hasn't done anything until now.
Firefox plans to add more functionality before enabling the feature by default.