### PR TITLE
Update iOS 16 support in avif.json

### DIFF
--- a/features-json/avif.json
+++ b/features-json/avif.json
@@ -429,7 +429,7 @@
       "15.2-15.3":"n",
       "15.4":"n",
       "15.5":"n",
-      "16.0":"y"
+      "16.0":"y #2 #4"
     },
     "op_mini":{
       "all":"n"
@@ -502,7 +502,8 @@
   "notes_by_num":{
     "1":"Can be enabled in Firefox via the `image.avif.enabled` pref in `about:config`.",
     "2":"Only supports still images. AVIF sequences are not supported!",
-    "3":"Only available on macOS 13 Ventura or later"
+    "3":"Only available on macOS 13 Ventura or later",
+    "4":"Does not support images with noise synthesis."
   },
   "usage_perc_y":71.11,
   "usage_perc_a":0.01,


### PR DESCRIPTION
Add note 2 to iOS 16.

Add no support for noise synthesis as note 4 and attach to iOS 16.