### PR TITLE
CSS `clip-path`: Add Chromium & WebKit bugs for shapes in external SVGs

### DIFF
--- a/features-json/css-clip-path.json
+++ b/features-json/css-clip-path.json
@@ -15,6 +15,14 @@
     {
       "url":"http://lab.iamvdo.me/css-svg-masks",
       "title":"Visual test cases"
+    },
+    {
+      "url":"https://bugs.chromium.org/p/chromium/issues/detail?id=109212",
+      "title":"Chromium bug for shapes in external SVGs"
+    },
+    {
+      "url":"https://bugs.webkit.org/show_bug.cgi?id=104442",
+      "title":"WebKit bug for shapes in external SVGs"
     }
   ],
   "bugs":[


### PR DESCRIPTION
- https://bugs.chromium.org/p/chromium/issues/detail?id=109212
- https://bugs.webkit.org/show_bug.cgi?id=104442