### PR TITLE
Safari on macOS has full support for WebP

### DIFF
--- a/features-json/webp.json
+++ b/features-json/webp.json
@@ -276,10 +276,10 @@
       "12.1":"n",
       "13":"n",
       "13.1":"n",
-      "14":"a #3",
-      "14.1":"a #3",
-      "15":"a #3",
-      "TP":"a #3"
+      "14":"y #3",
+      "14.1":"y #3",
+      "15":"y #3",
+      "TP":"y #3"
     },
     "opera":{
       "9":"n",
@@ -450,7 +450,7 @@
   "notes_by_num":{
     "1":"Partial support refers to not supporting lossless, alpha and animated WebP images.",
     "2":"Partial support refers to not supporting animated WebP images.",
-    "3":"Partial support in Safari refers to being limited to macOS 11 Big Sur and later."
+    "3":"Safari requires macOS Big Sur (version 11) or later."
   },
   "usage_perc_y":92.22,
   "usage_perc_a":3.36,


### PR DESCRIPTION
Safari on macOS has fully implemented WebP. It does require macOS Big Sur or later (2020 or later), so the note is helpful. But the "partial support" olive green implies that WebP won't fully work in Safari, when that is not true.