### PR TITLE
Fix missing "i" in CSS content-visibilty => visibility

### DIFF
--- a/features-json/css-content-visibility.json
+++ b/features-json/css-content-visibility.json
@@ -1,5 +1,5 @@
 {
-  "title":"CSS content-visibilty",
+  "title":"CSS content-visibility",
   "description":"Provides control over when elements are rendered, so rendering can be skipped for elements not yet in the user's viewport. ",
   "spec":"https://www.w3.org/TR/css-contain-2/#content-visibility",
   "status":"wd",


### PR DESCRIPTION
I'm afraid it's in the news as well, but I don't think we can edit that code 0:-)

![image](https://user-images.githubusercontent.com/2644614/94245835-2220db80-ff1b-11ea-80e3-86890e46c975.png)
