### PR TITLE
CSS3 3D Transforms: Adjust note

### DIFF
--- a/features-json/transforms3d.json
+++ b/features-json/transforms3d.json
@@ -451,7 +451,7 @@
   "notes":"",
   "notes_by_num":{
     "1":"Partial support in IE refers to not supporting [the transform-style: preserve-3d property](http://msdn.microsoft.com/en-us/library/ie/hh673529%28v=vs.85%29.aspx#the_ms_transform_style_property). This prevents nesting 3D transformed elements.",
-    "2":"Safari 9+ still require a prefix for the related `backface-visibility` property. [WebKit Bug 170983](https://bugs.webkit.org/show_bug.cgi?id=170983) requests prefix removal."
+    "2":"Safari 9+ still requires a prefix for the related `backface-visibility` property. [WebKit Bug 170983](https://bugs.webkit.org/show_bug.cgi?id=170983) requests prefix removal."
   },
   "usage_perc_y":97.19,
   "usage_perc_a":0.97,

--- a/features-json/transforms3d.json
+++ b/features-json/transforms3d.json
@@ -451,7 +451,7 @@
   "notes":"",
   "notes_by_num":{
     "1":"Partial support in IE refers to not supporting [the transform-style: preserve-3d property](http://msdn.microsoft.com/en-us/library/ie/hh673529%28v=vs.85%29.aspx#the_ms_transform_style_property). This prevents nesting 3D transformed elements.",
-    "2":"Safari 9 - 13 still require a prefix for the related `backface-visibility` property. [WebKit Bug 170983](https://bugs.webkit.org/show_bug.cgi?id=170983) requests prefix removal."
+    "2":"Safari 9+ still require a prefix for the related `backface-visibility` property. [WebKit Bug 170983](https://bugs.webkit.org/show_bug.cgi?id=170983) requests prefix removal."
   },
   "usage_perc_y":97.19,
   "usage_perc_a":0.97,


### PR DESCRIPTION
Adjust note 2 for Safari to include Safari 14 and future versions, to stop to have to adjust that with every new version.

Checked Safari 14, still the case:

<img width="1036" alt="Bildschirmfoto 2021-05-27 um 00 23 20" src="https://user-images.githubusercontent.com/2644614/119738926-c465da00-be81-11eb-8b4a-e7559893fd9a.png">
