### PR TITLE
fixing typo in note on Lazy Loading page for loading attribute 

### DIFF
--- a/features-json/loading-lazy-attr.json
+++ b/features-json/loading-lazy-attr.json
@@ -476,7 +476,7 @@
   "notes_by_num":{
     "1":"Firefox only supports lazy loading for images",
     "2":"Can be enabled in Settings under the Safari > Advanced > Experimental Features menu.",
-    "3":"Safari supports lazy image loading. Lazy iframes loading can be enabled under the Experiemental Features menu."
+    "3":"Safari supports lazy image loading. Lazy iframes loading can be enabled under the Experimental Features menu."
   },
   "usage_perc_y":70.63,
   "usage_perc_a":3.89,


### PR DESCRIPTION
The word experimental was misspelled.