### PR TITLE
Update Backdrop filter notes for firefox

### DIFF
--- a/features-json/css-backdrop-filter.json
+++ b/features-json/css-backdrop-filter.json
@@ -407,7 +407,7 @@
   "notes_by_num":{
     "1":"Can be enabled via the \"Experimental Web Platform Features\" flag",
     "2":"Currently only supported with the `-webkit-` prefix (not -ms-)",
-    "3":"Can be enabled by setting the `layout.css.backdrop-filter.enabled` preference to `true` in about:config."
+    "3":"Can be enabled by setting the `layout.css.backdrop-filter.enabled` and `gfx.webrender.all` preference to `true` in about:config."
   },
   "usage_perc_y":87.64,
   "usage_perc_a":0,


### PR DESCRIPTION
The backdrop filter also requires `gfx.webrender.all` (other than `layout.css.backdrop-filter.enabled`) to be true in Firefox which is false by default (checked in Firefox 81, currently latest on 05-10-2020). Updated this information in the notes section.

Reference : https://bugzilla.mozilla.org/show_bug.cgi?id=1591674#ct-3