### PR TITLE
Update notes on Referrer Policy

### DIFF
--- a/features-json/referrer-policy.json
+++ b/features-json/referrer-policy.json
@@ -212,7 +212,7 @@
       "80":"y",
       "81":"y",
       "83":"y",
-      "84":"y #3",
+      "84":"y",
       "85":"y #3",
       "86":"y #3",
       "87":"y #3",
@@ -238,10 +238,10 @@
       "11.1":"y",
       "12":"y",
       "12.1":"y",
-      "13":"y",
-      "13.1":"y",
-      "14":"y",
-      "TP":"y"
+      "13":"y #4",
+      "13.1":"y #4",
+      "14":"y #4",
+      "TP":"y #4"
     },
     "opera":{
       "9":"n",
@@ -331,9 +331,9 @@
       "12.2-12.4":"y",
       "13.0-13.1":"y",
       "13.2":"y",
-      "13.3":"y",
-      "13.4-13.7":"y",
-      "14":"y"
+      "13.3":"y #4",
+      "13.4-13.7":"y #4",
+      "14":"y #4"
     },
     "op_mini":{
       "all":"n"
@@ -401,7 +401,8 @@
   "notes_by_num":{
     "1":"Browsers initially supported an [early draft](https://wiki.whatwg.org/wiki/Meta_referrer) of the specification which can only use a meta tag and is only compatible with the `origin` value from the new spec.",
     "2":"Chrome 21-60 did not support the `same-origin`, `strict-origin` and `strict-origin-when-cross-origin` values. ([issue 627968](https://bugs.chromium.org/p/chromium/issues/detail?id=627968))",
-    "3":"Chrome is now defaulting to `strict-origin-when-cross-origin` which is the recommended setting for most use-cases."
+    "3":"The default policy has been changed from `no-referrer-when-downgrade` to `strict-origin-when-cross-origin.` See [the revised spec.](https://github.com/w3c/webappsec-referrer-policy/pull/142)",
+    "4":"[Safari's ITP](https://webkit.org/blog/9661/preventing-tracking-prevention-tracking/) (on by default) downgrades _all_ cross-site subresource request (not page navigation) referrer headers to the page's origin, ignoring the `unsafe-url` referrer policy."
   },
   "usage_perc_y":94.23,
   "usage_perc_a":3.21,
@@ -409,8 +410,8 @@
   "parent":"",
   "keywords":"meta,referrer,referer",
   "ie_id":"metareferrer",
-  "chrome_id":"5639972996513792",
+  "chrome_id":"5639972996513792,6251880185331712",
   "firefox_id":"",
-  "webkit_id":"",
+  "webkit_id":"201353",
   "shown":true
 }


### PR DESCRIPTION
- Removed Note 3 from Chrome 84
  - Note 3 applies to Chrome 85+ according to [the Chrome Platform Status.](http://chromestatus.com/feature/625188018533171)
- Changed Note 3 to reflect the revised Referrer Policy specification.
  - See https://github.com/w3c/webappsec-referrer-policy/pull/142 for more information.
- Added Note 4 to explain Safari ITP's behavior.
  - See [the WebKit blog post](https://webkit.org/blog/9661/preventing-tracking-prevention-tracking/) for more information.