### PR TITLE
AVIF support in Firefox has been postponed

### DIFF
--- a/features-json/avif.json
+++ b/features-json/avif.json
@@ -146,7 +146,7 @@
       "83":"n d #1",
       "84":"n d #1",
       "85":"n d #1",
-      "86":"y #2",
+      "86":"n d #1",
       "87":"y #2"
     },
     "chrome":{
@@ -420,7 +420,7 @@
   },
   "notes":"",
   "notes_by_num":{
-    "1":"In Firefox 85 and older, still image support can be enabled via the `image.avif.enabled` flag in `about:config`",
+    "1":"Can be enabled in Firefox via the `image.avif.enabled` pref in `about:config`.",
     "2":"Only supports still images. AVIF sequences are not supported."
   },
   "usage_perc_y":24.88,


### PR DESCRIPTION
AVIF support enabled by default in Firefox has been backed out for now and is not shipping in version 86.0.

Sources:
* [info on the backout on Mozilla Bugzilla](https://bugzilla.mozilla.org/show_bug.cgi?id=1682995#c32)
* my own testing in Firefox 86.0 and 87.0 Beta 2