### PR TITLE
Update svg-filters.json

### DIFF
--- a/features-json/svg-filters.json
+++ b/features-json/svg-filters.json
@@ -5,10 +5,6 @@
   "status":"rec",
   "links":[
     {
-      "url":"http://electricbeach.org/?p=950",
-      "title":"Experiments with filter effects"
-    },
-    {
       "url":"http://svg-wow.org/blog/category/filters/",
       "title":"SVG filter demos"
     },


### PR DESCRIPTION
The domain for the specific resource has been taken over by a hosting company, and as such, I am removing the link.

In case you'd like to preserve the resource there is an archive link is available here:

http://wayback.vefsafn.is/wayback/20140721113025/http://electricbeach.org/?p=950

(At the time of writing this Archive.org is having ElasticSearch problems so that's why the alternative Wayback link)