### PR TITLE
CSS position:sticky - added a height/scroll height related issue due to different browser implementations

### DIFF
--- a/features-json/css-sticky.json
+++ b/features-json/css-sticky.json
@@ -35,6 +35,9 @@
     },
     {
       "description":"A parent with overflow set to `auto` will prevent `position: sticky` from working in Safari"
+    },
+    {
+      "description":"Browsers implement the dynamic change in the height of a sticky element [differently](https://stackoverflow.com/q/62249752/2932484).
     }
   ],
   "categories":[


### PR DESCRIPTION
This implementation difference can cause incoherent behavior when dealing with elements that are sensitive to scroll position - for example, a sticky header that shrinks in height by 1px after the user scrolls down by 1px will cause the scrolling parent of the sticky header to scroll up by 1px in Chrome, resetting the sticky header to its former larger height as it is now at the top of its parent element.

Thanks to [Craig Brown](https://stackoverflow.com/users/3034366/craig-brown) for providing the SO question and test case.