### PR TITLE
Add safari gap bug

### DIFF
--- a/features-json/flexbox-gap.json
+++ b/features-json/flexbox-gap.json
@@ -27,7 +27,7 @@
   ],
   "bugs":[
     {
-      "description":"Safari does not apply `gap` when `flex-direction` is `collunm-reverse`"
+      "description":"Safari before version 15.4 does not apply `gap` when `flex-direction` is `column-reverse` [see WebKit bug](https://bugs.webkit.org/show_bug.cgi?id=225278)"
     }
   ],
   "categories":[

--- a/features-json/flexbox-gap.json
+++ b/features-json/flexbox-gap.json
@@ -26,7 +26,9 @@
     }
   ],
   "bugs":[
-    
+    {
+      "description":"Safari does not support gap with reverse flex-direction"
+    }
   ],
   "categories":[
     "CSS"

--- a/features-json/flexbox-gap.json
+++ b/features-json/flexbox-gap.json
@@ -27,7 +27,7 @@
   ],
   "bugs":[
     {
-      "description":"Safari does not support gap with reverse flex-direction"
+      "description":"Safari does not apply `gap` when `flex-direction` is `collunm-reverse`"
     }
   ],
   "categories":[


### PR DESCRIPTION
**Safari** does not support `gap` with `column-reverse` `flex-direction`

```html
<main>
  <section>A</section>
  <section>B</section>
  <section>C</section>
  <section>D</section>
</main>
```

```css
main {
  border: 1px solid blue;
  display: flex;
  gap: 16px;
  flex-direction: column-reverse;
}

section {
  border: 1px solid red;
}
```

`flex-direction: column;`
<img width="131" alt="image" src="https://user-images.githubusercontent.com/194784/158445776-b6d70337-b110-4cec-a211-c8857f00d0dc.png">


`flex-direction: column-reverse;`
<img width="140" alt="image" src="https://user-images.githubusercontent.com/194784/158445824-fe2a5e29-103d-48b8-ba2a-4af46c8a8a55.png">

