### PR TITLE
Custom Elements (V1): Add WebKit bug 182671 to note 1 regarding Safari partial support

### DIFF
--- a/features-json/custom-elementsv1.json
+++ b/features-json/custom-elementsv1.json
@@ -433,7 +433,7 @@
   },
   "notes":"",
   "notes_by_num":{
-    "1":"Supports \"Autonomous custom elements\" but not \"Customized built-in elements\".",
+    "1":"Supports \"Autonomous custom elements\" but not \"Customized built-in elements\" see [WebKit bug 182671](https://bugs.webkit.org/show_bug.cgi?id=182671).",
     "2":"Enabled through the `dom.webcomponents.enabled` preference in `about:config`.",
     "3":"Enabled through the `dom.webcomponents.customelements.enabled` preference in `about:config`."
   },


### PR DESCRIPTION
… since it seems like it will stay that way.

Links from on the way finding that bug, just for me:
- https://github.com/Fyrd/caniuse/issues/3164
- https://developers.google.com/web/fundamentals/web-components/customelements
- https://github.com/WICG/webcomponents/issues/509
- https://github.com/WICG/webcomponents/issues/662
- https://bugs.webkit.org/show_bug.cgi?id=154907
- https://wpt.fyi/results/custom-elements/builtin-coverage.html?run_id=478440003&run_id=484130003&run_id=461580002
- https://bugs.webkit.org/show_bug.cgi?id=182671