### PR TITLE
Firefox fully supports unprefixed CSS Appearance

### DIFF
--- a/features-json/css-appearance.json
+++ b/features-json/css-appearance.json
@@ -9,10 +9,6 @@
       "title":"CSS Tricks article"
     },
     {
-      "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=1620467",
-      "title":"Firefox implementation bug for unprefixed `apperance`"
-    },
-    {
       "url":"https://bugs.webkit.org/show_bug.cgi?id=143842",
       "title":"Safari implementation bug for unprefixed `apperance`"
     }
@@ -127,7 +123,7 @@
       "77":"a x #1",
       "78":"a x #1",
       "79":"a x #1",
-      "80":"a x #1"
+      "80":"y"
     },
     "chrome":{
       "4":"a x #1",

--- a/features-json/css-appearance.json
+++ b/features-json/css-appearance.json
@@ -10,7 +10,7 @@
     },
     {
       "url":"https://bugs.webkit.org/show_bug.cgi?id=143842",
-      "title":"Safari implementation bug for unprefixed `apperance`"
+      "title":"Safari implementation bug for unprefixed `appearance`"
     }
   ],
   "bugs":[


### PR DESCRIPTION
Firefox has completed their implementation of CSS Appearance. According to both their [bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1620467) and some manual testing by me, it is enabled by default in Firefox 80 🥳