### PR TITLE
sql-storage: Not supported in third party contexts in chrome 97

### DIFF
--- a/features-json/sql-storage.json
+++ b/features-json/sql-storage.json
@@ -18,7 +18,7 @@
       "description":"Reported to not be supported on the Samsung-based Android 4."
     },
     {
-      "description":"Is not supported from Web Workers in Chrome. Further more it is not supported in Third-Party Contexts since Chrome v97."
+      "description":"Is not supported from Web Workers in Chrome. Furthermore it is not supported in Third-Party Contexts since Chrome v97."
     }
   ],
   "categories":[

--- a/features-json/sql-storage.json
+++ b/features-json/sql-storage.json
@@ -18,7 +18,7 @@
       "description":"Reported to not be supported on the Samsung-based Android 4."
     },
     {
-      "description":"Is not supported from Web Workers in Chrome."
+      "description":"Is not supported from Web Workers in Chrome. Further more it is not supported in Third-Party Contexts since Chrome v97."
     }
   ],
   "categories":[


### PR DESCRIPTION
ref https://blog.chromium.org/2021/11/chrome-97-webtransport-new-array-static.html