### PR TITLE
Add `<template>` to keywords of template

### DIFF
--- a/features-json/template.json
+++ b/features-json/template.json
@@ -426,7 +426,7 @@
   "usage_perc_a":0.34,
   "ucprefix":false,
   "parent":"",
-  "keywords":"webcomponents, template",
+  "keywords":"webcomponents, template, <template>",
   "ie_id":"templateelement",
   "chrome_id":"5207287069147136",
   "firefox_id":"html-templates",


### PR DESCRIPTION
Coming from <https://developer.mozilla.org/en-US/docs/Web/HTML/Element/template> I [searched for `<template>`](https://caniuse.com/?search=%3Ctemplate%3E) and found nothing, therefore add it to the keywords.

I found https://github.com/Fyrd/caniuse/blob/8f4d0acf750890359315e97829d8802e854fae12/features-json/html5semantic.json#L435 which made it look legit to add \<elements\> as keywords.