### PR TITLE
Update css-overflow-anchor.json

### DIFF
--- a/features-json/css-overflow-anchor.json
+++ b/features-json/css-overflow-anchor.json
@@ -1,7 +1,7 @@
 {
   "title":"CSS overflow-anchor (Scroll Anchoring)",
   "description":"Changes in DOM elements above the visible region of a scrolling box can result in the page moving while the user is in the middle of consuming the content.\r\nBy default, the value of  `overflow-anchor` is `auto`, it can mitigate this jarring user experience by keeping track of the position of an anchor node and adjusting the scroll offset accordingly",
-  "spec":"https://wicg.github.io/ScrollAnchoring/",
+  "spec":"https://drafts.csswg.org/css-scroll-anchoring/",
   "status":"wd",
   "links":[
     {


### PR DESCRIPTION
The Scroll Anchoring spec has graduated from the WICG, and is now a CSSWG spec.

Closes #6415 