### PR TITLE
Safari: `:focus-visible` behind flag (still 🎉)

### DIFF
--- a/features-json/css-focus-visible.json
+++ b/features-json/css-focus-visible.json
@@ -295,8 +295,8 @@
       "13.1":"n",
       "14":"n",
       "14.1":"n",
-      "15":"n",
-      "TP":"n"
+      "15":"n d #3",
+      "TP":"n d #3"
     },
     "opera":{
       "9":"n",
@@ -398,7 +398,7 @@
       "13.4-13.7":"n",
       "14.0-14.4":"n",
       "14.5-14.8":"n",
-      "15":"n"
+      "15":"n d #3"
     },
     "op_mini":{
       "all":"n"
@@ -468,7 +468,8 @@
   "notes":"Previously drafted as `:focus-ring`",
   "notes_by_num":{
     "1":"As `:-moz-focusring`",
-    "2":"Enabled through the \"Experimental Web Platform features\" flag in chrome://flags"
+    "2":"Enabled through the \"Experimental Web Platform features\" flag in chrome://flags",
+    "3":"Can be enabled via \":focus-visible pseudo-class\" in the Experimental Features menu"
   },
   "usage_perc_y":74.59,
   "usage_perc_a":0,


### PR DESCRIPTION
<https://css-tricks.com/focus-visible-in-webkit/>
<https://blogs.igalia.com/mrego/2021/06/07/focus-visible-in-webkit-may-2021/>

> The high level summary is that the implementation in WebKit can be considered to be complete and all the `:focus-visible` patches have been included on the last [Safari Technology Preview 125](https://webkit.org/blog/11680/release-notes-for-safari-technology-preview-125/) as an experimental feature.

> You can test this feature in [Safari Technology Preview (since release 125)](https://developer.apple.com/safari/technology-preview/) by enabling the runtime flag in the menu (*Develop > Experimental Features > :focus-visible pseudo-class*).

I haven't tested Safari 15.0/15.1/TP nor Safari on iOS 15.0 (yet), but the flag is there in Safari on iOS 15.1 and given the age of TP 125 (2021-05-26) it's probably pretty safe to assume.

Plus <https://webkit.org/blog/11989/new-webkit-features-in-safari-15/>:
> Changes in this release of Safari were included in the following Safari Technology Preview releases: [123](https://webkit.org/blog/11585/release-notes-for-safari-technology-preview-123/), [124](https://webkit.org/blog/11672/release-notes-for-safari-technology-preview-124/), [125](https://webkit.org/blog/11680/release-notes-for-safari-technology-preview-125/), [126](https://webkit.org/blog/11727/release-notes-for-safari-technology-preview-126-with-safari-15-features/), [127](https://webkit.org/blog/11736/release-notes-for-safari-technology-preview-127/), [128](https://webkit.org/blog/11925/release-notes-for-safari-technology-preview-128/), [129](https://webkit.org/blog/11951/release-notes-for-safari-technology-preview-129/).