### PR TITLE
Update Safari Vorbis support

### DIFF
--- a/features-json/ogg-vorbis.json
+++ b/features-json/ogg-vorbis.json
@@ -251,8 +251,8 @@
       "13":"n",
       "13.1":"n",
       "14":"n",
-      "14.1":"n",
-      "TP":"n"
+      "14.1":"a #1",
+      "TP":"a #1"
     },
     "opera":{
       "9":"n",
@@ -416,7 +416,7 @@
   },
   "notes":"Support refers to this format's use in the `audio` element, not other conditions.",
   "notes_by_num":{
-    
+    "#1":"Partial due to the lack of Ogg container support, and being limited to macOS 11.3 or later."
   },
   "usage_perc_y":79.05,
   "usage_perc_a":0,


### PR DESCRIPTION
Related to #5873, Safari 14.1+ on macOS 11.3+ added Vorbis audio format support, without the .ogg support. 

Tested with `<audio controls src="https://upload.wikimedia.org/wikipedia/commons/2/22/Volcano_Lava_Sample.webm"></audio>`.

#### References
* https://webkit.org/blog/11648/new-webkit-features-in-safari-14-1/