### PR TITLE
Adds workflow file, to run validate against PRs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,15 @@
+name: main
+on:
+  - pull_request
+  - push
+jobs:
+  main:
+    name: validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "14"
+      - run: npm install
+      - run: npm run validate


### PR DESCRIPTION
Adds a GitHub Actions workflow file, to run `npm run validate` against Pull Requests.

Sample: https://github.com/kennethormandy/caniuse/runs/2017878290?check_suite_focus=true

I think there used to be CI on the repo, so you might have already decided against this. Feel free to close this if it’s not useful for you.