### PR TITLE
SVG favicons: Add WebKit feature request bug

### DIFF
--- a/features-json/link-icon-svg.json
+++ b/features-json/link-icon-svg.json
@@ -19,6 +19,10 @@
     {
       "url":"https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/18357657/",
       "title":"Microsoft EdgeHTML issue tracker: Issue #18357657: Support SVG favicons"
+    },
+    {
+      "url":"https://bugs.webkit.org/show_bug.cgi?id=136059",
+      "title":"WebKit feature request bug"
     }
   ],
   "bugs":[


### PR DESCRIPTION
Coming from <https://evilmartians.com/chronicles/how-to-favicon-in-2021-six-files-that-fit-most-needs#safari-pinned-icon> I wanted to check Safari (thats why #5843 exists - as a side note, didn't really find a good replacement link) and searched quite a bit since surely there had to be an issue with WebKit.

There is <https://bugs.webkit.org/show_bug.cgi?id=136059>, but the TL;DR is

> So if you're looking for SVG favicon support in Safari, you'll need to file with Apple at developer.apple.com.

But I think it still has value to add that link to spare others the time to search.