### PR TITLE
Small adjustment to note 3 regarding Safari

### DIFF
--- a/features-json/webp.json
+++ b/features-json/webp.json
@@ -494,7 +494,7 @@
   "notes_by_num":{
     "1":"Partial support refers to not supporting lossless, alpha and animated WebP images.",
     "2":"Partial support refers to not supporting animated WebP images.",
-    "3":"Safari 14.0 \u2013 15.x has full support of WebP, but requires macOS 11 Big Sur or later."
+    "3":"Safari 14.0 \u2013 15.6 has full support of WebP, but requires macOS 11 Big Sur or later."
   },
   "usage_perc_y":91.56,
   "usage_perc_a":3.02,


### PR DESCRIPTION
A small, clarifying adjustment to the note about WebP in Safari 14.0–15.6.