### PR TITLE
Chromium 86 supports Native Filesystem API

### DIFF
--- a/features-json/native-filesystem-api.json
+++ b/features-json/native-filesystem-api.json
@@ -214,9 +214,9 @@
       "83":"n d #1",
       "84":"n d #1",
       "85":"n d #1",
-      "86":"n d #1",
-      "87":"n d #1",
-      "88":"n d #1"
+      "86":"a #2",
+      "87":"a #2",
+      "88":"a #2"
     },
     "safari":{
       "3.1":"n",
@@ -395,7 +395,8 @@
   },
   "notes":"",
   "notes_by_num":{
-    "1":"Can be enabled in desktop Chromium browsers with the `#native-file-system-api` flag"
+    "1":"Can be enabled in desktop Chromium browsers with the `#native-file-system-api` flag.",
+    "2":"Desktop Chromium browsers currently support basic functionality and will be adding more of the API in the future."
   },
   "usage_perc_y":0,
   "usage_perc_a":0,

--- a/features-json/native-filesystem-api.json
+++ b/features-json/native-filesystem-api.json
@@ -9,8 +9,12 @@
       "title":"Explainer"
     },
     {
-      "url":"https://developers.google.com/web/updates/2019/08/native-file-system",
-      "title":"Chrome blog post"
+      "url":"https://web.dev/native-file-system/",
+      "title":"Web.dev blog post"
+    },
+    {
+      "url":"https://mozilla.github.io/standards-positions/#native-file-system",
+      "title":"Firefox position: defer"
     }
   ],
   "bugs":[
@@ -391,14 +395,13 @@
   },
   "notes":"",
   "notes_by_num":{
-    "1":"Can be enabled in desktop Chromium browsers with the \u00b4#native-file-system-api\u00b4 flag",
-    "2":"Part of an origin trial"
+    "1":"Can be enabled in desktop Chromium browsers with the `#native-file-system-api` flag"
   },
   "usage_perc_y":0,
   "usage_perc_a":0,
   "ucprefix":false,
   "parent":"",
-  "keywords":"chooseFileSystemEntries,getFile",
+  "keywords":"File System,File System API,chooseFileSystemEntries,getFile",
   "ie_id":"",
   "chrome_id":"6284708426022912",
   "firefox_id":"",


### PR DESCRIPTION
Chromium has landed support for the native filesystem API in v86, significantly closing the gap between native and web capabilities on the desktop 🥳

In trying not to fly too close to the sun, they have decided to only roll out some functionality, and then add to it in waves. Because of that, i have marked it as `partial` support, and will add more specifics as new functions come out.
This is the samme approach as [WebXR](https://caniuse.com/#feat=webxr), which is probably due for an update pretty soon :)

I have verified basic support in Chrome 86 with [the Caniuse test](https://tests.caniuse.com/native-filesystem-api) and [this cool demo](https://googlechromelabs.github.io/text-editor/). You can also check:
https://chromestatus.com/feature/6284708426022912
https://groups.google.com/a/chromium.org/g/blink-dev/c/9Fcpl2KVfbk/m/d9VN0Fz8BwAJ