### PR TITLE
Add WAAPI as keyword to Web Animations API

### DIFF
--- a/features-json/web-animation.json
+++ b/features-json/web-animation.json
@@ -471,7 +471,7 @@
   "usage_perc_a":5.96,
   "ucprefix":false,
   "parent":"",
-  "keywords":"animate,element.animate,play,pause,reverse,finish,currentTime,startTime,playbackRate,playState",
+  "keywords":"animate,element.animate,play,pause,reverse,finish,currentTime,startTime,playbackRate,playState,WAAPI",
   "ie_id":"webanimationsjavascriptapi",
   "chrome_id":"4854343836631040,5633748733263872",
   "firefox_id":"web-animations",


### PR DESCRIPTION
There was an issue before: https://github.com/Fyrd/caniuse/issues/5969

But currently https://caniuse.com/?search=waapi leads to nothing:

![image](https://user-images.githubusercontent.com/2644614/147271560-c10e5f4b-296b-41c1-9b62-6e138f810928.png)
