### PR TITLE
Update css-focus-visible.json

### DIFF
--- a/features-json/css-focus-visible.json
+++ b/features-json/css-focus-visible.json
@@ -25,10 +25,6 @@
       "title":"Microsoft Edge implementation suggestion"
     },
     {
-      "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=1437901",
-      "title":"Bugzilla: Add :focus-visible (former :focus-ring)"
-    },
-    {
       "url":"https://bugs.webkit.org/show_bug.cgi?id=30523",
       "title":"WebKit bug #140144: Add support for `-webkit-focusring` CSS pseudo class"
     },


### PR DESCRIPTION
Remove extra bugzilla link that only pertains to the adding of documentation -- not to the implementation of the feature in Gecko.