### PR TITLE
queryselector: Remove blog link, deadurl

### DIFF
--- a/features-json/queryselector.json
+++ b/features-json/queryselector.json
@@ -13,10 +13,6 @@
       "title":"MDN Web Docs - querySelectorAll"
     },
     {
-      "url":"http://cjihrig.com/blog/javascripts-selectors-api/",
-      "title":"Blog post"
-    },
-    {
       "url":"https://www.webplatform.org/docs/css/selectors_api/querySelector",
       "title":"WebPlatform Docs"
     }


### PR DESCRIPTION
https://cjihrig.com/ "is parked free, courtesy of GoDaddy.com."