### PR TITLE
Clarify File System Access API support in Safari

### DIFF
--- a/features-json/native-filesystem-api.json
+++ b/features-json/native-filesystem-api.json
@@ -299,9 +299,9 @@
       "14.1":"n",
       "15":"n",
       "15.1":"n",
-      "15.2-15.3":"a",
-      "15.4":"a",
-      "TP":"a"
+      "15.2-15.3":"a #3",
+      "15.4":"a #3",
+      "TP":"a #3"
     },
     "opera":{
       "9":"n",
@@ -411,8 +411,8 @@
       "14.0-14.4":"n",
       "14.5-14.8":"n",
       "15.0-15.1":"n",
-      "15.2-15.3":"a",
-      "15.4":"a"
+      "15.2-15.3":"a #3",
+      "15.4":"a #3"
     },
     "op_mini":{
       "all":"n"
@@ -483,7 +483,8 @@
   "notes":"",
   "notes_by_num":{
     "1":"Can be enabled in desktop Chromium browsers with the `#native-file-system-api` flag.",
-    "2":"Desktop Chromium browsers currently support basic functionality and will be adding more of the API in the future."
+    "2":"Desktop Chromium browsers currently support basic functionality and will be adding more of the API in the future.",
+    "3": "Only supports the Orign Private File System part."
   },
   "usage_perc_y":0,
   "usage_perc_a":39.43,

--- a/features-json/native-filesystem-api.json
+++ b/features-json/native-filesystem-api.json
@@ -484,7 +484,7 @@
   "notes_by_num":{
     "1":"Can be enabled in desktop Chromium browsers with the `#native-file-system-api` flag.",
     "2":"Desktop Chromium browsers currently support basic functionality and will be adding more of the API in the future.",
-    "3": "Only supports the Orign Private File System part."
+    "3":"Only supports the Origin Private File System part."
   },
   "usage_perc_y":0,
   "usage_perc_a":39.43,


### PR DESCRIPTION
Clarify that it only covers the Origin Private File System part.