### PR TITLE
Add notes on specific browser handling of TLS 1.1

### DIFF
--- a/features-json/tls1-1.json
+++ b/features-json/tls1-1.json
@@ -218,8 +218,8 @@
       "81":"y",
       "83":"y",
       "84":"y",
-      "85":"a #4 #5",
-      "86":"a #4 #5"
+      "85":"a #3 #4",
+      "86":"a #3 #4"
     },
     "safari":{
       "3.1":"n",
@@ -400,9 +400,8 @@
   "notes_by_num":{
     "1":"Firefox 68+ displays a small warning icon in the address bar when connecting over tls 1.1",
     "2":"Firefox 78+ displays a full page dismissable warning the first time it connects over tls 1.1",
-    "3":"Safari for MacOS 13.1+ displays `Not secure` in the address bar when connecting over tls 1.1",
-    "4":"Chrome 85+ displays `Not secure` in the address bar when connecting over tls 1.1",
-    "5":"Chrome 85+ displays a full page dismissable warning every time a new site connects over tls 1.1"
+    "3":"Chrome 85+ and Safari for MacOS 13.1+ displays `Not secure` in the address bar when connecting over tls 1.1",
+    "4":"Chrome 85+ displays a full page dismissable warning every time a new site connects over tls 1.1"
   },
   "usage_perc_y":97.14,
   "usage_perc_a":0,

--- a/features-json/tls1-1.json
+++ b/features-json/tls1-1.json
@@ -123,19 +123,19 @@
       "65":"y",
       "66":"y",
       "67":"y",
-      "68":"y",
-      "69":"y",
-      "70":"y",
-      "71":"y",
-      "72":"y",
-      "73":"y",
-      "74":"y",
-      "75":"y",
-      "76":"y",
-      "77":"y",
-      "78":"n",
-      "79":"n",
-      "80":"n"
+      "68":"y #1",
+      "69":"y #1",
+      "70":"y #1",
+      "71":"y #1",
+      "72":"y #1",
+      "73":"y #1",
+      "74":"y #1",
+      "75":"y #1",
+      "76":"y #1",
+      "77":"y #1",
+      "78":"a #1 #2",
+      "79":"a #1 #2",
+      "80":"a #1 #2"
     },
     "chrome":{
       "4":"n",
@@ -217,9 +217,9 @@
       "80":"y",
       "81":"y",
       "83":"y",
-      "84":"n",
-      "85":"n",
-      "86":"n"
+      "84":"y",
+      "85":"a #4",
+      "86":"a #4"
     },
     "safari":{
       "3.1":"n",
@@ -241,9 +241,9 @@
       "12":"y",
       "12.1":"y",
       "13":"y",
-      "13.1":"y",
-      "14":"y",
-      "TP":"y"
+      "13.1":"y #3",
+      "14":"y #3",
+      "TP":"y #3"
     },
     "opera":{
       "9":"n",
@@ -366,7 +366,7 @@
       "81":"y"
     },
     "and_ff":{
-      "68":"y"
+      "68":"y #1"
     },
     "ie_mob":{
       "10":"n d",
@@ -398,7 +398,10 @@
   },
   "notes":"TLS 1.0 & 1.1 are deprecated in Chrome, Edge, Firefox, Internet Explorer 11, & Safari.",
   "notes_by_num":{
-    
+    "1":"Firefox 68+ displays a small warning icon in the address bar when connecting over tls 1.1",
+    "2":"Firefox 78+ displays a full page dismissable warning the first time it connects over tls 1.1",
+    "3":"Desktop Safari 13.1+ will display `Not secure` in the address bar when connecting over tls 1.1",
+    "4":"Chrome 85+ displays a full page dismissable warning every time a new site connects over tls 1.1"
   },
   "usage_perc_y":97.14,
   "usage_perc_a":0,

--- a/features-json/tls1-1.json
+++ b/features-json/tls1-1.json
@@ -218,8 +218,8 @@
       "81":"y",
       "83":"y",
       "84":"y",
-      "85":"a #4",
-      "86":"a #4"
+      "85":"a #4 #5",
+      "86":"a #4 #5"
     },
     "safari":{
       "3.1":"n",
@@ -400,8 +400,9 @@
   "notes_by_num":{
     "1":"Firefox 68+ displays a small warning icon in the address bar when connecting over tls 1.1",
     "2":"Firefox 78+ displays a full page dismissable warning the first time it connects over tls 1.1",
-    "3":"Desktop Safari 13.1+ will display `Not secure` in the address bar when connecting over tls 1.1",
-    "4":"Chrome 85+ displays a full page dismissable warning every time a new site connects over tls 1.1"
+    "3":"Safari for MacOS 13.1+ displays `Not secure` in the address bar when connecting over tls 1.1",
+    "4":"Chrome 85+ displays `Not secure` in the address bar when connecting over tls 1.1",
+    "5":"Chrome 85+ displays a full page dismissable warning every time a new site connects over tls 1.1"
   },
   "usage_perc_y":97.14,
   "usage_perc_a":0,


### PR DESCRIPTION
I took the time to find a random website that only supported TLS 1.1/1.0 and check how all browsers respond to it. Turns out you can pretty quickly find one by looking through the [Qualys SSL Labs 'Recent Worst'](https://www.ssllabs.com/ssltest/#:~:text=Recent%20Worst) 😄

Changes for this PR:

Chrome and Firefox's new full-page warnings are hardly "unsupported" behaviour. The Chrome implementation is getting close, but Firefox's warning only shows on the very first TLS 1.1 load, and then never displays again. Furthermore, the "dismiss" button is directly accessible and highlighted, meaning most people will just click the button without reading the warning.
Because of this, i have decided to change `unsupported` versions to `partially supported`.

Chrome 84 (released last night) does not in implement the new full-page warning. That seems to be delayed for v85.

Added notes on the small UI warnings that Firefox and Safari has already implemented.

Chromium browsers also have small UI warnings in existing releases, but they are only shown if you click on the padlock (which shows no warnings). Also, i did not get reliable results when testing it. Therefore, i have just decided to not add a note on that behaviour.
