### PR TITLE
Rename Public Key Pinning to HTTP Public Key Pinning

### DIFF
--- a/features-json/publickeypinning.json
+++ b/features-json/publickeypinning.json
@@ -1,6 +1,6 @@
 {
-  "title":"Public Key Pinning",
-  "description":"Declare that a website's HTTPS certificate should only be treated as valid if the public key is contained in a specified list to prevent MITM attacks that use valid CA-issued certificates.",
+  "title":"HTTP Public Key Pinning",
+  "description":"Declare that a website's HTTPS certificate should only be treated as valid if the public key is contained in a list specified over HTTP to prevent MITM attacks that use valid CA-issued certificates.",
   "spec":"https://tools.ietf.org/html/rfc7469",
   "status":"other",
   "links":[


### PR DESCRIPTION
There is a difference between Public Key Pinning and HTTP Public Key Pinning. Nearly all major browsers still support Public Key Pinning for pinning specific websites which are built into the browser.

Chrome's PKP list - https://chromium.googlesource.com/chromium/src/net/+/master/http/transport_security_state_static.pins
Firefox's PKP list - https://searchfox.org/mozilla-central/source/security/manager/tools/PreloadedHPKPins.json