### PR TITLE
Update Chrome for Android 88 on SharedArrayBuffer

### DIFF
--- a/features-json/sharedarraybuffer.json
+++ b/features-json/sharedarraybuffer.json
@@ -371,7 +371,7 @@
       "59":"n"
     },
     "and_chr":{
-      "88":"n d #1"
+      "88":"y #3"
     },
     "and_ff":{
       "83":"y #3"
@@ -417,7 +417,7 @@
   "parent":"",
   "keywords":"",
   "ie_id":"",
-  "chrome_id":"4570991992766464",
+  "chrome_id":"4570991992766464,5171863141482496",
   "firefox_id":"shared-array-buffer",
   "webkit_id":"",
   "shown":true


### PR DESCRIPTION
Chrome for Android 88 will enable SharedArrayBuffer but only for COOP/COEP-enabled pages.

### References
* https://chromestatus.com/feature/5171863141482496
* http://web.dev/coop-coep/