### PR TITLE
Containment on by default in STP

### DIFF
--- a/features-json/css-containment.json
+++ b/features-json/css-containment.json
@@ -277,7 +277,7 @@
       "15":"n",
       "15.1":"n",
       "15.2":"n",
-      "TP":"n d #3"
+      "TP":"y"
     },
     "opera":{
       "9":"n",
@@ -452,8 +452,7 @@
   "notes":"",
   "notes_by_num":{
     "1":"Can be enabled in older Gecko engines with the `layout.css.contain.enabled` flag in about:config",
-    "2":"Partially supported in Firefox by enabling \"layout.css.contain.enabled\" in about:config",
-    "3":"Supported in Safari TP by enabling \"CSS Containment\" under the \"Experimental Features\" menu"
+    "2":"Partially supported in Firefox by enabling \"layout.css.contain.enabled\" in about:config"
   },
   "usage_perc_y":74.91,
   "usage_perc_a":0,


### PR DESCRIPTION
CSS Containment is now on by default in Safari Technology Preview.