### PR TITLE
COLRv1 additions

### DIFF
--- a/features-json/colr-v1.json
+++ b/features-json/colr-v1.json
@@ -19,6 +19,14 @@
     {
       "url":"https://www.colorfonts.wtf/#w-node-85d8080e63a6-0134536f",
       "title":"Where can I use color fonts"
+    },
+    {
+      "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=1740525",
+      "title":"Firefox support bug"
+    },
+    {
+      "url":"https://lists.webkit.org/pipermail/webkit-dev/2021-March/031765.html",
+      "title":"WebKit position"
     }
   ],
   "bugs":[
@@ -475,7 +483,7 @@
   "parent":"fontface",
   "keywords":"colr,colrv1,cpal,font,color-font,fontface,webfonts",
   "ie_id":"",
-  "chrome_id":"5897235770376192",
+  "chrome_id":"5638148514119680",
   "firefox_id":"",
   "webkit_id":"",
   "shown":true


### PR DESCRIPTION
[5897235770376192](https://chromestatus.com/feature/5897235770376192) was for v0 while [5638148514119680](https://chromestatus.com/feature/5638148514119680) is for v1 0:-)

Also link the other browsers mentioned there.

CC @yisibl and also thanks for adding this! :)