### PR TITLE
Fix issues in 59b9ecd12cef9c72e40fb08df365eeb2c0ae4983

### DIFF
--- a/features-json/ogg-vorbis.json
+++ b/features-json/ogg-vorbis.json
@@ -416,7 +416,7 @@
   },
   "notes":"Support refers to this format's use in the `audio` element, not other conditions.",
   "notes_by_num":{
-    "0":"Partial due to the lack of Ogg container support, and being limited to macOS 11.3 or later."
+    "1":"Partial due to the lack of Ogg container support, and being limited to macOS 11.3 or later."
   },
   "usage_perc_y":79.05,
   "usage_perc_a":0,

--- a/features-json/transforms2d.json
+++ b/features-json/transforms2d.json
@@ -29,10 +29,6 @@
       "title":"WebPlatform Docs"
     },
     {
-      "url":"https://developer.microsoft.com/en-us/microsoft-edge/platform/status/supportcsstransformsonsvg/",
-      "title":"IE platform status (SVG)"
-    },
-    {
       "url":"https://developer.microsoft.com/en-us/microsoft-edge/status/supportcsstransformsonsvg/",
       "title":"Microsoft Edge Platform Status (SVG)"
     }

--- a/features-json/urlsearchparams.json
+++ b/features-json/urlsearchparams.json
@@ -13,10 +13,6 @@
       "title":"MDN Web Docs - URLSearchParams"
     },
     {
-      "url":"https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/8993198/",
-      "title":"Edge implementation bug"
-    },
-    {
       "url":"https://github.com/zloirock/core-js#url-and-urlsearchparams",
       "title":"Polyfill for this feature is available in the core-js library"
     },


### PR DESCRIPTION
Looks like a merge/rebase resulting in 59b9ecd12cef9c72e40fb08df365eeb2c0ae4983 went a bit sideways, i.a. returing old parts? 0:-)