### PR TITLE
Updates to mediasource

### DIFF
--- a/features-json/mediasource.json
+++ b/features-json/mediasource.json
@@ -496,9 +496,7 @@
   "notes":"",
   "notes_by_num":{
     "1":"Partial support in IE11 refers to only working in Windows 8+",
-    "2":"Fully supported only in iPadOS 13 and later.",
-    "3":"Due to compatibility issues, MediaSource Extensions are currently disabled by default in Samsung Internet.",
-    "4":"Fully supported only in iPadOS 13 and later."
+    "2":"Fully supported only in iPadOS, 13 and later"
   },
   "usage_perc_y":82.25,
   "usage_perc_a":14.54,


### PR DESCRIPTION
- unused notes 3 and 4 seem to have returned; ref #5470
- maybe just a fail on my side, but I spent way too long thinking about why note 2 is there if support starts with version 13 anyway - because the emphasis is on iPadOS, as in it's iPadOS only. hence here my attempt to make it subtly more clear; ref #4995