### PR TITLE
Web Bluetooth: Update implementation status link

### DIFF
--- a/features-json/web-bluetooth.json
+++ b/features-json/web-bluetooth.json
@@ -17,7 +17,7 @@
       "title":"Demos"
     },
     {
-      "url":"https://github.com/WebBluetoothCG/web-bluetooth/blob/gh-pages/implementation-status.md",
+      "url":"https://github.com/WebBluetoothCG/web-bluetooth/blob/main/implementation-status.md",
       "title":"Implementation Status"
     },
     {


### PR DESCRIPTION
Looks like [WebBluetoothCG/web-bluetooth](https://github.com/WebBluetoothCG/web-bluetooth) moved this out of the `gh-pages` branch.