### PR TITLE
Updated links for Intrinsic & Extrinsic Sizing

### DIFF
--- a/features-json/intrinsic-width.json
+++ b/features-json/intrinsic-width.json
@@ -5,7 +5,7 @@
   "status":"wd",
   "links":[
     {
-      "url":"http://thenewcode.com/662/Design-From-the-Inside-Out-With-CSS-Min-Content",
+      "url":"https://thenewcode.com/662/Design-From-the-Inside-Out-With-CSS-Min-Content",
       "title":"Min-Content tutorial"
     }
   ],
@@ -420,8 +420,8 @@
   "notes_by_num":{
     "1":"Firefox does not support the `height`/`min-height`/`max-height` properties, only `width`. See [test case](https://codepen.io/shshaw/pen/Kiwaz), [Firefox bug](https://bugzilla.mozilla.org/show_bug.cgi?id=567039).",
     "2":"Firefox supports the `-moz-available` keyword rather than `stretch`. [Firefox bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1495868).",
-    "3":"Does not support the `flex-basis` property. See [specs](https://www.w3.org/TR/2015/WD-css-flexbox-1-20150514/#flex-basis-property), [Blink bug](https://codereview.chromium.org/1304853002/), [Firefox bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1055887).",
-    "4":"Chrome does not yet unprefix `stretch` (aka `fill`/`fill-available`), because the [CSSWG](https://lists.w3.org/Archives/Public/www-style/2015Aug/0127.html) is not ready for that yet. See [Chromium bug](https://chromium.googlesource.com/chromium/blink.git/+/bf119cdfece210e69c9a99af06f1b9981e2a1bc2).",
+    "3":"Does not support the `flex-basis` property. See [specs](https://www.w3.org/TR/2015/WD-css-flexbox-1-20150514/#flex-basis-property), [Blink bug](https://bugs.chromium.org/p/chromium/issues/detail?id=240765), [Firefox bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1055887).",
+    "4":"Chrome does not yet unprefix `stretch` (aka `fill`/`fill-available`), because the [CSSWG](https://lists.w3.org/Archives/Public/www-style/2015Aug/0127.html) is not ready for that yet. See [Chromium bug](https://bugs.chromium.org/p/chromium/issues/detail?id=611857).",
     "5":"While still being affected by note 1, it is only for `-moz-fit-content` and `-moz-available`."
   },
   "usage_perc_y":74.93,


### PR DESCRIPTION
Found the links by following what was already there, which are imho more precise.
<https://bugzilla.mozilla.org/show_bug.cgi?id=1055887#c9> at least confirms the links in note 3.

Actually I wanted to find the bug for WebKit in that note, but didn't mange to. Closest ones maybe:
- https://bugs.webkit.org/show_bug.cgi?id=221479
- https://bugs.webkit.org/show_bug.cgi?id=221481
- https://bugs.webkit.org/show_bug.cgi?id=116117
- https://bugs.webkit.org/show_bug.cgi?id=86154
- https://bugs.webkit.org/show_bug.cgi?id=221473