### PR TITLE
Update note for CSS "image-orientation" bug

### DIFF
--- a/features-json/css-image-orientation.json
+++ b/features-json/css-image-orientation.json
@@ -56,7 +56,7 @@
       "86":"y #2",
       "87":"y #2",
       "88":"y #2",
-      "89":"y #2"
+      "89":"y"
     },
     "firefox":{
       "2":"n",
@@ -234,10 +234,10 @@
       "86":"y #2",
       "87":"y #2",
       "88":"y #2",
-      "89":"y #2",
-      "90":"y #2",
-      "91":"y #2",
-      "92":"y #2"
+      "89":"y",
+      "90":"y",
+      "91":"y",
+      "92":"y"
     },
     "safari":{
       "3.1":"n",
@@ -422,7 +422,7 @@
   "notes":"Opening the image in a new tab in Chrome results in the image shown in the orientation according to the EXIF data.",
   "notes_by_num":{
     "1":"Partial support in iOS refers to the browser using EXIF data by default, though it does not actually support the property.",
-    "2":"Chrome/Edge has [a bug](https://bugs.chromium.org/p/chromium/issues/detail?id=1082669) where the browser is not maintaining the image\u2019s aspect ratio when `object-fit: cover` and `image-orientation: from-image` are used together."
+    "2":"Has [a bug](https://bugs.chromium.org/p/chromium/issues/detail?id=1082669) where the browser is not maintaining the image\u2019s aspect ratio when `object-fit: cover` and `image-orientation: from-image` are used together."
   },
   "usage_perc_y":88.29,
   "usage_perc_a":2.68,


### PR DESCRIPTION
The bug where an image’s aspect ratio is not maintained when
`object-fit: cover` and `image-orientation: from-image` are used
together is fixed with Chrome version 89.

See:
https://bugs.chromium.org/p/chromium/issues/detail?id=1082669