### PR TITLE
Adds more information about focus options in Edge, fixes link

### DIFF
--- a/features-json/focusoptions-preventscroll.json
+++ b/features-json/focusoptions-preventscroll.json
@@ -13,7 +13,7 @@
       "title":"Chrome Platform Status - Prevent scrolling in HTMLElement.focus()"
     },
     {
-      "url":"https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/14314565/",
+      "url":"https://web.archive.org/web/20190401133643/https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/14314565/",
       "title":"Edge Bug 14314565 - Enable ability to prevent scrolling in Element.focus()"
     },
     {
@@ -43,8 +43,8 @@
       "14":"n",
       "15":"n",
       "16":"n",
-      "17":"n",
-      "18":"n",
+      "17":"a #1",
+      "18":"a #1",
       "79":"y",
       "80":"y",
       "81":"y",
@@ -397,7 +397,7 @@
   },
   "notes":"",
   "notes_by_num":{
-    
+    "1":"Partial support in Edge refers to scrolling to text inputs or textareas, even when using preventScroll. Submit inputs and buttons work as expected."
   },
   "usage_perc_y":32.49,
   "usage_perc_a":0,


### PR DESCRIPTION
This PR adds more information about focus options to prevent scrolling in Edge v17 and 18, and fixes a link to a broken MS Developer page.

Per [that link](https://web.archive.org/web/20190401133643/https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/14314565/), support for `preventScrolling` was added in Edge v17. I’ve tested the test case, and everything does pass [the web platform test](wpt.live/html/interaction/focus/processing-model/preventScroll.html
) as expected.

<img width="300" alt="Screen Shot 2020-08-10 at 12 04 26 PM" src="https://user-images.githubusercontent.com/1581276/89820378-c84a8a80-db01-11ea-990c-5d40c3d2ea4f.png">

But it doesn’t pass [the more recent test for inputs where you can type](wpt.live/html/interaction/focus/processing-model/preventScroll-textarea.html
), or textareas:

<img width="300" alt="Screen Shot 2020-08-10 at 12 10 44 PM" src="https://user-images.githubusercontent.com/1581276/89820936-a30a4c00-db02-11ea-9a09-518946e823c0.png"> t

I’ve added that detail as a note.