### PR TITLE
Chrome does not support JPEG XL behind a runtime flag

### DIFF
--- a/features-json/jpegxl.json
+++ b/features-json/jpegxl.json
@@ -424,7 +424,7 @@
   },
   "notes":"",
   "notes_by_num":{
-    "1":"Can be enabled via the `enable-jxl` flag in `chrome://flags`"
+    "1":"Can experimentally be build with support for jxl decoding."
   },
   "usage_perc_y":0,
   "usage_perc_a":0,

--- a/features-json/jpegxl.json
+++ b/features-json/jpegxl.json
@@ -424,7 +424,7 @@
   },
   "notes":"",
   "notes_by_num":{
-    "1":"Can experimentally be build with support for jxl decoding."
+    "1":"Can experimentally be built with support for jxl decoding."
   },
   "usage_perc_y":0,
   "usage_perc_a":0,


### PR DESCRIPTION
This is a follow-up on #5846

Now that updated versions of Chrome 91 and 92 have been released, I tried to run them on Windows and Linux to check that they actually do support jxl decoding. Unfortunately, none of them expose the `enable-jxl` flag, which means the current note is wrong. I also tried to enable some other flags, like `enable-experimental-web-platform-features`, but nothing seems to enable jxl decoding.

I am far from an expert on building binaries, but I believe this is happening because Chrome needs to be built with the `ENABLE_JXL_DECODER` flag set before it is even possible to enable the flag in `chrome://flags`, and for whatever reason, the Chrome engineers decided not to turn that build flag on yet.

Building Chrome is a monumental task that requires a lot of technical knowledge, so I don't see any reason to bloat the note with specifics on which flags to set, especially when we haven't actually tested that it would work. Let me know if you disagree.