### PR TITLE
Remove unused duplicate note in TLS 1.3

### DIFF
--- a/features-json/tls1-3.json
+++ b/features-json/tls1-3.json
@@ -393,8 +393,7 @@
     "1":"Supports a draft of the TLS 1.3 specification, not the final version.",
     "2":"Can be enabled in Firefox by setting the `security.tls.version.max` pref to \"4\" in `about:config`.",
     "3":"Can be enabled in Chrome and Opera via the `#tls13-variant` flag in `chrome://flags` or `opera://flags`.",
-    "4":"Partial support in Safari refers to being limited to macOS 10.14 Mojave and later.",
-    "5":"Partial support in Safari refers to being limited to macOS 10.14 Mojave and later."
+    "4":"Partial support in Safari refers to being limited to macOS 10.14 Mojave and later."
   },
   "usage_perc_y":84,
   "usage_perc_a":3.6,


### PR DESCRIPTION
Seems to have been added in https://github.com/Fyrd/caniuse/commit/c0b22864b9f445abeede6c45cad9c5bdb2b2d137#diff-630bd6be31934f3566bbec0c2d7c2e4aR386, not sure why tho.