### PR TITLE
Chrome: JPEG XL back to being behind a flag

### DIFF
--- a/features-json/jpegxl.json
+++ b/features-json/jpegxl.json
@@ -428,7 +428,7 @@
   },
   "notes":"",
   "notes_by_num":{
-    "1":"Can experimentally be built with support for jxl decoding."
+    "1":"Can be enabled via the `enable-jxl` flag in `chrome://flags`."
   },
   "usage_perc_y":0,
   "usage_perc_a":0,


### PR DESCRIPTION
Follow up #5850 per @EwoutH's [comment](https://github.com/Fyrd/caniuse/pull/5850#issuecomment-825921645).

CC @atjn 