### PR TITLE
Edge 88: CSS Hyphenation not yet on par with Chrome

### DIFF
--- a/features-json/css-hyphens.json
+++ b/features-json/css-hyphens.json
@@ -53,7 +53,7 @@
       "85":"a #1",
       "86":"a #1",
       "87":"a #1",
-      "88":"y"
+      "88":"a #2"
     },
     "firefox":{
       "2":"n",
@@ -417,7 +417,8 @@
   },
   "notes":"Chrome < 55 and Android 4.0 Browser support \"-webkit-hyphens: none\", but not the \"auto\" property. It is [advisable to set the @lang attribute](http://blog.adrianroselli.com/2015/01/on-use-of-lang-attribute.html) on the HTML element to enable hyphenation support and improve accessibility.",
   "notes_by_num":{
-    "1":"Only supported on Android & Mac platforms (and only the \"auto\" value) for now. [See commit](https://crrev.com/ed7e106e0e48b3afb160a5bdbb37649e307d2b05) & related [bug](https://bugs.chromium.org/p/chromium/issues/detail?id=652964)."
+    "1":"Only supported on Android & Mac platforms (and only the \"auto\" value) for now. [See commit](https://crrev.com/ed7e106e0e48b3afb160a5bdbb37649e307d2b05) & related [bug](https://bugs.chromium.org/p/chromium/issues/detail?id=652964).",
+    "2":"Only supported on Android & Mac platforms"
   },
   "usage_perc_y":90.16,
   "usage_perc_a":6.35,


### PR DESCRIPTION
Fixes #5792.

<https://tests.caniuse.com/css-hyphens>:

macOS:

![image](https://user-images.githubusercontent.com/2644614/110028990-3bcd1700-7d34-11eb-919d-90071f59e940.png)

Android:

Edge for Android just wouldn't work in my emulator (Android Studio => AVD; Firefox and Chrome Canary are fine). My assumption is that the tests are completely green as well. But it would be really good if someone could test that before merging.

Win10 (EDIT: 89.0.774.45 is the same):

![image](https://user-images.githubusercontent.com/2644614/110029006-44255200-7d34-11eb-9b66-0b8f05c18412.png)

Haven't tested Linux though.

If we cant test Edge for Android I would change the PR so the previous state (`a #1`) is returned. Note 1 is a bit unfortunate because it only mentions Chrome. But at least that would be more accurate than `y`, because thats not true (see Win10).