### PR TITLE
Updates to WebAssembly

### DIFF
--- a/features-json/wasm.json
+++ b/features-json/wasm.json
@@ -5,12 +5,16 @@
   "status":"other",
   "links":[
     {
-      "url":"https://webassembly.github.io/",
+      "url":"https://webassembly.org/",
       "title":"Official site"
     },
     {
       "url":"https://developer.mozilla.org/docs/WebAssembly",
       "title":"WebAssembly on MDN"
+    },
+    {
+      "url":"https://webassembly.org/roadmap/",
+      "title":"Roadmap and detailed feature support table"
     }
   ],
   "bugs":[


### PR DESCRIPTION
- website moved
- link to https://webassembly.org/roadmap/

It's only one click away from the homepage, but I thought there's value in directly and clearly linking there.

I had this on my backlog because of the rolling definition of what wasm actually is, without meaningful version numbers (for now): https://github.com/WebAssembly/design/issues/1395