### PR TITLE
Safari TP 134: Surprise off by default Push API (🎉)

### DIFF
--- a/features-json/push-api.json
+++ b/features-json/push-api.json
@@ -447,7 +447,7 @@
     "2":"Requires full browser to be running to receive messages",
     "3":"Safari supports a custom implementation https://developer.apple.com/notifications/safari-push-notifications/. WWDC video by apple : https://developer.apple.com/videos/play/wwdc2013/614/ ",
     "4":"Disabled on Firefox ESR, but can be re-enabled with the `dom.serviceWorkers.enabled` and `dom.push.enabled` flags",
-    "5":"Can be enabled using \"Push API\" under the Develop > Experimental Features menu."
+    "5":"Can be enabled via \"Push API\" in the Experimental Features menu"
   },
   "usage_perc_y":78.31,
   "usage_perc_a":0.24,

--- a/features-json/push-api.json
+++ b/features-json/push-api.json
@@ -272,7 +272,7 @@
       "14":"n #3",
       "14.1":"n #3",
       "15":"n #3",
-      "TP":"n #3"
+      "TP":"n d #5"
     },
     "opera":{
       "9":"n",
@@ -446,7 +446,8 @@
     "1":"Partial support refers to not supporting `PushEvent.data` and `PushMessageData`",
     "2":"Requires full browser to be running to receive messages",
     "3":"Safari supports a custom implementation https://developer.apple.com/notifications/safari-push-notifications/. WWDC video by apple : https://developer.apple.com/videos/play/wwdc2013/614/ ",
-    "4":"Disabled on Firefox ESR, but can be re-enabled with the `dom.serviceWorkers.enabled` and `dom.push.enabled` flags"
+    "4":"Disabled on Firefox ESR, but can be re-enabled with the `dom.serviceWorkers.enabled` and `dom.push.enabled` flags",
+    "5":"Can be enabled using \"Push API\" under the Develop > Experimental Features menu."
   },
   "usage_perc_y":78.31,
   "usage_perc_a":0.24,

--- a/features-json/push-api.json
+++ b/features-json/push-api.json
@@ -447,7 +447,7 @@
     "2":"Requires full browser to be running to receive messages",
     "3":"Safari supports a custom implementation https://developer.apple.com/notifications/safari-push-notifications/. WWDC video by apple : https://developer.apple.com/videos/play/wwdc2013/614/ ",
     "4":"Disabled on Firefox ESR, but can be re-enabled with the `dom.serviceWorkers.enabled` and `dom.push.enabled` flags",
-    "5":"Can be enabled via \"Push API\" in the Experimental Features menu"
+    "5":"Partial implementation can be enabled via \"Push API\" in the Experimental Features menu"
   },
   "usage_perc_y":78.31,
   "usage_perc_a":0.24,


### PR DESCRIPTION
Thanks @dfabulich :)

- https://twitter.com/dfabu/status/1454118365509783556
- https://bugs.webkit.org/show_bug.cgi?id=231008

<https://tests.caniuse.com/push-api>:

![image](https://user-images.githubusercontent.com/2644614/139487435-938bee80-9e81-4a98-a4d0-6322b1d6b46a.png)

Checking the tests under <https://wpt.fyi/results/push-api?label=master&label=experimental&aligned&q=push> passing are now
- 51/51
- 10/84
- Error
- 41/42

so definitely improved (at least vs TP 125), but partial might be safer… what do you think?

EDIT: 

Yeah, leaning more towards partial… <https://twitter.com/schweinepriestr/status/1454167693330993163>

`"n d a #5"`, `"n a d #5"` or…? :)