### PR TITLE
🎉 iOS 14 webp support update!

### DIFF
--- a/features-json/webp.json
+++ b/features-json/webp.json
@@ -410,7 +410,7 @@
   "notes_by_num":{
     "1":"Partial support refers to not supporting lossless, alpha and animated WebP images.",
     "2":"Partial support refers to not supporting animated WebP images.",
-    "3":"Partial support in Safari refers to being limited to macOS 11 Big Sur and later."
+    "3":"Partial support in Safari refers to being limited to macOS 11 Big Sur or iOS 14 and later."
   },
   "usage_perc_y":84.33,
   "usage_perc_a":0.73,


### PR DESCRIPTION
After testing on an iPhone 11 running iOS 14.1 and Safari 14, webp images now load without showing a “broken image” icon. 