### PR TITLE
Web Bluetooth: Add Mozilla specification position link

### DIFF
--- a/features-json/web-bluetooth.json
+++ b/features-json/web-bluetooth.json
@@ -19,6 +19,10 @@
     {
       "url":"https://github.com/WebBluetoothCG/web-bluetooth/blob/gh-pages/implementation-status.md",
       "title":"Implementation Status"
+    },
+    {
+      "url":"https://mozilla.github.io/standards-positions/#web-bluetooth",
+      "title":"Mozilla Specification Positions: Harmful"
     }
   ],
   "bugs":[


### PR DESCRIPTION
This pull request adds the Mozilla specification position link for Web Bluetooth, similar to [Web USB, URL Scroll-To-Text Fragment and more](https://github.com/Fyrd/caniuse/search?q=https%3A%2F%2Fmozilla.github.io%2Fstandards-positions&unscoped_q=https%3A%2F%2Fmozilla.github.io%2Fstandards-positions).