### PR TITLE
Revert iOS Safari WebAuthn support to supported

### DIFF
--- a/features-json/webauthn.json
+++ b/features-json/webauthn.json
@@ -336,7 +336,7 @@
       "13.2":"n d #3",
       "13.3":"a #4",
       "13.4-13.7":"a #4",
-      "14":"y"
+      "14":"y #5"
     },
     "op_mini":{
       "all":"n"
@@ -405,7 +405,8 @@
     "1":"Can be enabled at `about:flags`\r\n\r\nEdge 13 used an earlier draft syntax. As of Edge 14 the implementation is prefixed and based on the FIDO 2.0 Web APIs.",
     "2":"Can be enabled using the Develop > Experimental Features menu. Currently supports USB-based CTAP & CTAP2 HID devices.",
     "3":"Can be enabled in Settings under the Safari > Advanced > Experimental Features menu.",
-    "4":"Partial support refers to FIDO2 devices not working if a PIN is set."
+    "4":"Partial support refers to FIDO2 devices not working if a PIN is set.",
+    "5":"Experimental feature not yet enabled in WKWebView-based browsers including Chrome for iOS."
   },
   "usage_perc_y":77.19,
   "usage_perc_a":0,

--- a/features-json/webauthn.json
+++ b/features-json/webauthn.json
@@ -334,9 +334,9 @@
       "12.2-12.4":"n",
       "13.0-13.1":"n",
       "13.2":"n d #3",
-      "13.3":"n",
-      "13.4-13.7":"n",
-      "14":"n"
+      "13.3":"a #4",
+      "13.4-13.7":"a #4",
+      "14":"y"
     },
     "op_mini":{
       "all":"n"
@@ -404,7 +404,8 @@
   "notes_by_num":{
     "1":"Can be enabled at `about:flags`\r\n\r\nEdge 13 used an earlier draft syntax. As of Edge 14 the implementation is prefixed and based on the FIDO 2.0 Web APIs.",
     "2":"Can be enabled using the Develop > Experimental Features menu. Currently supports USB-based CTAP & CTAP2 HID devices.",
-    "3":"Can be enabled in Settings under the Safari > Advanced > Experimental Features menu."
+    "3":"Can be enabled in Settings under the Safari > Advanced > Experimental Features menu.",
+    "4":"Partial support refers to FIDO2 devices not working if a PIN is set."
   },
   "usage_perc_y":77.19,
   "usage_perc_a":0,


### PR DESCRIPTION
Addressed https://github.com/Fyrd/caniuse/issues/5672#issuecomment-718388972 