### PR TITLE
Clarifying partial support note #3 for WebP

### DIFF
--- a/features-json/webp.json
+++ b/features-json/webp.json
@@ -487,7 +487,7 @@
   "notes_by_num":{
     "1":"Partial support refers to not supporting lossless, alpha and animated WebP images.",
     "2":"Partial support refers to not supporting animated WebP images.",
-    "3":"Partial support in Safari refers to being limited to macOS 11 Big Sur and later."
+    "3":"Safari 14.0 – 15.x has full support of WebP, but requires macOS 11 Big Sur or later."
   },
   "usage_perc_y":92.36,
   "usage_perc_a":2.41,


### PR DESCRIPTION
Clarifying partial support note #3 for WebP regarding support in Safari 14–15. 

We get a lot of questions about whether or not Safari supports WebP. Developers clearly have this question on their mind, since WebP is currently the number 3 most-looked up technology on Can I Use. 

Folks seem to think "partial support" means WebKit did not implement WebP correctly, or we haven't finished implementing the full specification. Neither of which is true. I'm hoping this revision to the note will explain exactly what partial support means in this case — especially to busy/fast-reading or non-fluent-in-English web developers. 

I say "Safari 14.0 – 15.x" intentionally, for the same reason Safari Technology Preview should be marked as full support.