### PR TITLE
Major update to CSS :matches() -> :is()

### DIFF
--- a/features-json/css-matches-pseudo.json
+++ b/features-json/css-matches-pseudo.json
@@ -1,32 +1,28 @@
 {
-  "title":":matches() CSS pseudo-class",
-  "description":"The `:matches()` (formerly `:any()`) pseudo-class checks whether the element at its position in the outer selector matches any of the selectors in its selector list. It's useful syntactic sugar that allows you to avoid writing out all the combinations manually as separate selectors. The effect is similar to nesting in Sass and most other CSS preprocessors.",
+  "title":":is() CSS pseudo-class",
+  "description":"The `:is()` (formerly `:matches()`, formerly `:any()`) pseudo-class checks whether the element at its position in the outer selector matches any of the selectors in its selector list. It's useful syntactic sugar that allows you to avoid writing out all the combinations manually as separate selectors. The effect is similar to nesting in Sass and most other CSS preprocessors.",
   "spec":"https://www.w3.org/TR/selectors4/#matches",
   "status":"wd",
   "links":[
     {
-      "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/:any",
-      "title":"MDN Web Docs - CSS :any"
+      "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/:is",
+      "title":"MDN Web Docs - CSS :is()"
     },
     {
       "url":"https://webkit.org/blog/3615/css-selectors-inside-selectors-discover-matches-not-and-nth-child/",
       "title":"WebKit blog post about adding `:matches()` and other Selectors Level 4 features"
     },
     {
-      "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=906353",
-      "title":"Mozilla Bug 906353 - Add support for css4 selector :matches(), the standard of :-moz-any()"
-    },
-    {
-      "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/9361350--matches",
-      "title":"Microsoft Edge UserVoice feature request for :matches()"
+      "url":"https://codepen.io/atjn/full/MWKErBe",
+      "title":"Codepen - Modern tests"
     },
     {
       "url":"http://output.jsbin.com/lehina",
-      "title":"JS Bin testcase"
+      "title":"JS Bin - Legacy tests"
     },
     {
       "url":"https://bugs.chromium.org/p/chromium/issues/detail?id=568705",
-      "title":"Issue 568705: Chrome does not support :matches() selector"
+      "title":"Chrome support bug for :is()"
     }
   ],
   "bugs":[
@@ -53,10 +49,10 @@
       "16":"n",
       "17":"n",
       "18":"n",
-      "79":"a d #2 #4",
-      "80":"a d #2 #4",
-      "81":"a d #2 #4",
-      "83":"a d #2 #4"
+      "79":"a d #1 #7",
+      "80":"a d #1 #7",
+      "81":"a d #1 #7",
+      "83":"a d #1 #7"
     },
     "firefox":{
       "2":"u",
@@ -137,8 +133,8 @@
       "75":"a x #3",
       "76":"a x #3",
       "77":"a x #3",
-      "78":"a x #3",
-      "79":"a x #3"
+      "78":"y #6",
+      "79":"y #6"
     },
     "chrome":{
       "4":"u",
@@ -202,27 +198,27 @@
       "62":"a x #1",
       "63":"a x #1",
       "64":"a x #1",
-      "65":"a d #2 #4",
-      "66":"a d #2 #4",
-      "67":"a d #2 #4",
-      "68":"a d #2 #4",
-      "69":"a d #2 #4",
-      "70":"a d #2 #4",
-      "71":"a d #2 #4",
-      "72":"a d #2 #4",
-      "73":"a d #2 #4",
-      "74":"a d #2 #4",
-      "75":"a d #2 #4",
-      "76":"a d #2 #4",
-      "77":"a d #2 #4",
-      "78":"a d #2 #4",
-      "79":"a d #2 #4",
-      "80":"a d #2 #4",
-      "81":"a d #2 #4",
-      "83":"a d #2 #4",
-      "84":"a d #2 #4",
-      "85":"a d #2 #4",
-      "86":"a d #2 #4"
+      "65":"a d #1",
+      "66":"a d #1",
+      "67":"a d #1",
+      "68":"a d #1 #7",
+      "69":"a d #1 #7",
+      "70":"a d #1 #7",
+      "71":"a d #1 #7",
+      "72":"a d #1 #7",
+      "73":"a d #1 #7",
+      "74":"a d #1 #7",
+      "75":"a d #1 #7",
+      "76":"a d #1 #7",
+      "77":"a d #1 #7",
+      "78":"a d #1 #7",
+      "79":"a d #1 #7",
+      "80":"a d #1 #7",
+      "81":"a d #1 #7",
+      "83":"a d #1 #7",
+      "84":"a d #1 #7",
+      "85":"a d #1 #7",
+      "86":"a d #1 #7"
     },
     "safari":{
       "3.1":"n",
@@ -235,18 +231,18 @@
       "7":"a x #1",
       "7.1":"a x #1",
       "8":"a x #1",
-      "9":"y #2",
-      "9.1":"y #2",
-      "10":"y #2",
-      "10.1":"y #2",
-      "11":"y #2",
-      "11.1":"y #2",
-      "12":"y #2",
-      "12.1":"y #2",
-      "13":"y #2",
-      "13.1":"y #2",
-      "14":"y #2",
-      "TP":"y #2"
+      "9":"a #2",
+      "9.1":"a #2",
+      "10":"a #2",
+      "10.1":"a #2",
+      "11":"a #2",
+      "11.1":"a #2",
+      "12":"a #2",
+      "12.1":"a #2",
+      "13":"a #2",
+      "13.1":"a #2",
+      "14":"y #4 #5",
+      "TP":"y #4 #5"
     },
     "opera":{
       "9":"n",
@@ -297,21 +293,21 @@
       "49":"a x #1",
       "50":"a x #1",
       "51":"a x #1",
-      "52":"a d #1 #4",
-      "53":"a d #1 #4",
-      "54":"a d #1 #4",
-      "55":"a d #1 #4",
-      "56":"a d #1 #4",
-      "57":"a d #1 #4",
-      "58":"a d #1 #4",
-      "60":"a d #1 #4",
-      "62":"a d #1 #4",
-      "63":"a d #1 #4",
-      "64":"a d #1 #4",
-      "65":"a d #1 #4",
-      "66":"a d #2 #4",
-      "67":"a d #2 #4",
-      "68":"a d #2 #4"
+      "52":"a d #1",
+      "53":"a d #1",
+      "54":"a d #1",
+      "55":"a d #1 #7",
+      "56":"a d #1 #7",
+      "57":"a d #1 #7",
+      "58":"a d #1 #7",
+      "60":"a d #1 #7",
+      "62":"a d #1 #7",
+      "63":"a d #1 #7",
+      "64":"a d #1 #7",
+      "65":"a d #1 #7",
+      "66":"a d #1 #7",
+      "67":"a d #1 #7",
+      "68":"a d #1 #7"
     },
     "ios_saf":{
       "3.2":"u",
@@ -322,19 +318,19 @@
       "7.0-7.1":"a x #1",
       "8":"a x #1",
       "8.1-8.4":"a x #1",
-      "9.0-9.2":"y #2",
-      "9.3":"y #2",
-      "10.0-10.2":"y #2",
-      "10.3":"y #2",
-      "11.0-11.2":"y #2",
-      "11.3-11.4":"y #2",
-      "12.0-12.1":"y #2",
-      "12.2-12.4":"y #2",
-      "13.0-13.1":"y #2",
-      "13.2":"y #2",
-      "13.3":"y #2",
-      "13.4-13.5":"y #2",
-      "14.0":"y #2"
+      "9.0-9.2":"a #2",
+      "9.3":"a #2",
+      "10.0-10.2":"a #2",
+      "10.3":"a #2",
+      "11.0-11.2":"a #2",
+      "11.3-11.4":"a #2",
+      "12.0-12.1":"a #2",
+      "12.2-12.4":"a #2",
+      "13.0-13.1":"a #2",
+      "13.2":"a #2",
+      "13.3":"a #2",
+      "13.4-13.5":"a #2",
+      "14.0":"y #4 #5"
     },
     "op_mini":{
       "all":"n"
@@ -365,7 +361,7 @@
       "46":"a x #1"
     },
     "and_chr":{
-      "81":"a d #1 #4"
+      "81":"a d #1 #7"
     },
     "and_ff":{
       "68":"a x #3"
@@ -388,7 +384,7 @@
       "11.1-11.2":"a x #1"
     },
     "and_qq":{
-      "10.4":"a d #2 #4"
+      "10.4":"a d #1 #7"
     },
     "baidu":{
       "7.12":"a x #1"
@@ -397,21 +393,24 @@
       "2.5":"a x #3"
     }
   },
-  "notes":"Most browsers support this spelled as a prefixed `:-vendor-any()` pseudo-class.",
+  "notes":"",
   "notes_by_num":{
-    "1":"Only supports the `:-webkit-any()` pseudo-class, which is deprecated due to handling specificity incorrectly.",
-    "2":"Also supports the `:-webkit-any()` pseudo-class, which is deprecated due to handling specificity incorrectly.",
-    "3":"Only supports the `:-moz-any()` pseudo-class.",
-    "4":"Support for ':matches()' is available behind the \"Experimental Web Platform features\" flag"
+    "1":"Only supports the deprecated `:-webkit-any()` pseudo-class",
+    "2":"Only supports the deprecated `:-webkit-any()` and `:-matches()` pseudo-classes",
+    "3":"Only supports the deprecated `:-moz-any()` pseudo-class.",
+    "4":"Also supports the deprecated `:-webkit-any()` pseudo-class",
+    "5":"Also supports the deprecated `:-matches()` pseudo-class",
+    "6":"Also supports the deprecated `:-moz-any()` pseudo-class.",
+    "7":"Support for `:is()` can be enabled with the `Experimental Web Platform features` flag"
   },
   "usage_perc_y":17.17,
   "usage_perc_a":76.89,
   "ucprefix":false,
   "parent":"",
-  "keywords":":matches,matches,:any,any",
+  "keywords":":is,is,:matches,matches,:any,any,:-moz-any,-moz-any,:-webkit-any,-webkit-any",
   "ie_id":"",
   "chrome_id":"5445716612743168",
   "firefox_id":"",
-  "webkit_id":"feature-css-selector-:matches()",
+  "webkit_id":"feature-css-selector-:is()",
   "shown":true
 }


### PR DESCRIPTION
The css `:maches()` spec has been renamed to `:is()`, and `:maches()` has become a deprecated alias.

[Firefox 78](https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/78#CSS) and [Safari 14](https://developer.apple.com/documentation/safari-release-notes/safari-14-beta-release-notes#CSS) are enabling `:is()` by default, and Chromium will probably follow suit in ~v87.

I have manually verified it all with [this quick test suite](https://codepen.io/atjn/full/MWKErBe).

I have made a million small tweaks - let me know if there are any specific changes you would like a comment on :)