### PR TITLE
webxr: add webkit id, move to in development

### DIFF
--- a/features-json/webxr.json
+++ b/features-json/webxr.json
@@ -422,6 +422,6 @@
   "ie_id":"",
   "chrome_id":"5680169905815552",
   "firefox_id":"webxr",
-  "webkit_id":"",
+  "webkit_id":"specification-webxr",
   "shown":true
 }


### PR DESCRIPTION
Despite no public announcements, the WebKit team is [working on WebXR](https://webkit.org/status/#specification-webxr) so it can be moved to "in-development".

Other random sources:
* [WebKit commits](https://github.com/WebKit/WebKit/search?o=desc&q=webxr&s=committer-date&type=commits)
* [WebKit bug tracker](https://bugs.webkit.org/show_bug.cgi?id=208988) (already linked in references)
