### PR TITLE
Firefox for Android does not support H264 from v68

### DIFF
--- a/features-json/mpeg4.json
+++ b/features-json/mpeg4.json
@@ -379,8 +379,10 @@
       "87":"y"
     },
     "and_ff":{
-      "67":"y"
-      "68":"n #2"
+      "1-16":"n",
+      "17-19":"a #2",
+      "20-67":"y",
+      "68-83":"n #3"
     },
     "ie_mob":{
       "10":"y",
@@ -414,7 +416,8 @@
   "notes":"Firefox supports H.264 on Windows 7 and later since version 21. Firefox supports H.264 on Linux since version 26 if the appropriate gstreamer plug-ins are installed.\r\n\r\nPartial support for older Firefox versions refers to the lack of support in OS X & some non-Android Linux platforms.",
   "notes_by_num":{
     "1":"The Android 2.3 browser requires [specific handling](https://www.broken-links.com/2010/07/08/making-html5-video-work-on-android-phones/) to play videos.",
-    "2":"From [MDN - Supported video codecs](https://developer.mozilla.org/en-US/docs/Web/Media/Formats/WebRTC_codecs#Supported_video_codecs): Firefox for Android 68 and later do not support AVC (H.264) anymore. This is due to a change in Google Play store requirements that prevent Firefox from downloading and installing the OpenH264 codec needed to handle H.264 in WebRTC connections. See [Mozilla Support article](https://support.mozilla.org/en-US/kb/firefox-android-openh264) for details."
+    "2":"No support for Gingerbread and Honeycomb devices. See [H.264 video in Firefox for Android](https://hacks.mozilla.org/2012/11/h264-video-in-firefox-for-android/).",
+    "3":"From [MDN - Supported video codecs](https://developer.mozilla.org/en-US/docs/Web/Media/Formats/WebRTC_codecs#Supported_video_codecs): Firefox for Android 68 and later do not support AVC (H.264) anymore. This is due to a change in Google Play store requirements that prevent Firefox from downloading and installing the OpenH264 codec needed to handle H.264 in WebRTC connections. See [Mozilla Support article](https://support.mozilla.org/en-US/kb/firefox-android-openh264) for details."
   },
   "usage_perc_y":96.44,
   "usage_perc_a":1.82,

--- a/features-json/mpeg4.json
+++ b/features-json/mpeg4.json
@@ -379,7 +379,8 @@
       "87":"y"
     },
     "and_ff":{
-      "83":"a #2"
+      "67":"y"
+      "68":"n #2"
     },
     "ie_mob":{
       "10":"y",
@@ -413,7 +414,7 @@
   "notes":"Firefox supports H.264 on Windows 7 and later since version 21. Firefox supports H.264 on Linux since version 26 if the appropriate gstreamer plug-ins are installed.\r\n\r\nPartial support for older Firefox versions refers to the lack of support in OS X & some non-Android Linux platforms.",
   "notes_by_num":{
     "1":"The Android 2.3 browser requires [specific handling](https://www.broken-links.com/2010/07/08/making-html5-video-work-on-android-phones/) to play videos.",
-    "2":"Partial supports refers to the lack of hardware acceleration."
+    "2":"From [MDN - Supported video codecs](https://developer.mozilla.org/en-US/docs/Web/Media/Formats/WebRTC_codecs#Supported_video_codecs): Firefox for Android 68 and later do not support AVC (H.264) anymore. This is due to a change in Google Play store requirements that prevent Firefox from downloading and installing the OpenH264 codec needed to handle H.264 in WebRTC connections. See [Mozilla Support article](https://support.mozilla.org/en-US/kb/firefox-android-openh264) for details."
   },
   "usage_perc_y":96.44,
   "usage_perc_a":1.82,

--- a/features-json/mpeg4.json
+++ b/features-json/mpeg4.json
@@ -379,10 +379,7 @@
       "87":"y"
     },
     "and_ff":{
-      "1-16":"n",
-      "17-19":"a #2",
-      "20-67":"y",
-      "68-83":"n #3"
+      "83":"n #2"
     },
     "ie_mob":{
       "10":"y",
@@ -416,8 +413,7 @@
   "notes":"Firefox supports H.264 on Windows 7 and later since version 21. Firefox supports H.264 on Linux since version 26 if the appropriate gstreamer plug-ins are installed.\r\n\r\nPartial support for older Firefox versions refers to the lack of support in OS X & some non-Android Linux platforms.",
   "notes_by_num":{
     "1":"The Android 2.3 browser requires [specific handling](https://www.broken-links.com/2010/07/08/making-html5-video-work-on-android-phones/) to play videos.",
-    "2":"No support for Gingerbread and Honeycomb devices. See [H.264 video in Firefox for Android](https://hacks.mozilla.org/2012/11/h264-video-in-firefox-for-android/).",
-    "3":"From [MDN - Supported video codecs](https://developer.mozilla.org/en-US/docs/Web/Media/Formats/WebRTC_codecs#Supported_video_codecs): Firefox for Android 68 and later do not support AVC (H.264) anymore. This is due to a change in Google Play store requirements that prevent Firefox from downloading and installing the OpenH264 codec needed to handle H.264 in WebRTC connections. See [Mozilla Support article](https://support.mozilla.org/en-US/kb/firefox-android-openh264) for details."
+    "2":"From [MDN - Supported video codecs](https://developer.mozilla.org/en-US/docs/Web/Media/Formats/WebRTC_codecs#Supported_video_codecs): Firefox for Android 68 and later do not support AVC (H.264) anymore. This is due to a change in Google Play store requirements that prevent Firefox from downloading and installing the OpenH264 codec needed to handle H.264 in WebRTC connections. See [Mozilla Support article](https://support.mozilla.org/en-US/kb/firefox-android-openh264) for details."
   },
   "usage_perc_y":96.44,
   "usage_perc_a":1.82,


### PR DESCRIPTION
Details are in the added note: "From [MDN - Supported video codecs](https://developer.mozilla.org/en-US/docs/Web/Media/Formats/WebRTC_codecs#Supported_video_codecs): Firefox for Android 68 and later do not support AVC (H.264) anymore. This is due to a change in Google Play store requirements that prevent Firefox from downloading and installing the OpenH264 codec needed to handle H.264 in WebRTC connections. See [Mozilla Support article](https://support.mozilla.org/en-US/kb/firefox-android-openh264) for details."