### PR TITLE
Updates to attr() function for all properties

### DIFF
--- a/features-json/css3-attr.json
+++ b/features-json/css3-attr.json
@@ -1,6 +1,6 @@
 {
   "title":"CSS3 attr() function for all properties",
-  "description":"While `attr()` is supported for effectively all browsers for the `content` property, CSS Values and Units Level 5 adds the ability to use `attr()` on  **any** CSS property, and to use it for non-string values (e.g. numbers, colors).",
+  "description":"While `attr()` is supported for effectively all browsers for the `content` property, CSS Values and Units Level 5 adds the ability to use `attr()` on **any** CSS property, and to use it for non-string values (e.g. numbers, colors).",
   "spec":"https://drafts.csswg.org/css-values-5/#attr-notation",
   "status":"unoff",
   "links":[

--- a/features-json/css3-attr.json
+++ b/features-json/css3-attr.json
@@ -1,8 +1,8 @@
 {
   "title":"CSS3 attr() function for all properties",
-  "description":"While `attr()` is supported for effectively all browsers for the `content` property, CSS Values and Units Level 3 adds the ability to use `attr()` on **any** CSS property, and to use it for non-string values (e.g. numbers, colors).",
-  "spec":"https://www.w3.org/TR/css-values/#attr-notation",
-  "status":"cr",
+  "description":"While `attr()` is supported for effectively all browsers for the `content` property, CSS Values and Units Level 5 adds the ability to use `attr()` on  **any** CSS property, and to use it for non-string values (e.g. numbers, colors).",
+  "spec":"https://drafts.csswg.org/css-values-5/#attr-notation",
+  "status":"unoff",
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/attr",
@@ -492,7 +492,7 @@
       "2.5":"n"
     }
   },
-  "notes":"See the [generated content](/#feat=css-gencontent) table for support for `attr()` for the `content` property.",
+  "notes":"See the [generated content](/css-gencontent) table for support for `attr()` for the `content` property.",
   "notes_by_num":{
     
   },


### PR DESCRIPTION
Following the mention on [Jake Archibalds recent post](https://jakearchibald.com/2022/img-aspect-ratio/#:~:text=But%20this%20isn%27t,change%20one%20day!) I went checking:

https://www.w3.org/TR/css-values-4/#changes-recent

> Deferred [toggle()](https://www.w3.org/TR/css-values-4/#funcdef-toggle) and [attr()](https://www.w3.org/TR/css-values-4/#funcdef-attr) to Level 5.

https://drafts.csswg.org/css-values-5 is currently [Editor’s Draft](https://www.w3.org/standards/types#ED), so back to `unoff`.

---

With the double space here
```markdown
on  **any**
```
I'm attempting to fix that there's no space rendered currently, despite one being there in the file:

![image](https://user-images.githubusercontent.com/2644614/178365509-0fc9dffb-1ba8-421e-8fa6-15f8ba708d65.png)

Is it a bug in the renderer or somewhere, do you know a better fix?

---

Additionally: I guess the file should technically now be changed

```diff
- css3-attr.json
+ css5-attr.json
```

but seeing as that now would 'break' e.g. Jakes post I guess it should stay (on top of that you rarely change names) - unless you are able to add a redirect? B-)