### PR TITLE
Add note for old Safari implementation of webshare

### DIFF
--- a/features-json/web-share.json
+++ b/features-json/web-share.json
@@ -253,9 +253,9 @@
       "11":"n",
       "11.1":"n",
       "12":"n",
-      "12.1":"y",
-      "13":"y",
-      "13.1":"y",
+      "12.1":"y #5",
+      "13":"y #5",
+      "13.1":"y #5",
       "14":"y",
       "TP":"y"
     },
@@ -344,11 +344,11 @@
       "11.0-11.2":"n",
       "11.3-11.4":"n",
       "12.0-12.1":"n",
-      "12.2-12.4":"y",
-      "13.0-13.1":"y",
-      "13.2":"y",
-      "13.3":"y",
-      "13.4-13.7":"y",
+      "12.2-12.4":"y #5",
+      "13.0-13.1":"y #5",
+      "13.2":"y #5",
+      "13.3":"y #5",
+      "13.4-13.7":"y #5",
       "14":"y"
     },
     "op_mini":{
@@ -418,7 +418,8 @@
     "1":"Implemented old [Web Intents](https://dvcs.w3.org/hg/web-intents/raw-file/tip/spec/Overview-respec.html)",
     "2":"[Android intent:// URLs](https://developer.chrome.com/multidevice/android/intents) can be used instead.",
     "3":"Only supported on Windows",
-    "4":"support is only for Windows."
+    "4":"support is only for Windows.",
+    "5":"Did not support share click that would trigger a [fetch call](https://bugs.webkit.org/show_bug.cgi?id=197779)."
   },
   "usage_perc_y":51.83,
   "usage_perc_a":2.84,


### PR DESCRIPTION
Safari, prior to iOS 14, did not allow for a fetch call to happen between user trigger and when native share api is called.

Can see more details here -> https://stackoverflow.com/questions/56046434/how-to-use-webshareapi-preceded-by-an-ajax-call-in-safari

After filing a bug with the WebKit team it was fixed in iOS 14 + macOS 11

I think that should be noted for others reference.