### PR TITLE
Safari TP 137: `:has()` 🎉 

### DIFF
--- a/features-json/css-has.json
+++ b/features-json/css-has.json
@@ -13,6 +13,10 @@
       "title":"Firefox support bug"
     },
     {
+      "url":"https://bugs.webkit.org/show_bug.cgi?id=227702",
+      "title":"WebKit support bug"
+    },
+    {
       "url":"https://bugs.chromium.org/p/chromium/issues/detail?id=669058",
       "title":"Chrome bug to track implementation"
     }
@@ -282,7 +286,7 @@
       "15":"n",
       "15.1":"n",
       "15.2":"n",
-      "TP":"n"
+      "TP":"y"
     },
     "opera":{
       "9":"n",


### PR DESCRIPTION
https://webkit.org/blog/12156/release-notes-for-safari-technology-preview-137/

> Enabled support for `:has()` pseudo-class by default ([r286495](https://trac.webkit.org/changeset/286495/webkit/), [r286135](https://trac.webkit.org/changeset/286135/webkit/), [r286302](https://trac.webkit.org/changeset/286302/webkit/), [r286180](https://trac.webkit.org/changeset/286180/webkit/), [r286226](https://trac.webkit.org/changeset/286226/webkit/), [r286494](https://trac.webkit.org/changeset/286494/webkit/), [r286433](https://trac.webkit.org/changeset/286433/webkit/), [r286188](https://trac.webkit.org/changeset/286188/webkit/), [r286169](https://trac.webkit.org/changeset/286169/webkit/), [r286365](https://trac.webkit.org/changeset/286365/webkit/))

Didn't test https://tests.caniuse.com/css-has though.

There is more great stuff of course, but I don't think more changes for caniuse (yet)…