### PR TITLE
Firefox: image-set behind flag

### DIFF
--- a/features-json/css-image-set.json
+++ b/features-json/css-image-set.json
@@ -413,7 +413,7 @@
   "notes":"",
   "notes_by_num":{
     "1":"Safari's implementation does not completely match the spec, in that only URLs are accepted for the image value and only 'x' is accepted as a resolution. See https://bugs.webkit.org/show_bug.cgi?id=160934.",
-    "2":"Can be enabled using `layout.css.image-set`. Enabled by default in Nightly only."
+    "2":"Supported in Firefox behind the `layout.css.image-set.enabled` flag."
   },
   "usage_perc_y":92.21,
   "usage_perc_a":0,

--- a/features-json/css-image-set.json
+++ b/features-json/css-image-set.json
@@ -138,8 +138,8 @@
       "83":"n",
       "84":"n",
       "85":"n",
-      "86":"n",
-      "87":"n"
+      "86":"n d #2",
+      "87":"n d #2"
     },
     "chrome":{
       "4":"n",
@@ -412,7 +412,8 @@
   },
   "notes":"",
   "notes_by_num":{
-    "1":"Safari's implementation does not completely match the spec, in that only URLs are accepted for the image value and only 'x' is accepted as a resolution. See https://bugs.webkit.org/show_bug.cgi?id=160934."
+    "1":"Safari's implementation does not completely match the spec, in that only URLs are accepted for the image value and only 'x' is accepted as a resolution. See https://bugs.webkit.org/show_bug.cgi?id=160934.",
+    "2":"Can be enabled using `layout.css.image-set`. Enabled by default in Nightly only."
   },
   "usage_perc_y":92.21,
   "usage_perc_a":0,


### PR DESCRIPTION
Following the public discussion, e.g. https://github.com/Fyrd/caniuse/issues/5785#issuecomment-787945061, [this tweet](https://twitter.com/pepelsbey_/status/1366343635437047812) by @pepelsbey made me aware that image-set is available behind a flag.

And indeed (https://tests.caniuse.com/css-image-set):

![image](https://user-images.githubusercontent.com/2644614/109505523-f80cb000-7a9c-11eb-86a8-dff38fe90493.png)