### PR TITLE
Media Queries: resolution for Safari 16 as well + update Edge bug

### DIFF
--- a/features-json/css-media-resolution.json
+++ b/features-json/css-media-resolution.json
@@ -23,7 +23,7 @@
   ],
   "bugs":[
     {
-      "description":"Microsoft Edge has a bug where `min-resolution` less than `1dpcm` [is ignored](https://jsfiddle.net/behmjd5t/)."
+      "description":"Microsoft Edge Legacy (v18 and below) has a bug where `min-resolution` less than `1dpcm` [is ignored](https://jsfiddle.net/behmjd5t/)."
     }
   ],
   "categories":[
@@ -312,7 +312,7 @@
       "15.2-15.3":"a x #3",
       "15.4":"a x #3",
       "15.5":"a x #3",
-      "16.0":"a x #3",
+      "16.0":"y",
       "TP":"y"
     },
     "opera":{
@@ -426,7 +426,7 @@
       "15.2-15.3":"a x #3",
       "15.4":"a x #3",
       "15.5":"a x #3",
-      "16.0":"a x #3"
+      "16.0":"y"
     },
     "op_mini":{
       "all":"a #1"


### PR DESCRIPTION
Same as (part of) #6148, but for Safari 16 🎉

<https://tests.caniuse.com/css-media-resolution>:

![EA6C4BBE-F28D-4370-A103-06EE2BEBE0F7](https://user-images.githubusercontent.com/2644614/178374374-488d37d6-119f-4968-ad34-ab37b54dc940.png)

---

I checked the Edge bug, when it was (re-)added(?) [here](https://github.com/Fyrd/caniuse/commit/78c2cefdecf520661fb3947768448c6f50ce33fd#diff-dcdffba17072ff6b3b2e889e170380806f90ec9a18f33243365148462633d1e6) the latest version was 18 using EdgeHTML and at least in the current version it's not around anymore:

![image](https://user-images.githubusercontent.com/2644614/178374153-c99b0ed4-f6d9-4261-b1f9-c8eebd2d82a7.png)
