### PR TITLE
Add missing information in selector list `:not()` description

### DIFF
--- a/features-json/css-not-sel-list.json
+++ b/features-json/css-not-sel-list.json
@@ -1,6 +1,6 @@
 {
   "title":"selector list argument of :not()",
-  "description":"Selectors Level 4 allows the `:not()` pseudo-class to accept a list of selectors, which the element must not match any of. Selectors Level 3 only allowed `:not()` to accept a single simple selector. Thus, `:not(a):not(.b):not([c])` can instead be written as `:not(a, .b, [c])`",
+  "description":"Selectors Level 3 only allowed `:not()` pseudo-class to accept a single simple selector, which the element must not match any of. Thus, `:not(a, .b, [c])` or `:not(a.b[c])` did not work. Selectors Level 4 allows `:not()` to accept a list of selectors. Thus, `:not(a):not(.b):not([c])` can instead be written as `:not(a, .b, [c])` and `:not(a.b[c])` works as intended.",
   "spec":"https://www.w3.org/TR/selectors4/#negation",
   "status":"wd",
   "links":[


### PR DESCRIPTION
Add the fact that compound selector in `:not()` is not supported in Selectors level 3 spec (e.g `:not(.a.b)`).