### PR TITLE
JPEG XL: Edge 91+ via runtime flag

### DIFF
--- a/features-json/jpegxl.json
+++ b/features-json/jpegxl.json
@@ -60,7 +60,7 @@
       "88":"n",
       "89":"n",
       "90":"n",
-      "91":"n"
+      "91":"n d #3"
     },
     "firefox":{
       "2":"n",
@@ -435,7 +435,8 @@
   "notes":"",
   "notes_by_num":{
     "1":"Can be enabled via the `enable-jxl` flag in `chrome://flags`.",
-    "2":"Can be enabled via the `image.jxl.enabled` flag in `about:config` in Nightly only."
+    "2":"Can be enabled via the `image.jxl.enabled` flag in `about:config` in Nightly only.",
+    "3":"Can be enabled via the `--enable-features=JXL` runtime flag."
   },
   "usage_perc_y":0,
   "usage_perc_a":0,


### PR DESCRIPTION
Fixes #5880.

Tested it using <https://tests.caniuse.com/jpegxl>:

![image](https://user-images.githubusercontent.com/2644614/120330747-660b8200-c2ed-11eb-8dff-fd65b03d47d7.png)

Haven't tested on macOS, but since [per comment](https://github.com/Fyrd/caniuse/issues/5880#issuecomment-832562501) Ubuntu is working I think it's likely that macOS works as well.