### PR TITLE
Bulk update links to HTTPS

### DIFF
--- a/features-json/ac3-ec3.json
+++ b/features-json/ac3-ec3.json
@@ -1,7 +1,7 @@
 {
   "title":"AC-3 (Dolby Digital) and EC-3 (Dolby Digital Plus) codecs",
   "description":"AC-3 and EC-3 are multi-channel lossy audio codecs, commonly used in movies. AC-3 supports 5.1 channels. Its successor EC-3 (or E-AC-3) supports 15.1 channels and bit rates up to 6144kbit/s. They're standardized as A/52:2012.",
-  "spec":"http://atsc.org/standard/a522012-digital-audio-compression-ac-3-e-ac-3-standard-12172012/",
+  "spec":"https://atsc.org/standard/a522012-digital-audio-compression-ac-3-e-ac-3-standard-12172012/",
   "status":"other",
   "links":[
     {

--- a/features-json/audio-api.json
+++ b/features-json/audio-api.json
@@ -396,7 +396,7 @@
       "2.5":"y"
     }
   },
-  "notes":"Not all browsers with support for the Audio API also support media streams (e.g. microphone input). See the [getUserMedia/Streams API](/#feat=stream) data for support for that feature.\r\n\r\nFirefox versions < 25 support an alternative, deprecated audio API.\r\n\r\nChrome support [went through some changes](http://updates.html5rocks.com/2014/07/Web-Audio-Changes-in-m36) as of version 36.",
+  "notes":"Not all browsers with support for the Audio API also support media streams (e.g. microphone input). See the [getUserMedia/Streams API](/#feat=stream) data for support for that feature.\r\n\r\nFirefox versions < 25 support an alternative, deprecated audio API.\r\n\r\nChrome support [went through some changes](https://developers.google.com/web/updates/2014/07/Web-Audio-Changes-in-m36) as of version 36.",
   "notes_by_num":{
     
   },

--- a/features-json/audio.json
+++ b/features-json/audio.json
@@ -5,7 +5,7 @@
   "status":"ls",
   "links":[
     {
-      "url":"http://html5doctor.com/native-audio-in-the-browser/",
+      "url":"https://html5doctor.com/native-audio-in-the-browser/",
       "title":"HTML5 Doctor article"
     },
     {
@@ -13,11 +13,11 @@
       "title":"Detailed article on video/audio elements"
     },
     {
-      "url":"http://www.jplayer.org/latest/demos/",
+      "url":"https://www.jplayer.org/latest/demos/",
       "title":"Demos of audio player that uses the audio element"
     },
     {
-      "url":"http://24ways.org/2010/the-state-of-html5-audio",
+      "url":"https://24ways.org/2010/the-state-of-html5-audio",
       "title":"Detailed article on support"
     },
     {
@@ -25,7 +25,7 @@
       "title":"File format test page"
     },
     {
-      "url":"http://www.phoboslab.org/log/2011/03/the-state-of-html5-audio",
+      "url":"https://www.phoboslab.org/log/2011/03/the-state-of-html5-audio",
       "title":"The State of HTML5 Audio"
     },
     {

--- a/features-json/audio.json
+++ b/features-json/audio.json
@@ -21,10 +21,6 @@
       "title":"Detailed article on support"
     },
     {
-      "url":"http://textopia.org/androidsoundformats.html",
-      "title":"File format test page"
-    },
-    {
       "url":"https://www.phoboslab.org/log/2011/03/the-state-of-html5-audio",
       "title":"The State of HTML5 Audio"
     },

--- a/features-json/background-position-x-y.json
+++ b/features-json/background-position-x-y.json
@@ -9,7 +9,7 @@
       "title":"Firefox implementation bug"
     },
     {
-      "url":"http://snook.ca/archives/html_and_css/background-position-x-y",
+      "url":"https://snook.ca/archives/html_and_css/background-position-x-y",
       "title":"Blog post on background-position-x & y properties"
     },
     {

--- a/features-json/battery-status.json
+++ b/features-json/battery-status.json
@@ -9,7 +9,7 @@
       "title":"MDN Web Docs - battery status"
     },
     {
-      "url":"http://pazguille.github.io/demo-battery-api/",
+      "url":"https://pazguille.github.io/demo-battery-api/",
       "title":"Simple demo"
     }
   ],

--- a/features-json/bigint.json
+++ b/features-json/bigint.json
@@ -13,7 +13,7 @@
       "title":"Blog article from Google Developer"
     },
     {
-      "url":"http://2ality.com/2017/03/es-integer.html",
+      "url":"https://2ality.com/2017/03/es-integer.html",
       "title":"Blog article from Dr. Axel Rauschmayer"
     },
     {

--- a/features-json/border-radius.json
+++ b/features-json/border-radius.json
@@ -5,11 +5,11 @@
   "status":"cr",
   "links":[
     {
-      "url":"http://border-radius.com",
+      "url":"https://border-radius.com",
       "title":"Border-radius CSS Generator"
     },
     {
-      "url":"http://muddledramblings.com/table-of-css3-border-radius-compliance",
+      "url":"https://muddledramblings.com/table-of-css3-border-radius-compliance",
       "title":"Detailed compliance table"
     },
     {

--- a/features-json/brotli.json
+++ b/features-json/brotli.json
@@ -5,7 +5,7 @@
   "status":"other",
   "links":[
     {
-      "url":"http://google-opensource.blogspot.com/2015/09/introducing-brotli-new-compression.html",
+      "url":"https://opensource.googleblog.com/2015/09/introducing-brotli-new-compression.html",
       "title":"Introducing Brotli"
     },
     {

--- a/features-json/calc.json
+++ b/features-json/calc.json
@@ -426,7 +426,7 @@
       "2.5":"y"
     }
   },
-  "notes":"Support can be somewhat emulated in older versions of IE using the non-standard `expression()` syntax.\r\n\r\nDue to the way browsers handle [sub-pixel rounding](http://ejohn.org/blog/sub-pixel-problems-in-css/) differently, layouts using `calc()` expressions may have unexpected results.",
+  "notes":"Support can be somewhat emulated in older versions of IE using the non-standard `expression()` syntax.\r\n\r\nDue to the way browsers handle [sub-pixel rounding](https://johnresig.com/blog/sub-pixel-problems-in-css/) differently, layouts using `calc()` expressions may have unexpected results.",
   "notes_by_num":{
     "1":"Partial support in Android Browser 4.4 refers to the browser lacking the ability to multiply and divide values.",
     "2":"Partial support in IE9 refers to the browser crashing when used as a `background-position` value.",

--- a/features-json/canvas-blending.json
+++ b/features-json/canvas-blending.json
@@ -5,7 +5,7 @@
   "status":"cr",
   "links":[
     {
-      "url":"http://blogs.adobe.com/webplatform/2013/01/28/blending-features-in-canvas/",
+      "url":"https://blogs.adobe.com/webplatform/2013/01/28/blending-features-in-canvas/",
       "title":"Blog post"
     }
   ],

--- a/features-json/canvas-text.json
+++ b/features-json/canvas-text.json
@@ -9,7 +9,7 @@
       "title":"Examples by Mozilla"
     },
     {
-      "url":"http://code.google.com/p/canvas-text/",
+      "url":"https://code.google.com/archive/p/canvas-text/",
       "title":"Support library"
     },
     {

--- a/features-json/canvas.json
+++ b/features-json/canvas.json
@@ -13,7 +13,7 @@
       "title":"Animation kit"
     },
     {
-      "url":"http://diveintohtml5.info/canvas.html",
+      "url":"https://diveintohtml5.info/canvas.html",
       "title":"Another tutorial"
     },
     {

--- a/features-json/classlist.json
+++ b/features-json/classlist.json
@@ -21,7 +21,7 @@
       "title":"SitePoint article"
     },
     {
-      "url":"http://aurelio.audero.it/demo/classlist-api-demo.html",
+      "url":"https://www.audero.it/demo/classlist-api-demo.html",
       "title":"Demo using classList"
     },
     {

--- a/features-json/clipboard.json
+++ b/features-json/clipboard.json
@@ -388,7 +388,7 @@
   },
   "notes":"Internet Explorer will display a security prompt for access to the OS clipboard.\r\n\r\nChrome 42+, Opera 29+ and Firefox 41+ support clipboard reading/writing only when part of a user action (click, keydown, etc).\r\n\r\nFirefox 40- users [can enable support](https://developer.mozilla.org/en-US/docs/Midas/Security_preferences) with a security preference setting.",
   "notes_by_num":{
-    "1":"Only supports `Text` and `URL` data types and uses [a non-standard method](http://msdn.microsoft.com/en-us/library/ie/ms535220%28v=vs.85%29.aspx) of interacting with the clipboard.",
+    "1":"Only supports `Text` and `URL` data types and uses [a non-standard method](https://msdn.microsoft.com/en-us/library/ie/ms535220%28v=vs.85%29.aspx) of interacting with the clipboard.",
     "2":"Only fires `copy` event on a valid selection and only `cut` and `paste` in focused editable fields.",
     "3":"Only supports OS clipboard reading/writing via shortcut keys, not through `document.execCommand()`.",
     "4":"Only supports `paste` event (on focused editable field).",

--- a/features-json/console-basic.json
+++ b/features-json/console-basic.json
@@ -393,7 +393,7 @@
     "1":"Only supports console functions when developer tools are open, otherwise the `console` object is undefined and any calls will throw errors.",
     "2":"Allows `console` functions to be used without throwing errors, but does not appear to output the data anywhere.",
     "3":"Log output on iOS 6+ Safari can only be seen by connecting to a Mac and using the [Safari debugger](https://developer.apple.com/safari/tools/).",
-    "4":"Log output on older Android browsers can be retrieved via Android's `logcat` command or using Chrome Developer Tools in Android 4.4+/Chrome for Android [see details](http://developer.android.com/guide/webapps/debugging.html)",
+    "4":"Log output on older Android browsers can be retrieved via Android's `logcat` command or using Chrome Developer Tools in Android 4.4+/Chrome for Android [see details](https://developer.android.com/guide/webapps/debugging.html)",
     "5":"Log output on Firefox for Android can be [accessed using WebIDE](https://developer.mozilla.org/en-US/docs/Tools/Remote_Debugging/Debugging_Firefox_for_Android_with_WebIDE)",
     "6":"See [this article](https://dev.opera.com/articles/opera-mini-and-javascript/) for details on how to see console logging in Opera Mini"
   },

--- a/features-json/const.json
+++ b/features-json/const.json
@@ -5,7 +5,7 @@
   "status":"other",
   "links":[
     {
-      "url":"http://generatedcontent.org/post/54444832868/variables-and-constants-in-es6",
+      "url":"https://generatedcontent.org/post/54444832868/variables-and-constants-in-es6",
       "title":"Variables and Constants in ES6"
     },
     {

--- a/features-json/contenteditable.json
+++ b/features-json/contenteditable.json
@@ -5,10 +5,6 @@
   "status":"ls",
   "links":[
     {
-      "url":"http://html5demos.com/contenteditable",
-      "title":"Demo page"
-    },
-    {
       "url":"https://blog.whatwg.org/the-road-to-html-5-contenteditable",
       "title":"WHATWG blog post"
     },

--- a/features-json/contentsecuritypolicy.json
+++ b/features-json/contentsecuritypolicy.json
@@ -9,7 +9,7 @@
       "title":"HTML5Rocks article"
     },
     {
-      "url":"http://content-security-policy.com/",
+      "url":"https://content-security-policy.com/",
       "title":"CSP Examples & Quick Reference"
     },
     {

--- a/features-json/cors.json
+++ b/features-json/cors.json
@@ -9,7 +9,7 @@
       "title":"Mozilla Hacks blog post"
     },
     {
-      "url":"http://msdn.microsoft.com/en-us/library/cc288060(VS.85).aspx",
+      "url":"https://msdn.microsoft.com/en-us/library/cc288060(VS.85).aspx",
       "title":"Alternative implementation by IE8"
     },
     {
@@ -27,10 +27,10 @@
   ],
   "bugs":[
     {
-      "description":"IE10+ does not send cookies when withCredential=true ([IE Bug #759587](https://connect.microsoft.com/IE/feedback/details/759587/ie10-doesnt-support-cookies-on-cross-origin-xmlhttprequest-withcredentials-true)). A workaround is [to use a P3P policy](http://www.techrepublic.com/blog/software-engineer/craft-a-p3p-policy-to-make-ie-behave/)"
+      "description":"IE10+ does not send cookies when withCredential=true ([IE Bug #759587](https://connect.microsoft.com/IE/feedback/details/759587/ie10-doesnt-support-cookies-on-cross-origin-xmlhttprequest-withcredentials-true)). A workaround is [to use a P3P policy](https://www.techrepublic.com/blog/software-engineer/craft-a-p3p-policy-to-make-ie-behave/)"
     },
     {
-      "description":"IE10+ does not make a CORS request if port is the only difference ([IE Bug #781303](http://connect.microsoft.com/IE/feedback/details/781303))"
+      "description":"IE10+ does not make a CORS request if port is the only difference ([IE Bug #781303](https://connect.microsoft.com/IE/feedback/details/781303))"
     },
     {
       "description":"Android and some old versions of WebKit (that may be found in various webview implementations) do not support Access-Control-Expose-Headers: https://code.google.com/p/android/issues/detail?id=56726"
@@ -411,7 +411,7 @@
   "notes":"",
   "notes_by_num":{
     "1":"Does not support CORS for images in `<canvas>`",
-    "2":"Supported somewhat in IE8 and IE9 using the XDomainRequest object (but has [limitations](http://blogs.msdn.com/b/ieinternals/archive/2010/05/13/xdomainrequest-restrictions-limitations-and-workarounds.aspx))",
+    "2":"Supported somewhat in IE8 and IE9 using the XDomainRequest object (but has [limitations](https://blogs.msdn.com/b/ieinternals/archive/2010/05/13/xdomainrequest-restrictions-limitations-and-workarounds.aspx))",
     "3":"Does not support CORS for `<video>` in `<canvas>`: https://bugs.webkit.org/show_bug.cgi?id=135379",
     "4":"Does not support CORS for resources which redirect: https://bugzilla.mozilla.org/show_bug.cgi?id=1346749"
   },

--- a/features-json/cryptography.json
+++ b/features-json/cryptography.json
@@ -9,11 +9,11 @@
       "title":"The History and Status of Web Crypto API"
     },
     {
-      "url":"http://research.microsoft.com/en-us/projects/msrjscrypto/",
+      "url":"https://github.com/microsoft/MSR-JavaScript-Crypto",
       "title":"Microsoft Research JavaScript Cryptography Library"
     },
     {
-      "url":"http://bitwiseshiftleft.github.io/sjcl/",
+      "url":"https://bitwiseshiftleft.github.io/sjcl/",
       "title":"Cross-browser cryptography library"
     },
     {

--- a/features-json/css-all.json
+++ b/features-json/css-all.json
@@ -9,7 +9,7 @@
       "title":"MDN Web Docs - CSS all"
     },
     {
-      "url":"http://mcc.id.au/blog/2013/10/all-unset",
+      "url":"https://mcc.id.au/blog/2013/10/all-unset",
       "title":"Resetting styles using `all: unset`"
     },
     {

--- a/features-json/css-canvas.json
+++ b/features-json/css-canvas.json
@@ -1,11 +1,11 @@
 {
   "title":"CSS Canvas Drawings",
   "description":"Method of using HTML5 Canvas as a background image. Not currently part of any specification.",
-  "spec":"http://webkit.org/blog/176/css-canvas-drawing/",
+  "spec":"https://webkit.org/blog/176/css-canvas-drawing/",
   "status":"unoff",
   "links":[
     {
-      "url":"http://webkit.org/blog/176/css-canvas-drawing/",
+      "url":"https://webkit.org/blog/176/css-canvas-drawing/",
       "title":"WebKit blog post"
     }
   ],

--- a/features-json/css-featurequeries.json
+++ b/features-json/css-featurequeries.json
@@ -9,11 +9,11 @@
       "title":"MDN Web Docs - CSS @supports"
     },
     {
-      "url":"http://mcc.id.au/blog/2012/08/supports",
+      "url":"https://mcc.id.au/blog/2012/08/supports",
       "title":"@supports in Firefox"
     },
     {
-      "url":"http://dabblet.com/gist/3895764",
+      "url":"https://dabblet.com/gist/3895764",
       "title":"Test case"
     },
     {

--- a/features-json/css-sticky.json
+++ b/features-json/css-sticky.json
@@ -5,7 +5,7 @@
   "status":"wd",
   "links":[
     {
-      "url":"http://updates.html5rocks.com/2012/08/Stick-your-landings-position-sticky-lands-in-WebKit",
+      "url":"https://developers.google.com/web/updates/2012/08/Stick-your-landings-position-sticky-lands-in-WebKit",
       "title":"HTML5Rocks"
     },
     {
@@ -25,7 +25,7 @@
       "title":"Another polyfill"
     },
     {
-      "url":"http://gedd.ski/post/position-sticky/",
+      "url":"https://mastery.games/post/position-sticky/",
       "title":"geddski article: Examples and Gotchas"
     }
   ],

--- a/features-json/es5.json
+++ b/features-json/es5.json
@@ -5,11 +5,11 @@
   "status":"other",
   "links":[
     {
-      "url":"http://kangax.github.io/compat-table/es5/",
+      "url":"https://kangax.github.io/compat-table/es5/",
       "title":"Detailed compatibility tables & tests"
     },
     {
-      "url":"http://ejohn.org/blog/ecmascript-5-objects-and-properties/",
+      "url":"https://johnresig.com/blog/ecmascript-5-objects-and-properties/",
       "title":"Overview of objects & properties"
     },
     {

--- a/features-json/es6.json
+++ b/features-json/es6.json
@@ -9,7 +9,7 @@
       "title":"ES6 New features: overview and comparisons"
     },
     {
-      "url":"http://exploringjs.com/es6/",
+      "url":"https://exploringjs.com/es6/",
       "title":"Exploring ES6 (book)"
     },
     {

--- a/features-json/flexbox.json
+++ b/features-json/flexbox.json
@@ -5,11 +5,11 @@
   "status":"cr",
   "links":[
     {
-      "url":"http://bennettfeely.com/flexplorer/",
+      "url":"https://bennettfeely.com/flexplorer/",
       "title":"Flexbox CSS generator"
     },
     {
-      "url":"http://www.adobe.com/devnet/html5/articles/working-with-flexbox-the-new-spec.html",
+      "url":"https://www.adobe.com/devnet/html5/articles/working-with-flexbox-the-new-spec.html",
       "title":"Article on using the latest spec"
     },
     {
@@ -17,7 +17,7 @@
       "title":"Tutorial on cross-browser support"
     },
     {
-      "url":"http://philipwalton.github.io/solved-by-flexbox/",
+      "url":"https://philipwalton.github.io/solved-by-flexbox/",
       "title":"Examples on how to solve common layout problems with flexbox"
     },
     {
@@ -25,7 +25,7 @@
       "title":"A Complete Guide to Flexbox"
     },
     {
-      "url":"http://the-echoplex.net/flexyboxes/",
+      "url":"https://the-echoplex.net/flexyboxes/",
       "title":"Flexbox playground and code generator"
     },
     {
@@ -41,7 +41,7 @@
       "title":"Ecligrid - Mobile first flexbox grid system"
     },
     {
-      "url":"http://gedd.ski/post/the-difference-between-width-and-flex-basis/",
+      "url":"https://mastery.games/post/the-difference-between-width-and-flex-basis/",
       "title":"The Difference Between Width and Flex-Basis"
     }
   ],

--- a/features-json/font-feature.json
+++ b/features-json/font-feature.json
@@ -1,7 +1,7 @@
 {
   "title":"CSS font-feature-settings",
   "description":"Method of applying advanced typographic and language-specific font features to supported OpenType fonts.",
-  "spec":"http://w3.org/TR/css3-fonts/#font-rend-props",
+  "spec":"https://w3.org/TR/css3-fonts/#font-rend-props",
   "status":"cr",
   "links":[
     {

--- a/features-json/heif.json
+++ b/features-json/heif.json
@@ -1,7 +1,7 @@
 {
   "title":"HEIF/ISO Base Media File Format",
   "description":"HEIF (High Efficiency Image File Format) is a standard developed by the Moving Picture Experts Group (MPEG) for storage and sharing of images and image sequences. Can use `.heif` or `.heic` file extensions.",
-  "spec":"http://nokiatech.github.io/heif/technical.html",
+  "spec":"https://nokiatech.github.io/heif/technical.html",
   "status":"other",
   "links":[
     {

--- a/features-json/insertadjacenthtml.json
+++ b/features-json/insertadjacenthtml.json
@@ -388,7 +388,7 @@
   },
   "notes":"",
   "notes_by_num":{
-    "1":"Throws an \"Invalid target element for this operation.\" error [when called on a table, tbody, thead, or tr element.](http://ejohn.org/blog/dom-insertadjacenthtml/)"
+    "1":"Throws an \"Invalid target element for this operation.\" error [when called on a table, tbody, thead, or tr element.](https://johnresig.com/blog/dom-insertadjacenthtml/)"
   },
   "usage_perc_y":97.94,
   "usage_perc_a":0.32,

--- a/features-json/jpeg2000.json
+++ b/features-json/jpeg2000.json
@@ -1,7 +1,7 @@
 {
   "title":"JPEG 2000 image format",
   "description":"JPEG 2000 (JP2) was created by the Joint Photographic Experts Group committee in 2000 with the intention of superseding their original discrete cosine transform-based JPEG standard (created in 1992) with a newly designed, wavelet-based method. It offers some advantages in image fidelity over standard JPEG.",
-  "spec":"http://www.itu.int/rec/T-REC-T.800-200208-I",
+  "spec":"https://www.itu.int/rec/T-REC-T.800-200208-I",
   "status":"other",
   "links":[
     {

--- a/features-json/jpegxr.json
+++ b/features-json/jpegxr.json
@@ -1,11 +1,11 @@
 {
   "title":"JPEG XR image format",
   "description":"The latest JPEG image format of Joint Photographic Experts Group which boasts better compression and supports lossless compression, alpha channel, and 48-bit deep color over normal jpg format.",
-  "spec":"http://www.itu.int/rec/T-REC-T.832",
+  "spec":"https://www.itu.int/rec/T-REC-T.832",
   "status":"other",
   "links":[
     {
-      "url":"http://msdn.microsoft.com/en-us/library/windows/desktop/hh707223(v=vs.85).aspx",
+      "url":"https://docs.microsoft.com/en-us/windows/win32/wic/jpeg-xr-codec",
       "title":"Microsoft JPEG XR Codec Overview"
     },
     {

--- a/features-json/js-regexp-lookbehind.json
+++ b/features-json/js-regexp-lookbehind.json
@@ -5,7 +5,7 @@
   "status":"other",
   "links":[
     {
-      "url":"http://2ality.com/2017/05/regexp-lookbehind-assertions.html",
+      "url":"https://2ality.com/2017/05/regexp-lookbehind-assertions.html",
       "title":"Blog post on lookbehind assertions"
     },
     {

--- a/features-json/json.json
+++ b/features-json/json.json
@@ -9,8 +9,8 @@
       "title":"MDN Web Docs - Using JSON"
     },
     {
-      "url":"http://www.json.org/js.html",
-      "title":"JSON in JS (includes script w/support)"
+      "url":"https://www.json.org/",
+      "title":"JSON explainer"
     },
     {
       "url":"https://raw.github.com/phiggins42/has.js/master/detect/json.js#json",

--- a/features-json/let.json
+++ b/features-json/let.json
@@ -5,7 +5,7 @@
   "status":"other",
   "links":[
     {
-      "url":"http://generatedcontent.org/post/54444832868/variables-and-constants-in-es6",
+      "url":"https://generatedcontent.org/post/54444832868/variables-and-constants-in-es6",
       "title":"Variables and Constants in ES6"
     },
     {

--- a/features-json/link-rel-dns-prefetch.json
+++ b/features-json/link-rel-dns-prefetch.json
@@ -1,6 +1,6 @@
 {
   "title":"Resource Hints: dns-prefetch",
-  "description":"Gives a hint to the browser to perform a DNS lookup in the background to improve performance. This is indicated using `<link rel=\"dns-prefetch\" href=\"http://example-domain.com/\">`",
+  "description":"Gives a hint to the browser to perform a DNS lookup in the background to improve performance. This is indicated using `<link rel=\"dns-prefetch\" href=\"https://example.com/\">`",
   "spec":"https://www.w3.org/TR/resource-hints/#dns-prefetch",
   "status":"wd",
   "links":[
@@ -392,7 +392,7 @@
   },
   "notes":"",
   "notes_by_num":{
-    "1":"IE9 [supported `dns-prefetch` as `prefetch`](http://blogs.msdn.com/b/ieinternals/archive/2012/03/01/ie10-beta-consumer-preview-minor-changes-changelist.aspx) as the former wasn\u2019t defined yet.",
+    "1":"IE9 [supported `dns-prefetch` as `prefetch`](https://blogs.msdn.com/b/ieinternals/archive/2012/03/01/ie10-beta-consumer-preview-minor-changes-changelist.aspx) as the former wasn\u2019t defined yet.",
     "2":"Firefox only supports `dns-prefetch` on HTTP origins. HTTPS is unsupported."
   },
   "usage_perc_y":78.53,

--- a/features-json/mathml.json
+++ b/features-json/mathml.json
@@ -9,7 +9,7 @@
       "title":"Wikipedia"
     },
     {
-      "url":"http://www.mozilla.org/projects/mathml/demo/",
+      "url":"https://www.mozilla.org/projects/mathml/demo/",
       "title":"MathML demos"
     },
     {

--- a/features-json/midi.json
+++ b/features-json/midi.json
@@ -1,7 +1,7 @@
 {
   "title":"Web MIDI API",
   "description":"The Web MIDI API specification defines a means for web developers to enumerate, manipulate and access MIDI devices",
-  "spec":"http://webaudio.github.io/web-midi-api/",
+  "spec":"https://webaudio.github.io/web-midi-api/",
   "status":"wd",
   "links":[
     {

--- a/features-json/netinfo.json
+++ b/features-json/netinfo.json
@@ -1,7 +1,7 @@
 {
   "title":"Network Information API",
   "description":"The Network Information API enables web applications to access information about the network connection in use by the device. Accessed via `navigator.connection`",
-  "spec":"http://wicg.github.io/netinfo/",
+  "spec":"https://wicg.github.io/netinfo/",
   "status":"unoff",
   "links":[
     {

--- a/features-json/ogg-vorbis.json
+++ b/features-json/ogg-vorbis.json
@@ -1,7 +1,7 @@
 {
   "title":"Ogg Vorbis audio format",
   "description":"Vorbis is a free and open source audio format, most commonly used with the Ogg container.",
-  "spec":"http://www.xiph.org/vorbis/doc/Vorbis_I_spec.html",
+  "spec":"https://www.xiph.org/vorbis/doc/Vorbis_I_spec.html",
   "status":"other",
   "links":[
     {

--- a/features-json/ogv.json
+++ b/features-json/ogv.json
@@ -1,7 +1,7 @@
 {
   "title":"Ogg/Theora video format",
   "description":"Free lossy video compression format.",
-  "spec":"http://theora.org/doc/",
+  "spec":"https://theora.org/doc/",
   "status":"other",
   "links":[
     {

--- a/features-json/page-transition-events.json
+++ b/features-json/page-transition-events.json
@@ -9,7 +9,7 @@
       "title":"MDN Web Docs - pageshow"
     },
     {
-      "url":"http://www.w3schools.com/tags/ev_onpageshow.asp",
+      "url":"https://www.w3schools.com/tags/ev_onpageshow.asp",
       "title":"HTML onpageshow Event Attribute"
     }
   ],

--- a/features-json/pointer-events.json
+++ b/features-json/pointer-events.json
@@ -1,11 +1,11 @@
 {
   "title":"CSS pointer-events (for HTML)",
   "description":"This CSS property, when set to \"none\" allows elements to not receive hover/click events, instead the event will occur on anything behind it. ",
-  "spec":"http://wiki.csswg.org/spec/css4-ui#pointer-events",
+  "spec":"https://wiki.csswg.org/spec/css4-ui#pointer-events",
   "status":"unoff",
   "links":[
     {
-      "url":"http://robertnyman.com/2010/03/22/css-pointer-events-to-allow-clicks-on-underlying-elements/",
+      "url":"https://robertnyman.com/2010/03/22/css-pointer-events-to-allow-clicks-on-underlying-elements/",
       "title":"Article & tutorial"
     },
     {

--- a/features-json/setimmediate.json
+++ b/features-json/setimmediate.json
@@ -1,7 +1,7 @@
 {
   "title":"Efficient Script Yielding: setImmediate()",
   "description":"Yields control flow without the minimum delays enforced by setTimeout",
-  "spec":"http://w3c.github.io/setImmediate/",
+  "spec":"https://w3c.github.io/setImmediate/",
   "status":"unoff",
   "links":[
     {

--- a/features-json/spdy.json
+++ b/features-json/spdy.json
@@ -1,7 +1,7 @@
 {
   "title":"SPDY protocol",
   "description":"Networking protocol for low-latency transport of content over the web. Superseded by HTTP version 2.",
-  "spec":"http://http2.github.io/http2-spec/index.html",
+  "spec":"https://http2.github.io/http2-spec/index.html",
   "status":"unoff",
   "links":[
     {
@@ -9,7 +9,7 @@
       "title":"Wikipedia"
     },
     {
-      "url":"http://dev.chromium.org/spdy/spdy-whitepaper",
+      "url":"https://dev.chromium.org/spdy/spdy-whitepaper",
       "title":"SPDY whitepaper"
     }
   ],

--- a/features-json/speech-synthesis.json
+++ b/features-json/speech-synthesis.json
@@ -5,19 +5,19 @@
   "status":"unoff",
   "links":[
     {
-      "url":"http://updates.html5rocks.com/2014/01/Web-apps-that-talk---Introduction-to-the-Speech-Synthesis-API",
-      "title":"HTML5Rocks article"
+      "url":"https://developers.google.com/web/updates/2014/01/Web-apps-that-talk-Introduction-to-the-Speech-Synthesis-API",
+      "title":"Google Developers article"
     },
     {
       "url":"https://www.sitepoint.com/talking-web-pages-and-the-speech-synthesis-api/",
       "title":"SitePoint article"
     },
     {
-      "url":"http://aurelio.audero.it/demo/speech-synthesis-api-demo.html",
+      "url":"https://www.audero.it/demo/speech-synthesis-api-demo.html",
       "title":"Demo"
     },
     {
-      "url":"http://zenorocha.github.io/voice-elements/",
+      "url":"https://zenorocha.github.io/voice-elements/",
       "title":"Advanced demo and resource"
     },
     {

--- a/features-json/svg.json
+++ b/features-json/svg.json
@@ -9,7 +9,7 @@
       "title":"Wikipedia"
     },
     {
-      "url":"http://www.alistapart.com/articles/using-svg-for-flexible-scalable-and-fun-backgrounds-part-i",
+      "url":"https://alistapart.com/article/using-svg-for-flexible-scalable-and-fun-backgrounds-part-i/",
       "title":"A List Apart article"
     },
     {

--- a/features-json/svg.json
+++ b/features-json/svg.json
@@ -17,10 +17,6 @@
       "title":"SVG showcase site"
     },
     {
-      "url":"http://code.google.com/p/svgweb/",
-      "title":"SVG Web: Flash-based polyfill"
-    },
-    {
       "url":"https://github.com/SVG-Edit/svgedit",
       "title":"Web-based SVG editor"
     },

--- a/features-json/testfeat.json
+++ b/features-json/testfeat.json
@@ -1,11 +1,11 @@
 {
   "title":"Test feature - updated",
   "description":"none",
-  "spec":"http://example.com",
+  "spec":"https://example.com",
   "status":"unoff",
   "links":[
     {
-      "url":"http://example.com",
+      "url":"https://example.com",
       "title":"test link"
     }
   ],

--- a/features-json/u2f.json
+++ b/features-json/u2f.json
@@ -9,7 +9,7 @@
       "title":"Mozilla bug"
     },
     {
-      "url":"http://googleonlinesecurity.blogspot.com/2014/10/strengthening-2-step-verification-with.html",
+      "url":"https://security.googleblog.com/2014/10/strengthening-2-step-verification-with.html",
       "title":"Google Security article"
     }
   ],

--- a/features-json/use-strict.json
+++ b/features-json/use-strict.json
@@ -5,7 +5,7 @@
   "status":"other",
   "links":[
     {
-      "url":"http://ejohn.org/blog/ecmascript-5-strict-mode-json-and-more/",
+      "url":"https://johnresig.com/blog/ecmascript-5-strict-mode-json-and-more/",
       "title":"Information page"
     },
     {

--- a/features-json/web-animation.json
+++ b/features-json/web-animation.json
@@ -1,7 +1,7 @@
 {
   "title":"Web Animations API",
   "description":"Lets you create animations that are run in the browser, as well as inspect and manipulate animations created through declarative means like CSS.",
-  "spec":"http://w3c.github.io/web-animations/",
+  "spec":"https://drafts.csswg.org/web-animations/",
   "status":"wd",
   "links":[
     {

--- a/features-json/web-bluetooth.json
+++ b/features-json/web-bluetooth.json
@@ -1,7 +1,7 @@
 {
   "title":"Web Bluetooth",
   "description":"Allows web sites to communicate over GATT with nearby user-selected Bluetooth devices in a secure and privacy-preserving way.",
-  "spec":"http://webbluetoothcg.github.io/web-bluetooth/",
+  "spec":"https://webbluetoothcg.github.io/web-bluetooth/",
   "status":"unoff",
   "links":[
     {

--- a/features-json/webp.json
+++ b/features-json/webp.json
@@ -9,15 +9,15 @@
       "title":"Official website"
     },
     {
-      "url":"http://antimatter15.github.io/weppy/demo.html",
+      "url":"https://antimatter15.com/weppy/demo.html",
       "title":"Polyfill for browsers with WebM support"
     },
     {
-      "url":"http://libwebpjs.appspot.com/",
+      "url":"https://libwebpjs.appspot.com/",
       "title":"Decoder in JS"
     },
     {
-      "url":"http://webpjs.appspot.com/",
+      "url":"https://webpjs.appspot.com/",
       "title":"Polyfill for browsers with or without WebM support (i.e. IE6-IE9, Safari/iOS version 6.1 and below; Firefox versions 24 and bel"
     },
     {
@@ -37,7 +37,7 @@
       "title":"Polyfill for browsers with or without WebM support"
     },
     {
-      "url":"http://antimatter15.com/weppy/demo.html",
+      "url":"https://antimatter15.com/weppy/demo.html",
       "title":"Polyfill for browsers with WebM support"
     }
   ],

--- a/features-json/webvr.json
+++ b/features-json/webvr.json
@@ -13,7 +13,7 @@
       "title":"WebVR polyfill"
     },
     {
-      "url":"http://aframe.io",
+      "url":"https://aframe.io",
       "title":"WebVR framework"
     },
     {

--- a/features-json/woff2.json
+++ b/features-json/woff2.json
@@ -9,7 +9,7 @@
       "title":"Basics about WOFF 2.0"
     },
     {
-      "url":"http://everythingfonts.com/ttf-to-woff2",
+      "url":"https://everythingfonts.com/ttf-to-woff2",
       "title":"WOFF 2.0 converter"
     }
   ],

--- a/features-json/xml-serializer.json
+++ b/features-json/xml-serializer.json
@@ -9,7 +9,7 @@
       "title":"MDN Web Docs - XMLSerializer"
     },
     {
-      "url":"http://ejohn.org/blog/dom-insertadjacenthtml/",
+      "url":"https://johnresig.com/blog/dom-insertadjacenthtml/",
       "title":"Comparing Document Position by John Resig"
     }
   ],

--- a/sample-data.json
+++ b/sample-data.json
@@ -1,11 +1,11 @@
 {
   "title":"Sample title",
   "description":"Sample description",
-  "spec":"http://example.com/path/to/spec.html",
+  "spec":"https://example.com/path/to/spec.html",
   "status":"wd",
   "links":[
     {
-      "url":"http://example.com/path/to/link.html",
+      "url":"https://example.com/path/to/link.html",
       "title":"Link title"
     }
   ],


### PR DESCRIPTION
There is a surprising number of insecure external links in the database. This PR fixes a lot of them, but not all of them. I have tried to make sure that the most used links are all secure now.

All links are tested for TLS support before changing them to HTTPS.

I have for the most part not evaluated if the links should even still be there, i have simply upgraded them to HTTPS :)