### PR TITLE
Firefox no longer supports menuitem by default

### DIFF
--- a/features-json/menu.json
+++ b/features-json/menu.json
@@ -148,8 +148,8 @@
       "82":"a #1",
       "83":"a #1",
       "84":"a #1",
-      "85":"a #1",
-      "86":"a #1"
+      "85":"n d #1 #2",
+      "86":"n d #1 #2"
     },
     "chrome":{
       "4":"n",
@@ -387,7 +387,7 @@
       "87":"n"
     },
     "and_ff":{
-      "83":"a #1 #2"
+      "83":"a #1"
     },
     "ie_mob":{
       "10":"n",
@@ -421,7 +421,7 @@
   "notes":"",
   "notes_by_num":{
     "1":"Partial support in Firefox refers to being limited to context menus, not toolbar menus.",
-    "2":"Nested menus are not supported"
+    "2":"Can be enabled with the `dom.menuitem.enabled` preference in `about:config`."
   },
   "usage_perc_y":0,
   "usage_perc_a":3.94,


### PR DESCRIPTION
It was put behind a flag in version 85.
https://bugzilla.mozilla.org/show_bug.cgi?id=1680596

Also, nested items on Firefox for android were fixed when they moved from Fennec to Fenix and are now properly supported.
Can't find a source for that one and maybe it was even fixed by mistake but "it works".
![Screenshot_20201216-124720_Firefox Beta](https://user-images.githubusercontent.com/13397494/102338797-fb63c580-3f9c-11eb-9b11-ff12f1af590d.jpg)
