### PR TITLE
fixing typo in description on Lazy Loading page for loading attribute 

### DIFF
--- a/features-json/loading-lazy-attr.json
+++ b/features-json/loading-lazy-attr.json
@@ -1,6 +1,6 @@
 {
   "title":"Lazy loading via attribute for images & iframes",
-  "description":"The `loading` attributing on images & iframes gives authors control over when the browser should start loading the resource. ",
+  "description":"The `loading` attribute on images & iframes gives authors control over when the browser should start loading the resource. ",
   "spec":"https://html.spec.whatwg.org/multipage/urls-and-fetching.html#lazy-loading-attributes",
   "status":"ls",
   "links":[


### PR DESCRIPTION
I found a typo in the description. This PR fixes it.