### PR TITLE
Fix for link fail I introduced in #6323 

### DIFF
--- a/features-json/push-api.json
+++ b/features-json/push-api.json
@@ -484,7 +484,7 @@
   "notes_by_num":{
     "1":"Partial support refers to not supporting `PushEvent.data` and `PushMessageData`",
     "2":"Requires full browser to be running to receive messages",
-    "3":"Safari supports a custom implementation, see <https://developer.apple.com/notifications/safari-push-notifications/> and [WWDC video](https://developer.apple.com/videos/play/wwdc2013/614/) by Apple",
+    "3":"Safari supports a custom implementation, see [https://developer.apple.com/notifications/safari-push-notifications/](https://developer.apple.com/notifications/safari-push-notifications/) and [WWDC video](https://developer.apple.com/videos/play/wwdc2013/614/) by Apple",
     "4":"Disabled on Firefox ESR, but can be re-enabled with the `dom.serviceWorkers.enabled` and `dom.push.enabled` flags",
     "5":"Partial implementation can be enabled via \"Push API\" in the Experimental Features menu",
     "6":"Only available on macOS 13 Ventura or later and only in Safari itself, not WKWebView nor SFSafariViewController"


### PR DESCRIPTION
I had hoped this would work out as a link as it works in some markdown, [but nope](https://caniuse.com/push-api):

![image](https://user-images.githubusercontent.com/2644614/173250732-4108ea6c-7b4b-416e-bebc-799cb58ce270.png)

Sorry 0:-)