### PR TITLE
U2F => `unoff` & tag with typo again

### DIFF
--- a/features-json/u2f.json
+++ b/features-json/u2f.json
@@ -2,7 +2,7 @@
   "title":"FIDO U2F API",
   "description":"JavaScript API to interact with Universal Second Factor (U2F) devices. This allows users to log into sites more securely using two-factor authentication with a USB dongle.",
   "spec":"https://fidoalliance.org/specs/fido-u2f-v1.0-nfc-bt-amendment-20150514/fido-u2f-javascript-api.html",
-  "status":"other",
+  "status":"unoff",
   "links":[
     {
       "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=1065729",

--- a/features-json/webauthn.json
+++ b/features-json/webauthn.json
@@ -505,7 +505,7 @@
   "usage_perc_a":0.76,
   "ucprefix":false,
   "parent":"",
-  "keywords":"fido,webauthn",
+  "keywords":"fido,webauthn,webauthm",
   "ie_id":"webauthenticationapi",
   "chrome_id":"5669923372138496",
   "firefox_id":"web-authentication",


### PR DESCRIPTION
Following up what [you said here](https://github.com/Fyrd/caniuse/pull/6390#issuecomment-1193371304)

> [@Schweinepriester](https://github.com/Schweinepriester) Think we should change the status to `unoff`? The spec seems to have been a ["review draft"](https://fidoalliance.org/specs/fido-u2f-v1.0-nfc-bt-amendment-20150514/fido-u2f-javascript-api.html) so probably should already have been…

and I totally agree!

Additionally I'm trying to add the wrong `webauthm` tag again - you fixed the typo in #6390, but I intentionally wrote it with m, because that was one issue in #6217 :D
But if you understandably don't want tags-with-spelling-error (to increase findability), feel free to remove again :)