### PR TITLE
Two tiny improvements to COLR

### DIFF
--- a/features-json/colr.json
+++ b/features-json/colr.json
@@ -266,9 +266,9 @@
       "12.1":"y #1",
       "13":"y #1",
       "13.1":"y #1",
-      "14":"y #1",
-      "14.1":"y #1",
-      "TP":"y #1"
+      "14":"y",
+      "14.1":"y",
+      "TP":"y"
     },
     "opera":{
       "9":"n",
@@ -434,7 +434,7 @@
   "notes_by_num":{
     "1":"Supported only on Safari for macOS High Sierra (10.13)+",
     "2":"Supported only on Windows 8.1+",
-    "3":"On Windows pre 8.1 and macOS Sierra (10.12) and below Chrome [falls back to using FreeType](https://bugs.chromium.org/p/chromium/issues/detail?id=882844#c3)"
+    "3":"On Windows pre 8.1 and macOS Sierra (10.12) and below Chromium [falls back to using FreeType](https://bugs.chromium.org/p/chromium/issues/detail?id=882844#c3)"
   },
   "usage_perc_y":94.91,
   "usage_perc_a":0,

--- a/features-json/colr.json
+++ b/features-json/colr.json
@@ -434,7 +434,7 @@
   "notes_by_num":{
     "1":"Supported only on Safari for macOS High Sierra (10.13)+",
     "2":"Supported only on Windows 8.1+",
-    "3":"On Windows pre 8.1 and macOS Sierra (10.12) and below Chromium [falls back to using FreeType](https://bugs.chromium.org/p/chromium/issues/detail?id=882844#c3)"
+    "3":"On Windows pre 8.1 and macOS Sierra (10.12) and below falls back to using FreeType: [Chromium bug 882844](https://bugs.chromium.org/p/chromium/issues/detail?id=882844#c3)"
   },
   "usage_perc_y":94.91,
   "usage_perc_a":0,


### PR DESCRIPTION
- Safari 14 [isn't available for macOS 10.13 High Sierra](https://en.wikipedia.org/wiki/Safari_version_history#Version_compatibility), therefore note 1 isn't needed starting with that version
- Chrome => Chromium for note 3, since it's on Edge and Opera as well

CC @yisibl because #5915 of course - thanks for adding this! :)