### PR TITLE
Size Container Queries starting to ship in Chrome 105 🎉

### DIFF
--- a/features-json/css-container-queries.json
+++ b/features-json/css-container-queries.json
@@ -508,7 +508,7 @@
   "notes_by_num":{
     "1":"Can be enabled with the \"Enable CSS Container Queries\" feature flag under `chrome://flags`",
     "2":"The initial Chrome prototype used an earlier draft syntax based on the `contain` property",
-    "3":"Combining size container queries and table layout inside a multicolumn layout doesn't work",
+    "3":"Combining size container queries and table layout inside a multicolumn layout doesn't work"
   },
   "usage_perc_y":0.03,
   "usage_perc_a":0,

--- a/features-json/css-container-queries.json
+++ b/features-json/css-container-queries.json
@@ -290,8 +290,8 @@
       "102":"n d #1",
       "103":"n d #1",
       "104":"n d #1",
-      "105":"n d #1",
-      "106":"n d #1"
+      "105":"a #3",
+      "106":"y"
     },
     "safari":{
       "3.1":"n",
@@ -507,7 +507,8 @@
   "notes":"",
   "notes_by_num":{
     "1":"Can be enabled with the \"Enable CSS Container Queries\" feature flag under `chrome://flags`",
-    "2":"The initial Chrome prototype used an earlier draft syntax based on the `contain` property"
+    "2":"The initial Chrome prototype used an earlier draft syntax based on the `contain` property",
+    "3":"Combining size container queries and table layout inside a multicolumn layout doesn't work",
   },
   "usage_perc_y":0.03,
   "usage_perc_a":0,


### PR DESCRIPTION
https://chromestatus.com/feature/6525308435955712

The source for note 3 is there as well:

> Note for M105: Table fragmentation in LayoutNG will not be shipped in M105, but expected to ship in M106. The consequence is that if an author combines table layout and size container queries inside a multicolumn layout, container queries will not work in that context in M105.

There doesn't seem to be a test on https://tests.caniuse.com/css-container-queries yet - I used 

```js
"container" in document.documentElement.style;
```

stolen from https://github.com/GoogleChromeLabs/container-query-polyfill:

![image](https://user-images.githubusercontent.com/2644614/177876691-cd0463fb-0576-4c08-8d40-6b3a21967817.png)

Still `false` in 104 (currently Beta).