### PR TITLE
Updates to CSS math functions

### DIFF
--- a/features-json/css-math-functions.json
+++ b/features-json/css-math-functions.json
@@ -9,14 +9,6 @@
       "title":"Test case on JSFiddle"
     },
     {
-      "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=css-min-max",
-      "title":"Firefox support bug"
-    },
-    {
-      "url":"https://crbug.com/825895",
-      "title":"Chrome support bug"
-    },
-    {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/min",
       "title":"MDN Web Docs article for min()"
     },
@@ -377,7 +369,7 @@
       "11.5":"n",
       "12":"n",
       "12.1":"n",
-      "59":"n"
+      "59":"y"
     },
     "and_chr":{
       "85":"y"
@@ -421,10 +413,10 @@
   "usage_perc_a":7.91,
   "ucprefix":false,
   "parent":"",
-  "keywords":"",
+  "keywords":"min,min(),max,max(),clamp,clamp()",
   "ie_id":"",
-  "chrome_id":"",
-  "firefox_id":"",
+  "chrome_id":"5714277878988800",
+  "firefox_id":"css-min-max-clamp",
   "webkit_id":"",
   "shown":true
 }


### PR DESCRIPTION
Gary Simons recently made a video on the new `clamp` property, where he [accidentally used the wrong support table](https://youtu.be/dg488RrpNTc?t=70). I think it's hard to blame him, since searching for `clamp` or `css clamp` first displays a non-standard property, and then shows 2-7 MDN tables before showing the thing that i believe most people will be searching for.
One of the MDN tables are actually also for the same property, so that should be removed, right?

You encounter similar issues when searching for `min` and `max`.

I don't actually know how the search engine works, but i have tried to add keywords that should help bring this support table to the top. By all means change them if you know something i don't :)

I have also tested Android Opera 59 to support this with the [caniuse test](https://tests.caniuse.com/css-math-functions). This is expected, since it's based on Chromium.

And i did a bit of tidying.