### PR TITLE
Change Firefox on Android to partial (bz#1573860)

### DIFF
--- a/features-json/same-site-cookie-attribute.json
+++ b/features-json/same-site-cookie-attribute.json
@@ -403,7 +403,8 @@
       "88":"y #3"
     },
     "and_ff":{
-      "83":"y"
+      "62-69":"y",
+      "79-85":"a #6"
     },
     "ie_mob":{
       "10":"n",
@@ -440,7 +441,8 @@
     "2":"Partial support because only supported in IE 11 on Windows 10 RS3 (2017 Fall Creators Update) and newer, but not in IE 11 on other Windows versions (Windows 7, ...)",
     "3":"Implemented [Incrementally Better Cookies](https://tools.ietf.org/html/draft-west-cookie-incrementalism-00) by default: Cookies without `SameSite` are treated as `Lax`, `SameSite=None` cookies without `Secure` are rejected.",
     "4":"Partial due to the lack of support in macOS before 10.14 Mojave.",
-    "5":"Partial due to [the bug](https://bugs.webkit.org/show_bug.cgi?id=198181) that treats `SameSite=None` and invalid values as `Strict` in macOS before 10.15 Catalina and in iOS before 13."
+    "5":"Partial due to [the bug](https://bugs.webkit.org/show_bug.cgi?id=198181) that treats `SameSite=None` and invalid values as `Strict` in macOS before 10.15 Catalina and in iOS before 13.",
+    "6":"Partial due to [the bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1573860) that doesn’t send `SameSite=Strict` cookies when navigating using the navigation/address field. [More info](https://www.ctrl.blog/entry/firefox-samesite-cookies-android.html)."
   },
   "usage_perc_y":86.97,
   "usage_perc_a":6.22,


### PR DESCRIPTION
https://www.ctrl.blog/entry/firefox-samesite-cookies-android.html
https://bugzilla.mozilla.org/show_bug.cgi?id=1573860

There was no releases between 69 and 79 due to the Fennec/Fenix transition. Not sure how to best represent this in the compatibility matrix. I didn’t find any examples of a Fenix-only bug.