### PR TITLE
AVIF coming to Safari & Safari on iOS 16

### DIFF
--- a/features-json/avif.json
+++ b/features-json/avif.json
@@ -308,8 +308,8 @@
       "15.2-15.3":"n",
       "15.4":"n",
       "15.5":"n",
-      "16.0":"n",
-      "TP":"n"
+      "16.0":"a #3",
+      "TP":"a #3"
     },
     "opera":{
       "9":"n",
@@ -422,7 +422,7 @@
       "15.2-15.3":"n",
       "15.4":"n",
       "15.5":"n",
-      "16.0":"n"
+      "16.0":"y"
     },
     "op_mini":{
       "all":"n"
@@ -494,7 +494,8 @@
   "notes":"",
   "notes_by_num":{
     "1":"Can be enabled in Firefox via the `image.avif.enabled` pref in `about:config`.",
-    "2":"Only supports still images. AVIF sequences are not supported!"
+    "2":"Only supports still images. AVIF sequences are not supported!",
+    "3":"Only available on macOS 13 Ventura or later"
   },
   "usage_perc_y":69,
   "usage_perc_a":0,


### PR DESCRIPTION
- https://twitter.com/jaffathecake/status/1540697894683942912
- https://github.com/WebKit/WebKit/pull/1717

Given it's early and not yet [test](https://tests.caniuse.com/avif)able, draft for now.

@jensimmons are you able to comment on this? :)
If you are, do you know or are able to find out about support for AVIF sequences?
See note 2, Firefox doesn't have them yet: https://caniuse.com/avif
Test here: https://tests.caniuse.com/avif