### PR TITLE
STP supports Cascade Layers by default

### DIFF
--- a/features-json/css-cascade-layers.json
+++ b/features-json/css-cascade-layers.json
@@ -290,7 +290,7 @@
       "15":"n",
       "15.1":"n",
       "15.2":"n",
-      "TP":"n d #3"
+      "TP":"y"
     },
     "opera":{
       "9":"n",
@@ -465,8 +465,7 @@
   "notes":"",
   "notes_by_num":{
     "1":"Can be enabled with the \"layout.css.cascade-layers.enabled\" feature flag under `about:config`",
-    "2":"Can be enabled in Chrome Canary using the `--enable-blink-features=CSSCascadeLayers` runtime flag",
-    "3":"Can be enabled in the Experimental Features developer menu"
+    "2":"Can be enabled in Chrome Canary using the `--enable-blink-features=CSSCascadeLayers` runtime flag"
   },
   "usage_perc_y":0.01,
   "usage_perc_a":0,


### PR DESCRIPTION
Safari Technology Preview supports Cascade Layers by default. It's been that way for a while now.