### PR TITLE
Update Safari 15.4 to partial support for lazy loading

### DIFF
--- a/features-json/loading-lazy-attr.json
+++ b/features-json/loading-lazy-attr.json
@@ -295,8 +295,8 @@
       "15":"n d #2",
       "15.1":"n d #2",
       "15.2-15.3":"n d #2",
-      "15.4":"n d #2",
-      "TP":"y"
+      "15.4":"a d #3",
+      "TP":"a d #3"
     },
     "opera":{
       "9":"n",
@@ -403,7 +403,7 @@
       "14.5-14.8":"n d #2",
       "15.0-15.1":"n d #2",
       "15.2-15.3":"n d #2",
-      "15.4":"n d #2"
+      "15.4":"a d #3"
     },
     "op_mini":{
       "all":"n"
@@ -474,7 +474,8 @@
   "notes":"",
   "notes_by_num":{
     "1":"Firefox only supports lazy loading for images",
-    "2":"Can be enabled in Settings under the Safari > Advanced > Experimental Features menu."
+    "2":"Can be enabled in Settings under the Safari > Advanced > Experimental Features menu.",
+    "3":"Safari supports lazy image loading. Lazy iframes loading can be enabled under the Experiemental Features menu."
   },
   "usage_perc_y":70.63,
   "usage_perc_a":3.89,


### PR DESCRIPTION
Lazy image loading is supported by default in Safari 15.4 and Safari Technology Preview. Lazy iframe loading is available via an off-by-default Experimental Features option.