### PR TITLE
Changes to Push API regarding Safari

### DIFF
--- a/features-json/push-api.json
+++ b/features-json/push-api.json
@@ -298,8 +298,8 @@
       "15.2-15.3":"n #3",
       "15.4":"n #3",
       "15.5":"n #3",
-      "16.0":"y #6",
-      "TP":"y #6"
+      "16.0":"a #6",
+      "TP":"a #6"
     },
     "opera":{
       "9":"n",
@@ -484,10 +484,10 @@
   "notes_by_num":{
     "1":"Partial support refers to not supporting `PushEvent.data` and `PushMessageData`",
     "2":"Requires full browser to be running to receive messages",
-    "3":"Safari supports a custom implementation, see <https://developer.apple.com/notifications/safari-push-notifications/>. [WWDC video](https://developer.apple.com/videos/play/wwdc2013/614/) by Apple",
+    "3":"Safari supports a custom implementation, see <https://developer.apple.com/notifications/safari-push-notifications/> and [WWDC video](https://developer.apple.com/videos/play/wwdc2013/614/) by Apple",
     "4":"Disabled on Firefox ESR, but can be re-enabled with the `dom.serviceWorkers.enabled` and `dom.push.enabled` flags",
     "5":"Partial implementation can be enabled via \"Push API\" in the Experimental Features menu",
-    "6":"Only available in Safari 16 on macOS 13 Ventura or later"
+    "6":"Only available on macOS 13 Ventura or later and only in Safari itself, not WKWebView nor SFSafariViewController"
   },
   "usage_perc_y":76.15,
   "usage_perc_a":0.11,

--- a/features-json/push-api.json
+++ b/features-json/push-api.json
@@ -484,7 +484,7 @@
   "notes_by_num":{
     "1":"Partial support refers to not supporting `PushEvent.data` and `PushMessageData`",
     "2":"Requires full browser to be running to receive messages",
-    "3":"Safari supports a custom implementation https://developer.apple.com/notifications/safari-push-notifications/. WWDC video by apple : https://developer.apple.com/videos/play/wwdc2013/614/ ",
+    "3":"Safari supports a custom implementation, see <https://developer.apple.com/notifications/safari-push-notifications/>. [WWDC video](https://developer.apple.com/videos/play/wwdc2013/614/) by Apple",
     "4":"Disabled on Firefox ESR, but can be re-enabled with the `dom.serviceWorkers.enabled` and `dom.push.enabled` flags",
     "5":"Partial implementation can be enabled via \"Push API\" in the Experimental Features menu",
     "6":"Only available in Safari 16 on macOS 13 Ventura or later"


### PR DESCRIPTION
Source: https://twitter.com/dfabu/status/1534223355225575424 (see above as well)

I've been struggling with myself if that warrants partial support, but for now I came to the conclusion yes, because in the past we gave partial even for only support starting with a specific macOS version and here's more.