### PR TITLE
Clarify VP8/VP9/WebM status on Safari

### DIFF
--- a/features-json/webm.json
+++ b/features-json/webm.json
@@ -244,8 +244,8 @@
       "12.1":"a #4",
       "13":"a #4",
       "13.1":"a #4",
-      "14":"a #5",
-      "TP":"a #5"
+      "14":"a #4 #5 #6",
+      "TP":"a #4 #5 #6"
     },
     "opera":{
       "9":"n",
@@ -337,7 +337,7 @@
       "13.2":"a #4",
       "13.3":"a #4",
       "13.4-13.7":"a #4",
-      "14.0-14.2":"a #4"
+      "14.0-14.2":"a #4 #5"
     },
     "op_mini":{
       "all":"n"
@@ -407,8 +407,9 @@
     "1":"Older browser versions did not support all codecs.",
     "2":"Older Edge versions did not support progressive sources.",
     "3":"Can be enabled in Internet Explorer and Safari for MacOS by manually installing the codecs in the operating system.",
-    "4":"Safari only supports [VP8 used in WebRTC](https://webkit.org/blog/8672/on-the-road-to-webrtc-1-0-including-vp8/).",
-    "5":"Safari only supports [VP8 used in WebRTC](https://webkit.org/blog/8672/on-the-road-to-webrtc-1-0-including-vp8/) and [VP9 used in WebRTC](https://webkit.org/blog/10929/release-notes-for-safari-technology-preview-110/)."
+    "4":"Supports [VP8 codec used in WebRTC](https://webkit.org/blog/8672).",
+    "5":"Supports [VP9 codec used in WebRTC](https://webkit.org/blog/10929) (off by default.)",
+    "6":"Supports [VP9 WebM used in MediaSource](https://bugs.webkit.org/show_bug.cgi?id=216652#c1) on [macOS Big Sur or later.](https://trac.webkit.org/changeset/264747/webkit)"
   },
   "usage_perc_y":77.3,
   "usage_perc_a":18.28,


### PR DESCRIPTION
- Separated the duplicate portion of note 4 from note 5.
- Added note 5 to iOS Safari 14.
- Added off-by-default clause to note 5.
- Added note 6 for [VP9 + WebM + MediaSource](https://bugs.webkit.org/show_bug.cgi?id=216652#c1) support on Safari 14 + Big Sur.

Fixes #5713 as YouTube uses MediaSource/MSE for 4K HDR support [on Big Sur.](https://developer.apple.com/documentation/macos-release-notes/macos-big-sur-11_0_1-release-notes)