### PR TITLE
Updating webkit ticket link

### DIFF
--- a/features-json/css-focus-visible.json
+++ b/features-json/css-focus-visible.json
@@ -29,8 +29,8 @@
       "title":"Bugzilla: Add :focus-visible (former :focus-ring)"
     },
     {
-      "url":"https://bugs.webkit.org/show_bug.cgi?id=30523",
-      "title":"WebKit bug #140144: Add support for `-webkit-focusring` CSS pseudo class"
+      "url":"https://bugs.webkit.org/show_bug.cgi?id=185859",
+      "title":"WebKit bug #185859: [selectors] Support for Focus-Indicated Pseudo-class: `:focus-visible`"
     },
     {
       "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=1445482",


### PR DESCRIPTION
The previous link's status was "RESOLVED DUPLICATE". Linked the active task.