### PR TITLE
Remove redirecting link

### DIFF
--- a/features-json/wordwrap.json
+++ b/features-json/wordwrap.json
@@ -5,10 +5,6 @@
   "status":"wd",
   "links":[
     {
-      "url":"https://developer.mozilla.org/En/CSS/Word-wrap",
-      "title":"MDN Web Docs - CSS word-wrap"
-    },
-    {
       "url":"https://www.webplatform.org/docs/css/properties/word-wrap",
       "title":"WebPlatform Docs"
     },


### PR DESCRIPTION
Removed word-wrap link as it redirects to the overflow-wrap page, which is one of the remaining links.
    {
      "url":"https://developer.mozilla.org/En/CSS/Word-wrap",
      "title":"MDN Web Docs - CSS word-wrap"
    },