### PR TITLE
Wayback Machine for every wpdev link + sprinkle HTTPS

### DIFF
--- a/features-json/apng.json
+++ b/features-json/apng.json
@@ -17,10 +17,6 @@
       "title":"Chrome extension providing support"
     },
     {
-      "url":"https://web.archive.org/web/20190820230354/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6513393-apng-animated-png-images-support-firefox-and-sa",
-      "title":"Microsoft Edge Legacy feature request on UserVoice (under review)"
-    },
-    {
       "url":"https://addons.opera.com/en/extensions/details/apng/?display=en",
       "title":"Opera extension providing support"
     },

--- a/features-json/apng.json
+++ b/features-json/apng.json
@@ -17,8 +17,8 @@
       "title":"Chrome extension providing support"
     },
     {
-      "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6513393-apng-animated-png-images-support-firefox-and-sa",
-      "title":"Microsoft Edge feature request on UserVoice (under review)"
+      "url":"https://web.archive.org/web/20190820230354/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6513393-apng-animated-png-images-support-firefox-and-sa",
+      "title":"Microsoft Edge Legacy feature request on UserVoice (under review)"
     },
     {
       "url":"https://addons.opera.com/en/extensions/details/apng/?display=en",

--- a/features-json/auxclick.json
+++ b/features-json/auxclick.json
@@ -19,10 +19,6 @@
     {
       "url":"https://wicg.github.io/auxclick/",
       "title":"Original Proposal"
-    },
-    {
-      "url":"https://web.archive.org/web/20190624214544/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/17997901-auxclick-event-for-non-primary-buttons",
-      "title":"Microsoft Edge Legacy feature request on UserVoice"
     }
   ],
   "bugs":[

--- a/features-json/auxclick.json
+++ b/features-json/auxclick.json
@@ -21,8 +21,8 @@
       "title":"Original Proposal"
     },
     {
-      "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/17997901-auxclick-event-for-non-primary-buttons",
-      "title":"Microsoft Edge feature request on UserVoice"
+      "url":"https://web.archive.org/web/20190624214544/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/17997901-auxclick-event-for-non-primary-buttons",
+      "title":"Microsoft Edge Legacy feature request on UserVoice"
     }
   ],
   "bugs":[

--- a/features-json/chacha20-poly1305.json
+++ b/features-json/chacha20-poly1305.json
@@ -11,10 +11,6 @@
     {
       "url":"https://www.ssllabs.com/ssltest/viewMyClient.html",
       "title":"SSL/TLS Capabilities of Your Browser by Qualys SSL Labs"
-    },
-    {
-      "url":"https://web.archive.org/web/20190624214238/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/12300414-support-chacha20-poly1305-cipher-suites-in-edge-sc",
-      "title":"Microsoft Edge Legacy feature request on UserVoice"
     }
   ],
   "bugs":[

--- a/features-json/chacha20-poly1305.json
+++ b/features-json/chacha20-poly1305.json
@@ -13,8 +13,8 @@
       "title":"SSL/TLS Capabilities of Your Browser by Qualys SSL Labs"
     },
     {
-      "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/12300414-support-chacha20-poly1305-cipher-suites-in-edge-sc",
-      "title":"Microsoft Edge feature request on UserVoice"
+      "url":"https://web.archive.org/web/20190624214238/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/12300414-support-chacha20-poly1305-cipher-suites-in-edge-sc",
+      "title":"Microsoft Edge Legacy feature request on UserVoice"
     }
   ],
   "bugs":[

--- a/features-json/client-hints-dpr-width-viewport.json
+++ b/features-json/client-hints-dpr-width-viewport.json
@@ -15,10 +15,6 @@
     {
       "url":"https://bugs.webkit.org/show_bug.cgi?id=145380",
       "title":"WebKit Bug 145380 - Add Content-DPR header support"
-    },
-    {
-      "url":"https://web.archive.org/web/20190624214443/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6261321-http-client-hints",
-      "title":"Microsoft Edge Legacy feature request on UserVoice"
     }
   ],
   "bugs":[

--- a/features-json/client-hints-dpr-width-viewport.json
+++ b/features-json/client-hints-dpr-width-viewport.json
@@ -17,8 +17,8 @@
       "title":"WebKit Bug 145380 - Add Content-DPR header support"
     },
     {
-      "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6261321-http-client-hints",
-      "title":"Microsoft Edge feature request on UserVoice"
+      "url":"https://web.archive.org/web/20190624214443/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6261321-http-client-hints",
+      "title":"Microsoft Edge Legacy feature request on UserVoice"
     }
   ],
   "bugs":[

--- a/features-json/constraint-validation.json
+++ b/features-json/constraint-validation.json
@@ -9,10 +9,6 @@
       "title":"MDN article on constraint validation"
     },
     {
-      "url":"https://web.archive.org/web/20190624214551/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/14744163-support-htmlformelement-reportvalidity",
-      "title":"Microsoft Edge Legacy feature request for reportValidity"
-    },
-    {
       "url":"https://github.com/jelmerdemaat/report-validity",
       "title":"`reportValidity()` ponyfill"
     }

--- a/features-json/constraint-validation.json
+++ b/features-json/constraint-validation.json
@@ -9,8 +9,8 @@
       "title":"MDN article on constraint validation"
     },
     {
-      "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/14744163-support-htmlformelement-reportvalidity",
-      "title":"MS Edge UserVoice request for reportValidity"
+      "url":"https://web.archive.org/web/20190624214551/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/14744163-support-htmlformelement-reportvalidity",
+      "title":"Microsoft Edge Legacy feature request for reportValidity"
     },
     {
       "url":"https://github.com/jelmerdemaat/report-validity",

--- a/features-json/css-all.json
+++ b/features-json/css-all.json
@@ -17,8 +17,8 @@
       "title":"WebKit bug 116966: [css3-cascade] Add support for `all` shorthand property"
     },
     {
-      "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6511510-all-initial",
-      "title":"Microsoft Edge feature request on UserVoice"
+      "url":"https://web.archive.org/web/20190624214440/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6511510-all-initial",
+      "title":"Microsoft Edge Legacy feature request on UserVoice"
     }
   ],
   "bugs":[

--- a/features-json/css-all.json
+++ b/features-json/css-all.json
@@ -15,10 +15,6 @@
     {
       "url":"https://bugs.webkit.org/show_bug.cgi?id=116966",
       "title":"WebKit bug 116966: [css3-cascade] Add support for `all` shorthand property"
-    },
-    {
-      "url":"https://web.archive.org/web/20190624214440/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6511510-all-initial",
-      "title":"Microsoft Edge Legacy feature request on UserVoice"
     }
   ],
   "bugs":[

--- a/features-json/css-backdrop-filter.json
+++ b/features-json/css-backdrop-filter.json
@@ -5,7 +5,7 @@
   "status":"unoff",
   "links":[
     {
-      "url":"http://product.voxmedia.com/til/2015/2/17/8053347/css-ios-transparency-with-webkit-backdrop-filter",
+      "url":"https://product.voxmedia.com/til/2015/2/17/8053347/css-ios-transparency-with-webkit-backdrop-filter",
       "title":"Blog post"
     },
     {
@@ -13,8 +13,8 @@
       "title":"MDN Web Docs - CSS backdrop filter"
     },
     {
-      "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/9160189-backdrop-filters",
-      "title":"Edge feature request"
+      "url":"https://web.archive.org/web/20190624214232/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/9160189-backdrop-filters",
+      "title":"Microsoft Edge Legacy feature request"
     },
     {
       "url":"https://bugs.webkit.org/show_bug.cgi?id=224899",

--- a/features-json/css-backdrop-filter.json
+++ b/features-json/css-backdrop-filter.json
@@ -13,10 +13,6 @@
       "title":"MDN Web Docs - CSS backdrop filter"
     },
     {
-      "url":"https://web.archive.org/web/20190624214232/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/9160189-backdrop-filters",
-      "title":"Microsoft Edge Legacy feature request"
-    },
-    {
       "url":"https://bugs.webkit.org/show_bug.cgi?id=224899",
       "title":"WebKit bug to unprefix `-webkit-backdrop-filter`"
     }

--- a/features-json/css-boxdecorationbreak.json
+++ b/features-json/css-boxdecorationbreak.json
@@ -13,10 +13,6 @@
       "title":"Demo of effect on box border"
     },
     {
-      "url":"https://web.archive.org/web/20190624214422/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6514472-box-decoration-break",
-      "title":"Microsoft Edge Legacy feature request on UserVoice"
-    },
-    {
       "url":"https://bugs.chromium.org/p/chromium/issues/detail?id=682224",
       "title":"Chromium bug to unprefix `-webkit-box-decoration-break`"
     }

--- a/features-json/css-boxdecorationbreak.json
+++ b/features-json/css-boxdecorationbreak.json
@@ -9,12 +9,12 @@
       "title":"MDN Web Docs - CSS box-decoration-break"
     },
     {
-      "url":"http://jsbin.com/xojoro/edit?css,output",
+      "url":"https://jsbin.com/xojoro/edit?css,output",
       "title":"Demo of effect on box border"
     },
     {
-      "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6514472-box-decoration-break",
-      "title":"Microsoft Edge feature request on UserVoice"
+      "url":"https://web.archive.org/web/20190624214422/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6514472-box-decoration-break",
+      "title":"Microsoft Edge Legacy feature request on UserVoice"
     },
     {
       "url":"https://bugs.chromium.org/p/chromium/issues/detail?id=682224",

--- a/features-json/css-caret-color.json
+++ b/features-json/css-caret-color.json
@@ -5,8 +5,8 @@
   "status":"cr",
   "links":[
     {
-      "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/17595823-implement-caret-color-support",
-      "title":"Edge UserVoice request for caret-color"
+      "url":"https://web.archive.org/web/20190624214557/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/17595823-implement-caret-color-support",
+      "title":"Microsoft Edge Legacy UserVoice request for caret-color"
     },
     {
       "url":"https://bugs.webkit.org/show_bug.cgi?id=166572",

--- a/features-json/css-caret-color.json
+++ b/features-json/css-caret-color.json
@@ -5,10 +5,6 @@
   "status":"cr",
   "links":[
     {
-      "url":"https://web.archive.org/web/20190624214557/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/17595823-implement-caret-color-support",
-      "title":"Microsoft Edge Legacy UserVoice request for caret-color"
-    },
-    {
       "url":"https://bugs.webkit.org/show_bug.cgi?id=166572",
       "title":"WebKit support bug"
     },

--- a/features-json/css-case-insensitive.json
+++ b/features-json/css-case-insensitive.json
@@ -9,12 +9,12 @@
       "title":"MDN Web Docs - CSS case-insensitive"
     },
     {
-      "url":"http://jsbin.com/zutuna/edit?html,css,output",
+      "url":"https://jsbin.com/zutuna/edit?html,css,output",
       "title":"JS Bin testcase"
     },
     {
-      "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/16910512-case-insensitive-attribute-selector-i-flag",
-      "title":"MS Edge feature request on UserVoice"
+      "url":"https://web.archive.org/web/20190624214507/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/16910512-case-insensitive-attribute-selector-i-flag",
+      "title":"Microsoft Edge Legacy feature request on UserVoice"
     }
   ],
   "bugs":[

--- a/features-json/css-case-insensitive.json
+++ b/features-json/css-case-insensitive.json
@@ -11,10 +11,6 @@
     {
       "url":"https://jsbin.com/zutuna/edit?html,css,output",
       "title":"JS Bin testcase"
-    },
-    {
-      "url":"https://web.archive.org/web/20190624214507/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/16910512-case-insensitive-attribute-selector-i-flag",
-      "title":"Microsoft Edge Legacy feature request on UserVoice"
     }
   ],
   "bugs":[

--- a/features-json/css-conic-gradients.json
+++ b/features-json/css-conic-gradients.json
@@ -13,8 +13,8 @@
       "title":"Server-side polyfill (PostCSS)"
     },
     {
-      "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/8471413-implement-conic-gradients-from-css-image-values-le",
-      "title":"Microsoft Edge feature request on UserVoice"
+      "url":"https://web.archive.org/web/20190624214554/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/8471413-implement-conic-gradients-from-css-image-values-le",
+      "title":"Microsoft Edge Legacy feature request on UserVoice"
     },
     {
       "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=1175958",

--- a/features-json/css-conic-gradients.json
+++ b/features-json/css-conic-gradients.json
@@ -13,10 +13,6 @@
       "title":"Server-side polyfill (PostCSS)"
     },
     {
-      "url":"https://web.archive.org/web/20190624214554/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/8471413-implement-conic-gradients-from-css-image-values-le",
-      "title":"Microsoft Edge Legacy feature request on UserVoice"
-    },
-    {
       "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=1175958",
       "title":"Mozilla bug #1175958: Implement conic gradients from CSS Image Values Level 4"
     },

--- a/features-json/css-default-pseudo.json
+++ b/features-json/css-default-pseudo.json
@@ -13,11 +13,11 @@
       "title":"MDN Web Docs - CSS :default"
     },
     {
-      "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/13311459--default-pseudo-class-from-selectors-level-4",
-      "title":"MS Edge feature request on UserVoice"
+      "url":"https://web.archive.org/web/20190624214509/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/13311459--default-pseudo-class-from-selectors-level-4",
+      "title":"Microsoft Edge Legacy feature request on UserVoice"
     },
     {
-      "url":"http://jsbin.com/hiyada/edit?html,css,output",
+      "url":"https://jsbin.com/hiyada/edit?html,css,output",
       "title":"JS Bin testcase"
     },
     {

--- a/features-json/css-default-pseudo.json
+++ b/features-json/css-default-pseudo.json
@@ -13,10 +13,6 @@
       "title":"MDN Web Docs - CSS :default"
     },
     {
-      "url":"https://web.archive.org/web/20190624214509/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/13311459--default-pseudo-class-from-selectors-level-4",
-      "title":"Microsoft Edge Legacy feature request on UserVoice"
-    },
-    {
       "url":"https://jsbin.com/hiyada/edit?html,css,output",
       "title":"JS Bin testcase"
     },

--- a/features-json/css-dir-pseudo.json
+++ b/features-json/css-dir-pseudo.json
@@ -17,15 +17,15 @@
       "title":"Chrome issue #576815: CSS4 pseudo-class :dir()"
     },
     {
-      "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/12299532--dir",
-      "title":"Microsoft Edge feature request on UserVoice"
+      "url":"https://web.archive.org/web/20190624214513/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/12299532--dir",
+      "title":"Microsoft Edge Legacy feature request on UserVoice"
     },
     {
       "url":"https://bugs.webkit.org/show_bug.cgi?id=64861",
       "title":"WebKit bug #64861: Need support for :dir() pseudo-class"
     },
     {
-      "url":"http://jsbin.com/celuye/edit?html,css,output",
+      "url":"https://jsbin.com/celuye/edit?html,css,output",
       "title":"JS Bin testcase"
     }
   ],

--- a/features-json/css-dir-pseudo.json
+++ b/features-json/css-dir-pseudo.json
@@ -17,10 +17,6 @@
       "title":"Chrome issue #576815: CSS4 pseudo-class :dir()"
     },
     {
-      "url":"https://web.archive.org/web/20190624214513/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/12299532--dir",
-      "title":"Microsoft Edge Legacy feature request on UserVoice"
-    },
-    {
       "url":"https://bugs.webkit.org/show_bug.cgi?id=64861",
       "title":"WebKit bug #64861: Need support for :dir() pseudo-class"
     },

--- a/features-json/css-display-contents.json
+++ b/features-json/css-display-contents.json
@@ -17,8 +17,8 @@
       "title":"WebKit support bug"
     },
     {
-      "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/10938981-implement-the-box-generation-keywords-from-css-dis",
-      "title":"Edge UserVoice support request"
+      "url":"https://web.archive.org/web/20190624214546/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/10938981-implement-the-box-generation-keywords-from-css-dis",
+      "title":"Microsoft Edge Legacy UserVoice support request"
     }
   ],
   "bugs":[

--- a/features-json/css-display-contents.json
+++ b/features-json/css-display-contents.json
@@ -15,10 +15,6 @@
     {
       "url":"https://bugs.webkit.org/show_bug.cgi?id=157477",
       "title":"WebKit support bug"
-    },
-    {
-      "url":"https://web.archive.org/web/20190624214546/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/10938981-implement-the-box-generation-keywords-from-css-dis",
-      "title":"Microsoft Edge Legacy UserVoice support request"
     }
   ],
   "bugs":[

--- a/features-json/css-env-function.json
+++ b/features-json/css-env-function.json
@@ -15,10 +15,6 @@
     {
       "url":"https://webkit.org/blog/7929/designing-websites-for-iphone-x/",
       "title":"Designing Websites for iPhone X - WebKit Blog"
-    },
-    {
-      "url":"https://web.archive.org/web/20190401105555/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/34589707-css-environment-variables",
-      "title":"Microsoft Edge Legacy feature suggestion"
     }
   ],
   "bugs":[

--- a/features-json/css-env-function.json
+++ b/features-json/css-env-function.json
@@ -17,8 +17,8 @@
       "title":"Designing Websites for iPhone X - WebKit Blog"
     },
     {
-      "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/34589707-css-environment-variables",
-      "title":"Microsoft Edge feature suggestion"
+      "url":"https://web.archive.org/web/20190401105555/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/34589707-css-environment-variables",
+      "title":"Microsoft Edge Legacy feature suggestion"
     }
   ],
   "bugs":[

--- a/features-json/css-focus-visible.json
+++ b/features-json/css-focus-visible.json
@@ -21,8 +21,8 @@
       "title":"Mozilla Developer Network (MDN) documentation - :-moz-focusring"
     },
     {
-      "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/19594159--focus-visible",
-      "title":"Microsoft Edge implementation suggestion"
+      "url":"https://web.archive.org/web/20190624214601/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/19594159--focus-visible",
+      "title":"Microsoft Edge Legacy implementation suggestion"
     },
     {
       "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=1437901",

--- a/features-json/css-focus-visible.json
+++ b/features-json/css-focus-visible.json
@@ -21,10 +21,6 @@
       "title":"Mozilla Developer Network (MDN) documentation - :-moz-focusring"
     },
     {
-      "url":"https://web.archive.org/web/20190624214601/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/19594159--focus-visible",
-      "title":"Microsoft Edge Legacy implementation suggestion"
-    },
-    {
       "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=1437901",
       "title":"Bugzilla: Add :focus-visible (former :focus-ring)"
     },

--- a/features-json/css-focus-within.json
+++ b/features-json/css-focus-within.json
@@ -9,12 +9,12 @@
       "title":"The Future Generation of CSS Selectors: Level 4: Generalized Input Focus Pseudo-class"
     },
     {
-      "url":"http://allyjs.io/api/style/focus-within.html",
+      "url":"https://allyjs.io/api/style/focus-within.html",
       "title":"ally.style.focusWithin Polyfill, part of ally.js"
     },
     {
-      "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/11725071-implement-focus-within-from-selectors-4",
-      "title":"Microsoft Edge feature request on UserVoice"
+      "url":"https://web.archive.org/web/20190624214516/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/11725071-implement-focus-within-from-selectors-4",
+      "title":"Microsoft Edge Legacy feature request on UserVoice"
     },
     {
       "url":"https://bugs.webkit.org/show_bug.cgi?id=140144",
@@ -29,7 +29,7 @@
       "title":"Mozilla bug #1176997: Add support for pseudo class `:focus-within`"
     },
     {
-      "url":"http://jsbin.com/qevoqa/edit?html,css,output",
+      "url":"https://jsbin.com/qevoqa/edit?html,css,output",
       "title":"JS Bin testcase"
     },
     {

--- a/features-json/css-focus-within.json
+++ b/features-json/css-focus-within.json
@@ -13,10 +13,6 @@
       "title":"ally.style.focusWithin Polyfill, part of ally.js"
     },
     {
-      "url":"https://web.archive.org/web/20190624214516/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/11725071-implement-focus-within-from-selectors-4",
-      "title":"Microsoft Edge Legacy feature request on UserVoice"
-    },
-    {
       "url":"https://bugs.webkit.org/show_bug.cgi?id=140144",
       "title":"WebKit bug #140144: Add support for CSS4 `:focus-within` pseudo"
     },

--- a/features-json/css-image-set.json
+++ b/features-json/css-image-set.json
@@ -19,10 +19,6 @@
     {
       "url":"https://bugs.webkit.org/show_bug.cgi?id=225185",
       "title":"WebKit bug to support type()"
-    },
-    {
-      "url":"https://web.archive.org/web/20190624214416/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6606738-image-set",
-      "title":"Microsoft Edge Legacy feature request on UserVoice"
     }
   ],
   "bugs":[

--- a/features-json/css-image-set.json
+++ b/features-json/css-image-set.json
@@ -19,6 +19,10 @@
     {
       "url":"https://bugs.webkit.org/show_bug.cgi?id=225185",
       "title":"WebKit bug to support type()"
+    },
+    {
+      "url":"https://web.archive.org/web/20190624214416/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6606738-image-set",
+      "title":"Microsoft Edge Legacy feature request on UserVoice"
     }
   ],
   "bugs":[

--- a/features-json/css-logical-props.json
+++ b/features-json/css-logical-props.json
@@ -13,8 +13,8 @@
       "title":"MDN Web Docs - CSS -moz-padding-start"
     },
     {
-      "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/7438435-css-logical-properties",
-      "title":"Microsoft Edge feature request on UserVoice"
+      "url":"https://web.archive.org/web/20190624214427/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/7438435-css-logical-properties",
+      "title":"Microsoft Edge Legacy feature request on UserVoice"
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Logical_Properties/Basic_concepts",

--- a/features-json/css-logical-props.json
+++ b/features-json/css-logical-props.json
@@ -13,10 +13,6 @@
       "title":"MDN Web Docs - CSS -moz-padding-start"
     },
     {
-      "url":"https://web.archive.org/web/20190624214427/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/7438435-css-logical-properties",
-      "title":"Microsoft Edge Legacy feature request on UserVoice"
-    },
-    {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Logical_Properties/Basic_concepts",
       "title":"MDN - Basic concepts of Logical Properties and Values"
     }

--- a/features-json/css-marker-pseudo.json
+++ b/features-json/css-marker-pseudo.json
@@ -17,10 +17,6 @@
       "title":"WebKit support bug"
     },
     {
-      "url":"https://web.archive.org/web/20190624214534/https://wpdev.uservoice.com/forums/257854-internet-explorer-platform/suggestions/7084750-css-3-marker-pseudo-element",
-      "title":"Microsoft Edge Legacy UserVoice request"
-    },
-    {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/::marker",
       "title":"MDN Web Docs - CSS ::marker"
     },

--- a/features-json/css-marker-pseudo.json
+++ b/features-json/css-marker-pseudo.json
@@ -17,8 +17,8 @@
       "title":"WebKit support bug"
     },
     {
-      "url":"https://wpdev.uservoice.com/forums/257854-internet-explorer-platform/suggestions/7084750-css-3-marker-pseudo-element",
-      "title":"Edge UserVoice request"
+      "url":"https://web.archive.org/web/20190624214534/https://wpdev.uservoice.com/forums/257854-internet-explorer-platform/suggestions/7084750-css-3-marker-pseudo-element",
+      "title":"Microsoft Edge Legacy UserVoice request"
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/::marker",

--- a/features-json/css-media-scripting.json
+++ b/features-json/css-media-scripting.json
@@ -19,10 +19,6 @@
     {
       "url":"https://www.quirksmode.org/css/mediaqueries/features.html#basicscripting",
       "title":"Basic testcase at quirksmode.org"
-    },
-    {
-      "url":"https://web.archive.org/web/20190625023759/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/8034771--scripting-media-query-feature",
-      "title":"Microsoft Edge Legacy feature request on UserVoice"
     }
   ],
   "bugs":[

--- a/features-json/css-media-scripting.json
+++ b/features-json/css-media-scripting.json
@@ -9,11 +9,11 @@
       "title":"Potential use cases for script, hover and pointer CSS Level 4 Media Features"
     },
     {
-      "url":"http://www.nczonline.net/blog/2012/01/04/proposal-scripting-detection-using-css-media-queries/",
+      "url":"https://www.nczonline.net/blog/2012/01/04/proposal-scripting-detection-using-css-media-queries/",
       "title":"Original proposal blog post"
     },
     {
-      "url":"http://jsbin.com/comefi/1",
+      "url":"https://jsbin.com/comefi/1",
       "title":"JS Bin testcase"
     },
     {
@@ -21,8 +21,8 @@
       "title":"Basic testcase at quirksmode.org"
     },
     {
-      "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/8034771--scripting-media-query-feature",
-      "title":"Microsoft Edge feature request on UserVoice"
+      "url":"https://web.archive.org/web/20190625023759/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/8034771--scripting-media-query-feature",
+      "title":"Microsoft Edge Legacy feature request on UserVoice"
     }
   ],
   "bugs":[

--- a/features-json/css-nth-child-of.json
+++ b/features-json/css-nth-child-of.json
@@ -13,8 +13,8 @@
       "title":"Chromium Issue 304163: Implement :nth-child(an+b of S) and :nth-last-child(an+b of S) pseudo-classes"
     },
     {
-      "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/15944476",
-      "title":"MS Edge feature request on UserVoice"
+      "url":"https://web.archive.org/web/20190624214457/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/15944476",
+      "title":"Microsoft Edge Legacy feature request on UserVoice"
     },
     {
       "url":"https://web.archive.org/web/20190401105447if_/https://developer.microsoft.com/en-us/microsoft-edge/platform/status/cssselectorslevel4/",

--- a/features-json/css-nth-child-of.json
+++ b/features-json/css-nth-child-of.json
@@ -13,10 +13,6 @@
       "title":"Chromium Issue 304163: Implement :nth-child(an+b of S) and :nth-last-child(an+b of S) pseudo-classes"
     },
     {
-      "url":"https://web.archive.org/web/20190624214457/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/15944476",
-      "title":"Microsoft Edge Legacy feature request on UserVoice"
-    },
-    {
       "url":"https://web.archive.org/web/20190401105447if_/https://developer.microsoft.com/en-us/microsoft-edge/platform/status/cssselectorslevel4/",
       "title":"MS Edge Platform Status: Under Consideration"
     }

--- a/features-json/css-overscroll-behavior.json
+++ b/features-json/css-overscroll-behavior.json
@@ -9,8 +9,8 @@
       "title":"Demo"
     },
     {
-      "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/32172871-implement-css-overscroll-behavior",
-      "title":"UserVoice support request for Edge"
+      "url":"https://web.archive.org/web/20190624214559/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/32172871-implement-css-overscroll-behavior",
+      "title":"Microsoft Edge Legacy UserVoice support request"
     },
     {
       "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=951793#c11",

--- a/features-json/css-overscroll-behavior.json
+++ b/features-json/css-overscroll-behavior.json
@@ -9,10 +9,6 @@
       "title":"Demo"
     },
     {
-      "url":"https://web.archive.org/web/20190624214559/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/32172871-implement-css-overscroll-behavior",
-      "title":"Microsoft Edge Legacy UserVoice support request"
-    },
-    {
       "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=951793#c11",
       "title":"Firefox implementation bug"
     },

--- a/features-json/css-paged-media.json
+++ b/features-json/css-paged-media.json
@@ -19,10 +19,6 @@
     {
       "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=286443",
       "title":"Firefox support bug"
-    },
-    {
-      "url":"https://web.archive.org/web/20190624214530/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/12839052-css-paged-media-module-level-3",
-      "title":"Microsoft Edge Legacy support request"
     }
   ],
   "bugs":[

--- a/features-json/css-paged-media.json
+++ b/features-json/css-paged-media.json
@@ -21,8 +21,8 @@
       "title":"Firefox support bug"
     },
     {
-      "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/12839052-css-paged-media-module-level-3",
-      "title":"Edge support request"
+      "url":"https://web.archive.org/web/20190624214530/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/12839052-css-paged-media-module-level-3",
+      "title":"Microsoft Edge Legacy support request"
     }
   ],
   "bugs":[

--- a/features-json/css-placeholder-shown.json
+++ b/features-json/css-placeholder-shown.json
@@ -5,7 +5,7 @@
   "status":"wd",
   "links":[
     {
-      "url":"http://trac.webkit.org/changeset/172826",
+      "url":"https://trac.webkit.org/changeset/172826",
       "title":"WebKit commit"
     },
     {
@@ -13,8 +13,8 @@
       "title":"Firefox bug"
     },
     {
-      "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/12435951--placeholder-shown-css-pseudo-class",
-      "title":"Microsoft Edge feature request on UserVoice"
+      "url":"https://web.archive.org/web/20190624214425/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/12435951--placeholder-shown-css-pseudo-class",
+      "title":"Microsoft Edge Legacy feature request on UserVoice"
     }
   ],
   "bugs":[

--- a/features-json/css-placeholder-shown.json
+++ b/features-json/css-placeholder-shown.json
@@ -11,10 +11,6 @@
     {
       "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=1069015",
       "title":"Firefox bug"
-    },
-    {
-      "url":"https://web.archive.org/web/20190624214425/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/12435951--placeholder-shown-css-pseudo-class",
-      "title":"Microsoft Edge Legacy feature request on UserVoice"
     }
   ],
   "bugs":[

--- a/features-json/css-reflections.json
+++ b/features-json/css-reflections.json
@@ -1,16 +1,16 @@
 {
   "title":"CSS Reflections",
   "description":"Method of displaying a reflection of an element",
-  "spec":"http://webkit.org/blog/182/css-reflections/",
+  "spec":"https://webkit.org/blog/182/css-reflections/",
   "status":"unoff",
   "links":[
     {
-      "url":"http://webkit.org/blog/182/css-reflections/",
+      "url":"https://webkit.org/blog/182/css-reflections/",
       "title":"WebKit blog post"
     },
     {
-      "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/7930470-support-css-reflections",
-      "title":"Microsoft Edge feature request on UserVoice"
+      "url":"https://web.archive.org/web/20190624214158/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/7930470-support-css-reflections",
+      "title":"Microsoft Edge Legacy feature request on UserVoice"
     }
   ],
   "bugs":[

--- a/features-json/css-reflections.json
+++ b/features-json/css-reflections.json
@@ -7,10 +7,6 @@
     {
       "url":"https://webkit.org/blog/182/css-reflections/",
       "title":"WebKit blog post"
-    },
-    {
-      "url":"https://web.archive.org/web/20190624214158/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/7930470-support-css-reflections",
-      "title":"Microsoft Edge Legacy feature request on UserVoice"
     }
   ],
   "bugs":[

--- a/features-json/css-resize.json
+++ b/features-json/css-resize.json
@@ -13,10 +13,6 @@
       "title":"On textarea resizing"
     },
     {
-      "url":"https://web.archive.org/web/20190624214251/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6513977-css-resize-property",
-      "title":"Microsoft Edge Legacy feature request on UserVoice"
-    },
-    {
       "url":"https://catalin.red/css-resize-none-is-bad-for-ux/",
       "title":"CSS resize none on textarea is bad for UX"
     }

--- a/features-json/css-resize.json
+++ b/features-json/css-resize.json
@@ -13,8 +13,8 @@
       "title":"On textarea resizing"
     },
     {
-      "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6513977-css-resize-property",
-      "title":"Microsoft Edge feature request on UserVoice"
+      "url":"https://web.archive.org/web/20190624214251/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6513977-css-resize-property",
+      "title":"Microsoft Edge Legacy feature request on UserVoice"
     },
     {
       "url":"https://catalin.red/css-resize-none-is-bad-for-ux/",

--- a/features-json/css-revert-value.json
+++ b/features-json/css-revert-value.json
@@ -13,8 +13,8 @@
       "title":"Firefox feature request bug"
     },
     {
-      "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/10469316-the-css4-revert-value",
-      "title":"Microsoft Edge feature request on UserVoice"
+      "url":"https://web.archive.org/web/20190624214454/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/10469316-the-css4-revert-value",
+      "title":"Microsoft Edge Legacy feature request on UserVoice"
     },
     {
       "url":"https://code.google.com/p/chromium/issues/detail?id=579788",

--- a/features-json/css-revert-value.json
+++ b/features-json/css-revert-value.json
@@ -13,10 +13,6 @@
       "title":"Firefox feature request bug"
     },
     {
-      "url":"https://web.archive.org/web/20190624214454/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/10469316-the-css4-revert-value",
-      "title":"Microsoft Edge Legacy feature request on UserVoice"
-    },
-    {
       "url":"https://code.google.com/p/chromium/issues/detail?id=579788",
       "title":"Chrome feature request issue"
     }

--- a/features-json/css-rrggbbaa.json
+++ b/features-json/css-rrggbbaa.json
@@ -5,12 +5,12 @@
   "status":"unoff",
   "links":[
     {
-      "url":"http://jsbin.com/ruyetahatu/edit?html,css,output",
+      "url":"https://jsbin.com/ruyetahatu/edit?html,css,output",
       "title":"JS Bin testcase"
     },
     {
-      "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/17366608--rrggbbaa-and-rgba-color-notation-support",
-      "title":"Edge support request for rrggbbaa"
+      "url":"https://web.archive.org/web/20190624214539/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/17366608--rrggbbaa-and-rgba-color-notation-support",
+      "title":"Microsoft Edge Legacy support request for rrggbbaa"
     }
   ],
   "bugs":[

--- a/features-json/css-rrggbbaa.json
+++ b/features-json/css-rrggbbaa.json
@@ -7,10 +7,6 @@
     {
       "url":"https://jsbin.com/ruyetahatu/edit?html,css,output",
       "title":"JS Bin testcase"
-    },
-    {
-      "url":"https://web.archive.org/web/20190624214539/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/17366608--rrggbbaa-and-rgba-color-notation-support",
-      "title":"Microsoft Edge Legacy support request for rrggbbaa"
     }
   ],
   "bugs":[

--- a/features-json/css3-attr.json
+++ b/features-json/css3-attr.json
@@ -9,8 +9,8 @@
       "title":"MDN Web Docs - CSS attr"
     },
     {
-      "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/7671960-css-attr-as-defined-in-css-values-level-3",
-      "title":"Microsoft Edge feature request on UserVoice"
+      "url":"https://web.archive.org/web/20190624214521/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/7671960-css-attr-as-defined-in-css-values-level-3",
+      "title":"Microsoft Edge Legacy feature request on UserVoice"
     },
     {
       "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=435426",

--- a/features-json/css3-attr.json
+++ b/features-json/css3-attr.json
@@ -9,10 +9,6 @@
       "title":"MDN Web Docs - CSS attr"
     },
     {
-      "url":"https://web.archive.org/web/20190624214521/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/7671960-css-attr-as-defined-in-css-values-level-3",
-      "title":"Microsoft Edge Legacy feature request on UserVoice"
-    },
-    {
       "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=435426",
       "title":"Mozilla Bug #435426: implement css3-values extensions to `attr()`"
     },

--- a/features-json/css3-tabsize.json
+++ b/features-json/css3-tabsize.json
@@ -9,10 +9,6 @@
       "title":"MDN Web Docs - CSS tab-size"
     },
     {
-      "url":"https://web.archive.org/web/20190624214334/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6524689-tab-size-property",
-      "title":"Microsoft Edge Legacy feature request on UserVoice"
-    },
-    {
       "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=737785",
       "title":"Firefox bug to unprefix `-moz-tab-size`"
     }

--- a/features-json/css3-tabsize.json
+++ b/features-json/css3-tabsize.json
@@ -9,8 +9,8 @@
       "title":"MDN Web Docs - CSS tab-size"
     },
     {
-      "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6524689-tab-size-property",
-      "title":"Microsoft Edge feature request on UserVoice"
+      "url":"https://web.archive.org/web/20190624214334/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6524689-tab-size-property",
+      "title":"Microsoft Edge Legacy feature request on UserVoice"
     },
     {
       "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=737785",

--- a/features-json/dataset.json
+++ b/features-json/dataset.json
@@ -5,7 +5,7 @@
   "status":"ls",
   "links":[
     {
-      "url":"http://html5doctor.com/html5-custom-data-attributes/",
+      "url":"https://html5doctor.com/html5-custom-data-attributes/",
       "title":"HTML5 Doctor article"
     },
     {
@@ -29,8 +29,8 @@
       "title":"MDN Guide - Using data-* attributes"
     },
     {
-      "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/15885483-support-dataset-and-data-attributes-on-svg-element",
-      "title":"MS Edge UserVoice #15885483: Support dataset and data attributes on SVG elements"
+      "url":"https://web.archive.org/web/20190624214240/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/15885483-support-dataset-and-data-attributes-on-svg-element",
+      "title":"Microsoft Edge Legacy UserVoice #15885483: Support dataset and data attributes on SVG elements"
     }
   ],
   "bugs":[

--- a/features-json/dataset.json
+++ b/features-json/dataset.json
@@ -27,10 +27,6 @@
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Using_data_attributes",
       "title":"MDN Guide - Using data-* attributes"
-    },
-    {
-      "url":"https://web.archive.org/web/20190624214240/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/15885483-support-dataset-and-data-attributes-on-svg-element",
-      "title":"Microsoft Edge Legacy UserVoice #15885483: Support dataset and data attributes on SVG elements"
     }
   ],
   "bugs":[

--- a/features-json/dom-manip-convenience.json
+++ b/features-json/dom-manip-convenience.json
@@ -25,10 +25,6 @@
       "title":"MDN Web Docs - ChildNode"
     },
     {
-      "url":"https://web.archive.org/web/20190624214518/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/16036408",
-      "title":"Microsoft Edge Legacy feature request on UserVoice"
-    },
-    {
       "url":"https://github.com/WebReflection/dom4",
       "title":"DOM4 polyfill"
     }

--- a/features-json/dom-manip-convenience.json
+++ b/features-json/dom-manip-convenience.json
@@ -13,7 +13,7 @@
       "title":"WHATWG DOM Specification for ParentNode"
     },
     {
-      "url":"http://jsbin.com/fiqacod/edit?html,js,output",
+      "url":"https://jsbin.com/fiqacod/edit?html,js,output",
       "title":"JS Bin testcase"
     },
     {
@@ -25,8 +25,8 @@
       "title":"MDN Web Docs - ChildNode"
     },
     {
-      "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/16036408",
-      "title":"MS Edge feature request on UserVoice"
+      "url":"https://web.archive.org/web/20190624214518/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/16036408",
+      "title":"Microsoft Edge Legacy feature request on UserVoice"
     },
     {
       "url":"https://github.com/WebReflection/dom4",

--- a/features-json/dragndrop.json
+++ b/features-json/dragndrop.json
@@ -5,11 +5,11 @@
   "status":"ls",
   "links":[
     {
-      "url":"http://html5doctor.com/native-drag-and-drop/",
+      "url":"https://html5doctor.com/native-drag-and-drop/",
       "title":"HTML5 Doctor article"
     },
     {
-      "url":"http://nettutsplus.s3.amazonaws.com/64_html5dragdrop/demo/index.html",
+      "url":"https://nettutsplus.s3.amazonaws.com/64_html5dragdrop/demo/index.html",
       "title":"Shopping cart demo"
     },
     {
@@ -33,8 +33,8 @@
       "title":"iOS/Android shim for HTML 5 drag'n'drop"
     },
     {
-      "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6542268-setdragimage-on-datatransfer-of-dragevent",
-      "title":"Microsoft Edge setDragImage feature request on UserVoice"
+      "url":"https://web.archive.org/web/20190624214156/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6542268-setdragimage-on-datatransfer-of-dragevent",
+      "title":"Microsoft Edge Legacy setDragImage feature request on UserVoice"
     }
   ],
   "bugs":[

--- a/features-json/dragndrop.json
+++ b/features-json/dragndrop.json
@@ -31,10 +31,6 @@
     {
       "url":"https://github.com/timruffles/ios-html5-drag-drop-shim",
       "title":"iOS/Android shim for HTML 5 drag'n'drop"
-    },
-    {
-      "url":"https://web.archive.org/web/20190624214156/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6542268-setdragimage-on-datatransfer-of-dragevent",
-      "title":"Microsoft Edge Legacy setDragImage feature request on UserVoice"
     }
   ],
   "bugs":[

--- a/features-json/element-closest.json
+++ b/features-json/element-closest.json
@@ -11,10 +11,6 @@
     {
       "url":"https://github.com/jonathantneal/closest",
       "title":"Polyfill"
-    },
-    {
-      "url":"https://web.archive.org/web/20190624214446/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/10119510-element-closest",
-      "title":"Microsoft Edge Legacy feature request on UserVoice"
     }
   ],
   "bugs":[

--- a/features-json/element-closest.json
+++ b/features-json/element-closest.json
@@ -13,8 +13,8 @@
       "title":"Polyfill"
     },
     {
-      "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/10119510-element-closest",
-      "title":"Microsoft Edge feature request on UserVoice"
+      "url":"https://web.archive.org/web/20190624214446/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/10119510-element-closest",
+      "title":"Microsoft Edge Legacy feature request on UserVoice"
     }
   ],
   "bugs":[

--- a/features-json/feature-policy.json
+++ b/features-json/feature-policy.json
@@ -21,8 +21,8 @@
       "title":"Feature Policy Tester (Chrome DevTools Extension)"
     },
     {
-      "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/33507907-support-feature-policy",
-      "title":"MS Edge feature suggestion"
+      "url":"https://web.archive.org/web/20190401103040/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/33507907-support-feature-policy",
+      "title":"Microsoft Edge Legacy feature suggestion"
     },
     {
       "url":"https://featurepolicy.info/",

--- a/features-json/feature-policy.json
+++ b/features-json/feature-policy.json
@@ -21,10 +21,6 @@
       "title":"Feature Policy Tester (Chrome DevTools Extension)"
     },
     {
-      "url":"https://web.archive.org/web/20190401103040/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/33507907-support-feature-policy",
-      "title":"Microsoft Edge Legacy feature suggestion"
-    },
-    {
       "url":"https://featurepolicy.info/",
       "title":"featurepolicy.info (Feature-Policy Playground)"
     },

--- a/features-json/flac.json
+++ b/features-json/flac.json
@@ -11,10 +11,6 @@
     {
       "url":"https://bugs.chromium.org/p/chromium/issues/detail?id=93887",
       "title":"Chrome support bug"
-    },
-    {
-      "url":"https://web.archive.org/web/20190624214452/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/15601752-support-flac",
-      "title":"Microsoft Edge Legacy UserVoice request"
     }
   ],
   "bugs":[

--- a/features-json/flac.json
+++ b/features-json/flac.json
@@ -13,8 +13,8 @@
       "title":"Chrome support bug"
     },
     {
-      "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/15601752-support-flac",
-      "title":"Edge UserVoice request"
+      "url":"https://web.archive.org/web/20190624214452/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/15601752-support-flac",
+      "title":"Microsoft Edge Legacy UserVoice request"
     }
   ],
   "bugs":[

--- a/features-json/flow-root.json
+++ b/features-json/flow-root.json
@@ -17,10 +17,6 @@
       "title":"WebKit bug report"
     },
     {
-      "url":"https://web.archive.org/web/20190624214536/https://wpdev.uservoice.com/forums/257854/suggestions/17420707",
-      "title":"Microsoft Edge Legacy bug report"
-    },
-    {
       "url":"https://rachelandrew.co.uk/archives/2017/01/24/the-end-of-the-clearfix-hack/",
       "title":"Blog post: \"The end of the clearfix hack?\""
     }

--- a/features-json/flow-root.json
+++ b/features-json/flow-root.json
@@ -17,8 +17,8 @@
       "title":"WebKit bug report"
     },
     {
-      "url":"https://wpdev.uservoice.com/forums/257854/suggestions/17420707",
-      "title":"Edge bug report"
+      "url":"https://web.archive.org/web/20190624214536/https://wpdev.uservoice.com/forums/257854/suggestions/17420707",
+      "title":"Microsoft Edge Legacy bug report"
     },
     {
       "url":"https://rachelandrew.co.uk/archives/2017/01/24/the-end-of-the-clearfix-hack/",

--- a/features-json/font-loading.json
+++ b/features-json/font-loading.json
@@ -7,10 +7,6 @@
     {
       "url":"https://www.igvita.com/2014/01/31/optimizing-web-font-rendering-performance/#font-load-events",
       "title":"Optimizing with font load events"
-    },
-    {
-      "url":"https://web.archive.org/web/20190624214354/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6509785-css-font-loading",
-      "title":"Microsoft Edge Legacy feature request on UserVoice"
     }
   ],
   "bugs":[

--- a/features-json/font-loading.json
+++ b/features-json/font-loading.json
@@ -9,8 +9,8 @@
       "title":"Optimizing with font load events"
     },
     {
-      "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6509785-css-font-loading",
-      "title":"Microsoft Edge feature request on UserVoice"
+      "url":"https://web.archive.org/web/20190624214354/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6509785-css-font-loading",
+      "title":"Microsoft Edge Legacy feature request on UserVoice"
     }
   ],
   "bugs":[

--- a/features-json/font-size-adjust.json
+++ b/features-json/font-size-adjust.json
@@ -11,10 +11,6 @@
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/font-size-adjust",
       "title":"MDN Web Docs - CSS font-size-adjust"
-    },
-    {
-      "url":"https://web.archive.org/web/20190624214411/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6514821-font-size-adjust-other-font-properties",
-      "title":"Microsoft Edge Legacy feature request on UserVoice"
     }
   ],
   "bugs":[

--- a/features-json/font-size-adjust.json
+++ b/features-json/font-size-adjust.json
@@ -5,7 +5,7 @@
   "status":"cr",
   "links":[
     {
-      "url":"http://webdesignernotebook.com/css/the-little-known-font-size-adjust-css3-property/",
+      "url":"https://webdesignernotebook.com/css/the-little-known-font-size-adjust-css3-property/",
       "title":"Article on font-size-adjust"
     },
     {
@@ -13,8 +13,8 @@
       "title":"MDN Web Docs - CSS font-size-adjust"
     },
     {
-      "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6514821-font-size-adjust-other-font-properties",
-      "title":"Microsoft Edge feature request on UserVoice"
+      "url":"https://web.archive.org/web/20190624214411/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6514821-font-size-adjust-other-font-properties",
+      "title":"Microsoft Edge Legacy feature request on UserVoice"
     }
   ],
   "bugs":[

--- a/features-json/font-unicode-range.json
+++ b/features-json/font-unicode-range.json
@@ -19,10 +19,6 @@
     {
       "url":"https://jsbin.com/jeqoguzeye/1/edit?html,output",
       "title":"Demo"
-    },
-    {
-      "url":"https://web.archive.org/web/20190624214358/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6510254-unicode-range",
-      "title":"Microsoft Edge Legacy feature request on UserVoice"
     }
   ],
   "bugs":[

--- a/features-json/font-unicode-range.json
+++ b/features-json/font-unicode-range.json
@@ -17,12 +17,12 @@
       "title":"Web Platform Docs: unicode-range"
     },
     {
-      "url":"http://jsbin.com/jeqoguzeye/1/edit?html,output",
+      "url":"https://jsbin.com/jeqoguzeye/1/edit?html,output",
       "title":"Demo"
     },
     {
-      "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6510254-unicode-range",
-      "title":"Microsoft Edge feature request on UserVoice"
+      "url":"https://web.archive.org/web/20190624214358/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6510254-unicode-range",
+      "title":"Microsoft Edge Legacy feature request on UserVoice"
     }
   ],
   "bugs":[

--- a/features-json/form-attribute.json
+++ b/features-json/form-attribute.json
@@ -9,12 +9,12 @@
       "title":"Input attribute specification"
     },
     {
-      "url":"http://www.impressivewebs.com/html5-form-attribute/",
+      "url":"https://www.impressivewebs.com/html5-form-attribute/",
       "title":"Article on usage"
     },
     {
-      "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/7327649-add-support-for-the-form-attribute",
-      "title":"Microsoft Edge feature request on UserVoice"
+      "url":"https://web.archive.org/web/20190624214432/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/7327649-add-support-for-the-form-attribute",
+      "title":"Microsoft Edge Legacy feature request on UserVoice"
     }
   ],
   "bugs":[

--- a/features-json/form-attribute.json
+++ b/features-json/form-attribute.json
@@ -11,10 +11,6 @@
     {
       "url":"https://www.impressivewebs.com/html5-form-attribute/",
       "title":"Article on usage"
-    },
-    {
-      "url":"https://web.archive.org/web/20190624214432/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/7327649-add-support-for-the-form-attribute",
-      "title":"Microsoft Edge Legacy feature request on UserVoice"
     }
   ],
   "bugs":[

--- a/features-json/hevc.json
+++ b/features-json/hevc.json
@@ -13,8 +13,8 @@
       "title":"Wikipedia article"
     },
     {
-      "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/10311075-hevc-support",
-      "title":"UserVoice support request for Edge"
+      "url":"https://web.archive.org/web/20190624214549/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/10311075-hevc-support",
+      "title":"Microsoft Edge Legacy UserVoice support request"
     },
     {
       "url":"https://bugs.chromium.org/p/chromium/issues/detail?id=684382",

--- a/features-json/hevc.json
+++ b/features-json/hevc.json
@@ -13,10 +13,6 @@
       "title":"Wikipedia article"
     },
     {
-      "url":"https://web.archive.org/web/20190624214549/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/10311075-hevc-support",
-      "title":"Microsoft Edge Legacy UserVoice support request"
-    },
-    {
       "url":"https://bugs.chromium.org/p/chromium/issues/detail?id=684382",
       "title":"Chrome support bug (WontFix)"
     }

--- a/features-json/iframe-seamless.json
+++ b/features-json/iframe-seamless.json
@@ -15,10 +15,6 @@
     {
       "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=631218",
       "title":"Bug on Firefox support: wontfix"
-    },
-    {
-      "url":"https://web.archive.org/web/20190624214347/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6261330-iframe-seamless-attribute",
-      "title":"Microsoft Edge Legacy Developer UserVoice: No plans"
     }
   ],
   "bugs":[

--- a/features-json/iframe-seamless.json
+++ b/features-json/iframe-seamless.json
@@ -9,7 +9,7 @@
       "title":"Experimental polyfill"
     },
     {
-      "url":"http://labs.ft.com/2013/01/seamless-iframes-not-quite-seamless/",
+      "url":"https://labs.ft.com/2013/01/seamless-iframes-not-quite-seamless/",
       "title":"Article"
     },
     {
@@ -17,8 +17,8 @@
       "title":"Bug on Firefox support: wontfix"
     },
     {
-      "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6261330-iframe-seamless-attribute",
-      "title":"Microsoft Edge Developer UserVoice: No plans"
+      "url":"https://web.archive.org/web/20190624214347/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6261330-iframe-seamless-attribute",
+      "title":"Microsoft Edge Legacy Developer UserVoice: No plans"
     }
   ],
   "bugs":[

--- a/features-json/input-color.json
+++ b/features-json/input-color.json
@@ -17,10 +17,6 @@
       "title":"WebPlatform Docs"
     },
     {
-      "url":"https://web.archive.org/web/20190624214248/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6514216--input-type-color",
-      "title":"Microsoft Edge Legacy feature request on UserVoice"
-    },
-    {
       "url":"https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/color",
       "title":"MDN web docs"
     },

--- a/features-json/input-color.json
+++ b/features-json/input-color.json
@@ -5,7 +5,7 @@
   "status":"ls",
   "links":[
     {
-      "url":"http://www.html5tutorial.info/html5-color.php",
+      "url":"https://www.html5tutorial.info/html5-color.php",
       "title":"Tutorial"
     },
     {
@@ -17,8 +17,8 @@
       "title":"WebPlatform Docs"
     },
     {
-      "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6514216--input-type-color",
-      "title":"Microsoft Edge feature request on UserVoice"
+      "url":"https://web.archive.org/web/20190624214248/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6514216--input-type-color",
+      "title":"Microsoft Edge Legacy feature request on UserVoice"
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/color",

--- a/features-json/input-event.json
+++ b/features-json/input-event.json
@@ -13,8 +13,8 @@
       "title":"MDN Web Docs - input event"
     },
     {
-      "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/10182111--input-type-checkbox-type-radio-should-fire-in",
-      "title":"Microsoft Edge feature request on UserVoice"
+      "url":"https://web.archive.org/web/20190624214448/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/10182111--input-type-checkbox-type-radio-should-fire-in",
+      "title":"Microsoft Edge Legacy feature request on UserVoice"
     }
   ],
   "bugs":[

--- a/features-json/input-event.json
+++ b/features-json/input-event.json
@@ -11,10 +11,6 @@
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/Events/input",
       "title":"MDN Web Docs - input event"
-    },
-    {
-      "url":"https://web.archive.org/web/20190624214448/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/10182111--input-type-checkbox-type-radio-should-fire-in",
-      "title":"Microsoft Edge Legacy feature request on UserVoice"
     }
   ],
   "bugs":[

--- a/features-json/input-file-accept.json
+++ b/features-json/input-file-accept.json
@@ -7,10 +7,6 @@
     {
       "url":"https://www.wufoo.com/html5/attributes/07-accept.html",
       "title":"Demo & information"
-    },
-    {
-      "url":"https://web.archive.org/web/20190624214319/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/13661175-full-spec-support-for-accept-in-input-type-file",
-      "title":"Microsoft Edge Legacy feature request on UserVoice"
     }
   ],
   "bugs":[

--- a/features-json/input-file-accept.json
+++ b/features-json/input-file-accept.json
@@ -9,8 +9,8 @@
       "title":"Demo & information"
     },
     {
-      "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/13661175-full-spec-support-for-accept-in-input-type-file",
-      "title":"Microsoft Edge feature request on UserVoice"
+      "url":"https://web.archive.org/web/20190624214319/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/13661175-full-spec-support-for-accept-in-input-type-file",
+      "title":"Microsoft Edge Legacy feature request on UserVoice"
     }
   ],
   "bugs":[

--- a/features-json/input-minlength.json
+++ b/features-json/input-minlength.json
@@ -9,8 +9,8 @@
       "title":"W3C usage example"
     },
     {
-      "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6565212-minlength-attribute",
-      "title":"Microsoft Edge feature request on UserVoice"
+      "url":"https://web.archive.org/web/20190624214429/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6565212-minlength-attribute",
+      "title":"Microsoft Edge Legacy feature request on UserVoice"
     },
     {
       "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=932755",

--- a/features-json/input-minlength.json
+++ b/features-json/input-minlength.json
@@ -9,10 +9,6 @@
       "title":"W3C usage example"
     },
     {
-      "url":"https://web.archive.org/web/20190624214429/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6565212-minlength-attribute",
-      "title":"Microsoft Edge Legacy feature request on UserVoice"
-    },
-    {
       "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=932755",
       "title":"Firefox tracking bug"
     },

--- a/features-json/link-icon-svg.json
+++ b/features-json/link-icon-svg.json
@@ -19,14 +19,6 @@
     {
       "url":"https://dev.to/masakudamatsu/favicon-nightmare-how-to-maintain-sanity-3al7",
       "title":"How to favicon in 2021"
-    },
-    {
-      "url":"https://web.archive.org/web/20190624214413/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6509196-svg-favicons",
-      "title":"Microsoft Edge Legacy feature request on UserVoice"
-    },
-    {
-      "url":"https://web.archive.org/web/20190401105608/https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/18357657/",
-      "title":"Microsoft EdgeHTML issue tracker: Issue #18357657: Support SVG favicons"
     }
   ],
   "bugs":[

--- a/features-json/link-icon-svg.json
+++ b/features-json/link-icon-svg.json
@@ -19,6 +19,14 @@
     {
       "url":"https://dev.to/masakudamatsu/favicon-nightmare-how-to-maintain-sanity-3al7",
       "title":"How to favicon in 2021"
+    },
+    {
+      "url":"https://web.archive.org/web/20190624214413/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6509196-svg-favicons",
+      "title":"Microsoft Edge Legacy feature request on UserVoice"
+    },
+    {
+      "url":"https://web.archive.org/web/20190401105608/https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/18357657/",
+      "title":"Microsoft EdgeHTML issue tracker: Issue #18357657: Support SVG favicons"
     }
   ],
   "bugs":[

--- a/features-json/matchesselector.json
+++ b/features-json/matchesselector.json
@@ -13,8 +13,8 @@
       "title":"WebPlatform Docs"
     },
     {
-      "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6524858-unprefix-and-update-msmatchesselector-to-matches",
-      "title":"Microsoft Edge feature request on UserVoice"
+      "url":"https://web.archive.org/web/20190624214246/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6524858-unprefix-and-update-msmatchesselector-to-matches",
+      "title":"Microsoft Edge Legacy feature request on UserVoice"
     }
   ],
   "bugs":[

--- a/features-json/matchesselector.json
+++ b/features-json/matchesselector.json
@@ -11,10 +11,6 @@
     {
       "url":"https://www.webplatform.org/docs/dom/HTMLElement/matches",
       "title":"WebPlatform Docs"
-    },
-    {
-      "url":"https://web.archive.org/web/20190624214246/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6524858-unprefix-and-update-msmatchesselector-to-matches",
-      "title":"Microsoft Edge Legacy feature request on UserVoice"
     }
   ],
   "bugs":[

--- a/features-json/menu.json
+++ b/features-json/menu.json
@@ -21,8 +21,8 @@
       "title":"Bug on Firefox support"
     },
     {
-      "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6508881-html5-menu-tag-contextmenu-attribute",
-      "title":"Microsoft Edge feature request on UserVoice"
+      "url":"https://web.archive.org/web/20190624214243/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6508881-html5-menu-tag-contextmenu-attribute",
+      "title":"Microsoft Edge Legacy feature request on UserVoice"
     },
     {
       "url":"https://bugs.chromium.org/p/chromium/issues/detail?id=87553",

--- a/features-json/menu.json
+++ b/features-json/menu.json
@@ -21,10 +21,6 @@
       "title":"Bug on Firefox support"
     },
     {
-      "url":"https://web.archive.org/web/20190624214243/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6508881-html5-menu-tag-contextmenu-attribute",
-      "title":"Microsoft Edge Legacy feature request on UserVoice"
-    },
-    {
       "url":"https://bugs.chromium.org/p/chromium/issues/detail?id=87553",
       "title":"Chromium support bug"
     }

--- a/features-json/meter.json
+++ b/features-json/meter.json
@@ -23,6 +23,10 @@
     {
       "url":"https://www.ctrl.blog/entry/html-meter-segment-boundaries.html",
       "title":"The HTML `<meter>` element and its (undefined) segment boundaries"
+    },
+    {
+      "url":"https://web.archive.org/web/20171017105401/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6514198--meter-element",
+      "title":"Microsoft Edge Legacy feature request on UserVoice"
     }
   ],
   "bugs":[

--- a/features-json/meter.json
+++ b/features-json/meter.json
@@ -23,10 +23,6 @@
     {
       "url":"https://www.ctrl.blog/entry/html-meter-segment-boundaries.html",
       "title":"The HTML `<meter>` element and its (undefined) segment boundaries"
-    },
-    {
-      "url":"https://web.archive.org/web/20171017105401/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6514198--meter-element",
-      "title":"Microsoft Edge Legacy feature request on UserVoice"
     }
   ],
   "bugs":[

--- a/features-json/ol-reversed.json
+++ b/features-json/ol-reversed.json
@@ -5,12 +5,12 @@
   "status":"ls",
   "links":[
     {
-      "url":"http://html5doctor.com/ol-element-attributes/",
+      "url":"https://html5doctor.com/ol-element-attributes/",
       "title":"HTML5 Doctor article on <ol> element attributes (including reversed)"
     },
     {
-      "url":"http://web.archive.org/web/20190624214438/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6514423-ol-reversed-attribute",
-      "title":"Microsoft Edge feature request on UserVoice"
+      "url":"https://web.archive.org/web/20190624214438/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6514423-ol-reversed-attribute",
+      "title":"Microsoft Edge Legacy feature request on UserVoice"
     }
   ],
   "bugs":[

--- a/features-json/ol-reversed.json
+++ b/features-json/ol-reversed.json
@@ -7,10 +7,6 @@
     {
       "url":"https://html5doctor.com/ol-element-attributes/",
       "title":"HTML5 Doctor article on <ol> element attributes (including reversed)"
-    },
-    {
-      "url":"https://web.archive.org/web/20190624214438/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6514423-ol-reversed-attribute",
-      "title":"Microsoft Edge Legacy feature request on UserVoice"
     }
   ],
   "bugs":[

--- a/features-json/once-event-listener.json
+++ b/features-json/once-event-listener.json
@@ -11,10 +11,6 @@
     {
       "url":"https://jsbin.com/zigiru/edit?html,js,output",
       "title":"JS Bin testcase"
-    },
-    {
-      "url":"https://web.archive.org/web/20190624214525/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/17702248-implement-once-event-listener-option",
-      "title":"Microsoft Edge Legacy feature request on UserVoice"
     }
   ],
   "bugs":[

--- a/features-json/once-event-listener.json
+++ b/features-json/once-event-listener.json
@@ -9,12 +9,12 @@
       "title":"Chromium Issue 615384: Support \"once\" event listener option"
     },
     {
-      "url":"http://jsbin.com/zigiru/edit?html,js,output",
+      "url":"https://jsbin.com/zigiru/edit?html,js,output",
       "title":"JS Bin testcase"
     },
     {
-      "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/17702248-implement-once-event-listener-option",
-      "title":"MS Edge feature request on UserVoice"
+      "url":"https://web.archive.org/web/20190624214525/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/17702248-implement-once-event-listener-option",
+      "title":"Microsoft Edge Legacy feature request on UserVoice"
     }
   ],
   "bugs":[

--- a/features-json/opus.json
+++ b/features-json/opus.json
@@ -11,10 +11,6 @@
     {
       "url":"https://www.ietf.org/mail-archive/web/rtcweb/current/msg04953.html",
       "title":"Google's statement about the use of VP8 and Opus codec for WebRTC standard"
-    },
-    {
-      "url":"https://web.archive.org/web/20190820230354/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6513488-ogg-vorbis-and-opus-audio-formats-support-firefox",
-      "title":"Microsoft Edge Legacy feature request on UserVoice"
     }
   ],
   "bugs":[

--- a/features-json/opus.json
+++ b/features-json/opus.json
@@ -9,12 +9,12 @@
       "title":"Introduction of Opus by Mozilla"
     },
     {
-      "url":"http://www.ietf.org/mail-archive/web/rtcweb/current/msg04953.html",
+      "url":"https://www.ietf.org/mail-archive/web/rtcweb/current/msg04953.html",
       "title":"Google's statement about the use of VP8 and Opus codec for WebRTC standard"
     },
     {
-      "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6513488-ogg-vorbis-and-opus-audio-formats-support-firefox",
-      "title":"Microsoft Edge feature request on UserVoice"
+      "url":"https://web.archive.org/web/20190820230354/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6513488-ogg-vorbis-and-opus-audio-formats-support-firefox",
+      "title":"Microsoft Edge Legacy feature request on UserVoice"
     }
   ],
   "bugs":[

--- a/features-json/ping.json
+++ b/features-json/ping.json
@@ -9,8 +9,8 @@
       "title":"MDN Web Docs - Element ping attribute"
     },
     {
-      "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6996308-implement-hyperlink-auditing-aka-the-ping-attribu",
-      "title":"UserVoice request for ping attribute"
+      "url":"https://web.archive.org/web/20190624214532/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6996308-implement-hyperlink-auditing-aka-the-ping-attribu",
+      "title":"Microsoft Edge Legacy UserVoice request for ping attribute"
     }
   ],
   "bugs":[

--- a/features-json/ping.json
+++ b/features-json/ping.json
@@ -7,10 +7,6 @@
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-ping",
       "title":"MDN Web Docs - Element ping attribute"
-    },
-    {
-      "url":"https://web.archive.org/web/20190624214532/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6996308-implement-hyperlink-auditing-aka-the-ping-attribu",
-      "title":"Microsoft Edge Legacy UserVoice request for ping attribute"
     }
   ],
   "bugs":[

--- a/features-json/rel-noopener.json
+++ b/features-json/rel-noopener.json
@@ -15,10 +15,6 @@
     {
       "url":"https://bugs.webkit.org/show_bug.cgi?id=155166",
       "title":"WebKit/Safari issue"
-    },
-    {
-      "url":"https://web.archive.org/web/20190624214501/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/12942405-implement-rel-noopener",
-      "title":"Microsoft Edge Legacy feature request"
     }
   ],
   "bugs":[

--- a/features-json/rel-noopener.json
+++ b/features-json/rel-noopener.json
@@ -17,8 +17,8 @@
       "title":"WebKit/Safari issue"
     },
     {
-      "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/12942405-implement-rel-noopener",
-      "title":"Edge feature request"
+      "url":"https://web.archive.org/web/20190624214501/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/12942405-implement-rel-noopener",
+      "title":"Microsoft Edge Legacy feature request"
     }
   ],
   "bugs":[

--- a/features-json/same-site-cookie-attribute.json
+++ b/features-json/same-site-cookie-attribute.json
@@ -5,7 +5,7 @@
   "status":"other",
   "links":[
     {
-      "url":"http://www.sjoerdlangkemper.nl/2016/04/14/preventing-csrf-with-samesite-cookie-attribute/",
+      "url":"https://www.sjoerdlangkemper.nl/2016/04/14/preventing-csrf-with-samesite-cookie-attribute/",
       "title":"Preventing CSRF with the same-site cookie attribute"
     },
     {
@@ -17,8 +17,8 @@
       "title":"Mozilla Bug #1286861, includes the patches that landed SameSite support in Firefox"
     },
     {
-      "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/17140412-support-samesite-cookie-option",
-      "title":"Microsoft Edge feature request on UserVoice"
+      "url":"https://web.archive.org/web/20190624214510/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/17140412-support-samesite-cookie-option",
+      "title":"Microsoft Edge Legacy feature request on UserVoice"
     },
     {
       "url":"https://developer.microsoft.com/en-us/microsoft-edge/status/samesitecookies/",

--- a/features-json/same-site-cookie-attribute.json
+++ b/features-json/same-site-cookie-attribute.json
@@ -17,10 +17,6 @@
       "title":"Mozilla Bug #1286861, includes the patches that landed SameSite support in Firefox"
     },
     {
-      "url":"https://web.archive.org/web/20190624214510/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/17140412-support-samesite-cookie-option",
-      "title":"Microsoft Edge Legacy feature request on UserVoice"
-    },
-    {
       "url":"https://developer.microsoft.com/en-us/microsoft-edge/status/samesitecookies/",
       "title":"Microsoft Edge Browser Status"
     },

--- a/features-json/text-decoration.json
+++ b/features-json/text-decoration.json
@@ -17,10 +17,6 @@
       "title":"MDN Web Docs - text-decoration-line"
     },
     {
-      "url":"https://web.archive.org/web/20190624214340/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6514536-text-decoration-styling",
-      "title":"Microsoft Edge Legacy feature request on UserVoice"
-    },
-    {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-skip",
       "title":"MDN Web Docs - text-decoration-skip"
     },

--- a/features-json/text-decoration.json
+++ b/features-json/text-decoration.json
@@ -17,8 +17,8 @@
       "title":"MDN Web Docs - text-decoration-line"
     },
     {
-      "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6514536-text-decoration-styling",
-      "title":"Microsoft Edge feature request on UserVoice"
+      "url":"https://web.archive.org/web/20190624214340/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6514536-text-decoration-styling",
+      "title":"Microsoft Edge Legacy feature request on UserVoice"
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-skip",

--- a/features-json/text-emphasis.json
+++ b/features-json/text-emphasis.json
@@ -9,8 +9,8 @@
       "title":"A javascript fallback for CSS3 emphasis mark."
     },
     {
-      "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6514536-text-decoration-styling",
-      "title":"Microsoft Edge feature request on UserVoice"
+      "url":"https://web.archive.org/web/20190624214340/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6514536-text-decoration-styling",
+      "title":"Microsoft Edge Legacy feature request on UserVoice"
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/text-emphasis",

--- a/features-json/text-emphasis.json
+++ b/features-json/text-emphasis.json
@@ -9,10 +9,6 @@
       "title":"A javascript fallback for CSS3 emphasis mark."
     },
     {
-      "url":"https://web.archive.org/web/20190624214340/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6514536-text-decoration-styling",
-      "title":"Microsoft Edge Legacy feature request on UserVoice"
-    },
-    {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/text-emphasis",
       "title":"MDN Web Docs - text-emphasis"
     },

--- a/features-json/textencoder.json
+++ b/features-json/textencoder.json
@@ -9,8 +9,8 @@
       "title":"MDN Web Docs - TextEncoder"
     },
     {
-      "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6558040-support-the-encoding-api",
-      "title":"Microsoft Edge feature request on UserVoice"
+      "url":"https://web.archive.org/web/20190624214523/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6558040-support-the-encoding-api",
+      "title":"Microsoft Edge Legacy feature request on UserVoice"
     },
     {
       "url":"https://bugs.webkit.org/show_bug.cgi?id=160653",

--- a/features-json/textencoder.json
+++ b/features-json/textencoder.json
@@ -9,10 +9,6 @@
       "title":"MDN Web Docs - TextEncoder"
     },
     {
-      "url":"https://web.archive.org/web/20190624214523/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6558040-support-the-encoding-api",
-      "title":"Microsoft Edge Legacy feature request on UserVoice"
-    },
-    {
       "url":"https://bugs.webkit.org/show_bug.cgi?id=160653",
       "title":"WebKit Bug 160653 - Support TextEncoder & TextDecoder APIs"
     }

--- a/features-json/tls1-3.json
+++ b/features-json/tls1-3.json
@@ -11,10 +11,6 @@
     {
       "url":"https://bugs.chromium.org/p/chromium/issues/detail?id=630147",
       "title":"Chrome support bug"
-    },
-    {
-      "url":"https://web.archive.org/web/20190624214541/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/17379247-support-tls-1-3-with-1-rtt",
-      "title":"Microsoft Edge Legacy UserVoice support request"
     }
   ],
   "bugs":[

--- a/features-json/tls1-3.json
+++ b/features-json/tls1-3.json
@@ -13,8 +13,8 @@
       "title":"Chrome support bug"
     },
     {
-      "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/17379247-support-tls-1-3-with-1-rtt",
-      "title":"UserVoice support request"
+      "url":"https://web.archive.org/web/20190624214541/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/17379247-support-tls-1-3-with-1-rtt",
+      "title":"Microsoft Edge Legacy UserVoice support request"
     }
   ],
   "bugs":[

--- a/features-json/viewport-units.json
+++ b/features-json/viewport-units.json
@@ -21,8 +21,8 @@
       "title":"Back-Forward issue blog post"
     },
     {
-      "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6514497-vmax-unit",
-      "title":"Microsoft Edge feature request on UserVoice"
+      "url":"https://web.archive.org/web/20191025111015/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6514497-vmax-unit",
+      "title":"Microsoft Edge Legacy feature request on UserVoice"
     }
   ],
   "bugs":[

--- a/features-json/viewport-units.json
+++ b/features-json/viewport-units.json
@@ -19,10 +19,6 @@
     {
       "url":"https://blog.rodneyrehm.de/archives/34-iOS7-Mobile-Safari-And-Viewport-Units.html",
       "title":"Back-Forward issue blog post"
-    },
-    {
-      "url":"https://web.archive.org/web/20191025111015/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6514497-vmax-unit",
-      "title":"Microsoft Edge Legacy feature request on UserVoice"
     }
   ],
   "bugs":[

--- a/features-json/wordwrap.json
+++ b/features-json/wordwrap.json
@@ -13,8 +13,8 @@
       "title":"Bug on Firefox support"
     },
     {
-      "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6524680-update-word-wrap-to-overflow-wrap",
-      "title":"Microsoft Edge feature request on UserVoice"
+      "url":"https://web.archive.org/web/20190624214235/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6524680-update-word-wrap-to-overflow-wrap",
+      "title":"Microsoft Edge Legacy feature request on UserVoice"
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap",

--- a/features-json/wordwrap.json
+++ b/features-json/wordwrap.json
@@ -13,10 +13,6 @@
       "title":"Bug on Firefox support"
     },
     {
-      "url":"https://web.archive.org/web/20190624214235/https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6524680-update-word-wrap-to-overflow-wrap",
-      "title":"Microsoft Edge Legacy feature request on UserVoice"
-    },
-    {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap",
       "title":"MDN Web Docs - CSS overflow-wrap"
     }


### PR DESCRIPTION
Not mentioned there, but basically related to #5870 as https://wpdev.uservoice.com/ only displays

> This UserVoice instance is no longer available.

now.

Arguably not that much value given the state of Edge Legacy, but I'm sure there are some poor souls having to still support that and the issues are probably a good start. Also: Historic purposes 

Also updated some links to use HTTPS where available.

---

![image](https://user-images.githubusercontent.com/2644614/117376749-14c8c800-aed2-11eb-994a-41f2ad2c5acb.png)

Witness me for checking each link manually!!1! :P