### PR TITLE
Firefox's position on the File System Access API is harmful now

### DIFF
--- a/features-json/native-filesystem-api.json
+++ b/features-json/native-filesystem-api.json
@@ -14,7 +14,7 @@
     },
     {
       "url":"https://mozilla.github.io/standards-positions/#file-system-access",
-      "title":"Firefox position: defer"
+      "title":"Firefox position: harmful"
     },
     {
       "url":"https://developers.google.com/web/updates/2019/08/native-file-system",


### PR DESCRIPTION
According to https://mozilla.github.io/standards-positions/#native-file-system, Firefox now has taken a stance against the File System Access API, but the caniuse page on it still says that Firefox has the defer position.
Since this is such a small edit, I was not sure whether I should make a PR for it, but I think it is important enough, and I thought a PR would be less work for the maintainers than opening an issue and getting another person to make the edit