### PR TITLE
AVIF - No Firefox support for sequences

### DIFF
--- a/features-json/avif.json
+++ b/features-json/avif.json
@@ -160,9 +160,9 @@
       "90":"n d #1",
       "91":"n d #1",
       "92":"n d #1",
-      "93":"y",
-      "94":"y",
-      "95":"y"
+      "93":"y #2",
+      "94":"y #2",
+      "95":"y #2"
     },
     "chrome":{
       "4":"n",
@@ -456,7 +456,7 @@
   "notes":"",
   "notes_by_num":{
     "1":"Can be enabled in Firefox via the `image.avif.enabled` pref in `about:config`.",
-    "2":"Only supports still images. AVIF sequences are not supported."
+    "2":"Only supports still images. AVIF sequences are not supported!"
   },
   "usage_perc_y":67.19,
   "usage_perc_a":0,


### PR DESCRIPTION
Adding the note `#2` to the Firefox versions, which "support" AVIF but only still images, which is pretty much not supporting it at all, as I consider AVIF to be mainly great for animations with its ability to reduce complex animated gifs from multiple megabytes to a couple hundred kilobytes.

This is something developers should be wary of, as it also kills the use of a `<picture>` tag; if you have animated AVIF images, Firefox believes it supports it and will display a still image instead of falling back to a GIF or WebP.