### PR TITLE
Mark WebP as "other"

### DIFF
--- a/features-json/webp.json
+++ b/features-json/webp.json
@@ -2,7 +2,7 @@
   "title":"WebP image format",
   "description":"Image format (based on the VP8 video format) that supports lossy and lossless compression, as well as animation and alpha transparency. WebP generally has better compression than JPEG, PNG and GIF and is designed to supersede them. [AVIF](/avif) and [JPEG XL](/jpegxl) are designed to supersede WebP.",
   "spec":"https://developers.google.com/speed/webp/",
-  "status":"unoff",
+  "status":"other",
   "links":[
     {
       "url":"https://developers.google.com/speed/webp/",


### PR DESCRIPTION
WebP should be marked as "other", like JPEG XL https://caniuse.com/jpegxl and AVIF https://caniuse.com/avif, not "unofficial".