### PR TITLE
Update Mozilla link in canvas-text.json

### DIFF
--- a/features-json/canvas-text.json
+++ b/features-json/canvas-text.json
@@ -5,7 +5,7 @@
   "status":"ls",
   "links":[
     {
-      "url":"https://developer.mozilla.org/en/Drawing_text_using_a_canvas#Additional_examples",
+      "url":"https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API/Tutorial/Drawing_text",
       "title":"Examples by Mozilla"
     },
     {


### PR DESCRIPTION
Followed the redirect via http://web.archive.org/web/20190303013144/https://developer.mozilla.org/en-US/docs/Drawing_text_using_a_canvas

![image](https://user-images.githubusercontent.com/1831398/120060672-eab88080-c00d-11eb-9f37-fa0e77c009eb.png)
