### PR TITLE
Change rel=preload Firefox bug page to meta bug page

### DIFF
--- a/features-json/link-rel-preload.json
+++ b/features-json/link-rel-preload.json
@@ -9,8 +9,8 @@
       "title":"Preload: What Is It Good For?"
     },
     {
-      "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=1222633",
-      "title":"Firefox support bug"
+      "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=Rel%3Dpreload",
+      "title":"Firefox meta support bug"
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/HTML/Preloading_content",


### PR DESCRIPTION
Changed the link from the old solved bug to the meta bug page. As Firefox is still working on this, and rendering to the meta bug page makes it clearer for the user what the status is of this feature.