### PR TITLE
fix property list

### DIFF
--- a/features-json/css3-tabsize.json
+++ b/features-json/css3-tabsize.json
@@ -1,6 +1,6 @@
 {
   "title":"CSS3 tab-size",
-  "description":"Method of customizing the width of the tab character. Only effective using 'white-space: pre', 'white-space: pre-wrap', and 'break-spaces'.",
+  "description":"Method of customizing the width of the tab character. Only effective using 'white-space: pre', 'white-space: pre-wrap', and 'white-space: break-spaces'.",
   "spec":"https://www.w3.org/TR/css3-text/#tab-size",
   "status":"wd",
   "links":[

--- a/features-json/css3-tabsize.json
+++ b/features-json/css3-tabsize.json
@@ -1,6 +1,6 @@
 {
   "title":"CSS3 tab-size",
-  "description":"Method of customizing the width of the tab character. Only effective using 'white-space: pre' or 'white-space: pre-wrap'.",
+  "description":"Method of customizing the width of the tab character. Only effective using 'white-space: pre', 'white-space: pre-wrap', and 'break-spaces'.",
   "spec":"https://www.w3.org/TR/css3-text/#tab-size",
   "status":"wd",
   "links":[


### PR DESCRIPTION
tab size is relevant for 3 values of white space, but only two were listed. 
added `white-space: break-spaces` to the list.

example: https://codepen.io/estelle/pen/WNdpPPo