### PR TITLE
`image-set`: Add Chromium bug to unprefix `-webkit-image-set`

### DIFF
--- a/features-json/css-image-set.json
+++ b/features-json/css-image-set.json
@@ -15,6 +15,10 @@
     {
       "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=1107646",
       "title":"Firefox feature request bug"
+    },
+    {
+      "url":"https://bugs.chromium.org/p/chromium/issues/detail?id=630597",
+      "title":"Chromium bug to unprefix `-webkit-image-set`"
     }
   ],
   "bugs":[


### PR DESCRIPTION
Title 0:-)

For convenience: <https://bugs.chromium.org/p/chromium/issues/detail?id=630597>