### PR TITLE
Chrome: :dir() CSS pseudo-class is back to experimental

### DIFF
--- a/features-json/css-dir-pseudo.json
+++ b/features-json/css-dir-pseudo.json
@@ -242,8 +242,8 @@
       "88":"n",
       "89":"n",
       "90":"n",
-      "91":"y",
-      "92":"y"
+      "91":"n d #1",
+      "92":"n d #1"
     },
     "safari":{
       "3.1":"n",
@@ -427,7 +427,7 @@
   },
   "notes":"",
   "notes_by_num":{
-    
+    "1":"Can be enabled via the `#enable-experimental-web-platform-features` flag"
   },
   "usage_perc_y":3.92,
   "usage_perc_a":0,


### PR DESCRIPTION
<https://bugs.chromium.org/p/chromium/issues/detail?id=576815#c31>

> Flip CSSPseudoDir back to experimental

~~Haven't tested it yet, I suppose we have to wait for tomorrows build.~~

Yup: <https://tests.caniuse.com/css-dir-pseudo>

![image](https://user-images.githubusercontent.com/2644614/111629219-5a7de400-87f1-11eb-9385-be5220f308e5.png)

Also checked enabling the flag, which made it work again.