### PR TITLE
Update the spec URL for Offline web applications

### DIFF
--- a/features-json/offline-apps.json
+++ b/features-json/offline-apps.json
@@ -1,7 +1,7 @@
 {
   "title":"Offline web applications",
   "description":"Now deprecated method of defining web page files to be cached using a cache manifest file, allowing them to work offline on subsequent visits to the page. ",
-  "spec":"https://html.spec.whatwg.org/multipage/browsers.html#offline",
+  "spec":"https://www.w3.org/TR/2011/WD-html5-20110525/offline.html#offline",
   "status":"unoff",
   "links":[
     {


### PR DESCRIPTION
<s>This change drops the spec URL for the "Offline web applications" feature — because that entire section has now been removed from the HTML standard.</s>

This change updates the spec URL for the "Offline web applications" feature. That entire section has now been removed from the HTML standard, so this change updates it to point to an older W3C copy.