### PR TITLE
fix: partial logical props support in Opera Mini

### DIFF
--- a/features-json/css-logical-props.json
+++ b/features-json/css-logical-props.json
@@ -362,7 +362,8 @@
       "11.5":"n",
       "12":"n",
       "12.1":"n",
-      "46":"a x #2"
+      "46":"a x #2",
+      "48":"a #3 #4"
     },
     "and_chr":{
       "84":"y"
@@ -402,8 +403,8 @@
   "notes_by_num":{
     "1":"Only supports the *-start, and *-end values for `margin`, `border` and `padding`, not the inline/block type values as defined in the spec.",
     "2":"Like #1 but also supports `*-before` and `*-end` for `*-block-start` and `*-block-end` properties as well as `start` and `end` values for `text-align`",
-    "3":"Does not support the `margin-block`, `margin-inline`, `padding-inline`, or any of the `inset` shorthand properties. Supported in newer Chromium browsers behind the `#enable-experimental-web-platform-features` flag",
-    "4":"Does not support the `padding-block`, `padding-inline`, or any `inset` property. Supported in newer Chromium browsers behind the `#enable-experimental-web-platform-features` flag"
+    "3":"Does not support the `margin-block`, `margin-inline`, `padding-inline`, or any of the `inset` shorthand properties. Supported in newer browsers behind the `#enable-experimental-web-platform-features` flag",
+    "4":"Does not support the `padding-block`, `padding-inline`, or any `inset` property. Supported in newer browsers behind the `#enable-experimental-web-platform-features` flag"
   },
   "usage_perc_y":89.39,
   "usage_perc_a":6.14,


### PR DESCRIPTION
Used Android Studio's emulator and [this CodePen](https://codepen.io/kripod97/pen/Rwageze) for testing. Please see mdn/browser-compat-data for [why v48 was picked](https://github.com/mdn/browser-compat-data/blob/365cf70b860bdbbdc6663593beaa54a7f92d4631/css/properties/margin-block-start.json#L55-L57).