### PR TITLE
Complex :nth-child selectors are Working Draft

### DIFF
--- a/features-json/css-nth-child-of.json
+++ b/features-json/css-nth-child-of.json
@@ -2,7 +2,7 @@
   "title":"selector list argument of :nth-child and :nth-last-child CSS pseudo-classes",
   "description":"The newest versions of `:nth-child()` and `:nth-last-child()` accept an optional `of S` clause which filters the children to only those which match the selector list `S`. For example, `:nth-child(1 of .foo)` selects the first child among the children that have the `foo` class (ignoring any non-`foo` children which precede that child). Similar to `:nth-of-type`, but for arbitrary selectors instead of only type selectors.",
   "spec":"https://drafts.csswg.org/selectors/#the-nth-child-pseudo",
-  "status":"unoff",
+  "status":"wd",
   "links":[
     {
       "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=854148",


### PR DESCRIPTION
Complex :nth-child  and :nth-last-child selectors are part of Selectors 4, which is in Working Draft. This is not an unofficial specification. 
https://www.w3.org/TR/selectors-4/#the-nth-child-pseudo