### PR TITLE
Chrome 100: Small/large/dynamic/logical viewport units behind flag 💡🎉

### DIFF
--- a/features-json/viewport-unit-variants.json
+++ b/features-json/viewport-unit-variants.json
@@ -263,9 +263,9 @@
       "97":"n",
       "98":"n",
       "99":"n",
-      "100":"n",
-      "101":"n",
-      "102":"n"
+      "100":"n d #1",
+      "101":"n d #1",
+      "102":"n d #1"
     },
     "safari":{
       "3.1":"n",
@@ -471,7 +471,7 @@
   },
   "notes":"",
   "notes_by_num":{
-    
+    "1":"Can be enabled via the [Experimental Web Platform features](chrome://flags/#enable-experimental-web-platform-features) flag"
   },
   "usage_perc_y":0.05,
   "usage_perc_a":0,


### PR DESCRIPTION
Finally figured #6166 out - the units are simply behind the Experimental Web Platform features flag :P

<https://tests.caniuse.com/viewport-unit-variants>:

![image](https://user-images.githubusercontent.com/2644614/157082061-64dd78a4-085a-4738-8f33-0297b0a3548c.png)
