### PR TITLE
Removing a bad example from svg-img

### DIFF
--- a/features-json/svg-img.json
+++ b/features-json/svg-img.json
@@ -5,10 +5,6 @@
   "status":"ls",
   "links":[
     {
-      "url":"http://blog.dholbert.org/2010/10/svg-as-image.html",
-      "title":"Blog post with examples"
-    },
-    {
       "url":"http://www.codedread.com/blog/",
       "title":"Blog with SVGs an images"
     }


### PR DESCRIPTION
Hi!

Removing a bad example here because this blog links to a missing SVG, which is very misleading in this context! :D 

<img width="1649" alt="Screen Shot 2021-09-01 at 9 58 18 PM" src="https://user-images.githubusercontent.com/1312973/131735948-9ab7e22e-74ec-4960-b61f-94cfd9b11468.png">

Page: https://caniuse.com/svg-img (Resources).