### PR TITLE
Chrome 101: CSS `:has()` behind flag

### DIFF
--- a/features-json/css-has.json
+++ b/features-json/css-has.json
@@ -265,8 +265,8 @@
       "98":"n",
       "99":"n",
       "100":"n",
-      "101":"n",
-      "102":"n"
+      "101":"n d #1",
+      "102":"n d #1"
     },
     "safari":{
       "3.1":"n",
@@ -472,7 +472,7 @@
   },
   "notes":"",
   "notes_by_num":{
-    
+    "1":"Can be enabled via the [Experimental Web Platform features](chrome://flags/#enable-experimental-web-platform-features) flag"
   },
   "usage_perc_y":0.05,
   "usage_perc_a":0,


### PR DESCRIPTION
<https://bugs.chromium.org/p/chromium/issues/detail?id=669058#c47>:

> Enable both snapshot and live :has() pseudo class support behind
the experiemental web platform feature flag.

Though

> There are some functional limitations.
> - :has() doesn't work properly with pseudo elements in the
  subselector.
> - :has() doesn't work properly with some logical combinations
  (:is(), :where() and :has()) in the subselector.

which seems to show on <https://wpt.fyi/results/css/selectors?label=master&label=experimental&aligned&q=has>:

![image](https://user-images.githubusercontent.com/2644614/158040264-54d5956a-023d-4904-b415-5fb9e9bbcb3c.png)

But since it's behind a flag away, literally saying experimental, I think it's not yet anything to denote on caniuse.

For the record, <https://tests.caniuse.com/css-has>:

![image](https://user-images.githubusercontent.com/2644614/158040321-2cf57ee2-100d-4fde-b160-7d44ff65af6b.png)
