### PR TITLE
Update web-bluetooth.json to correct broken link

### DIFF
--- a/features-json/web-bluetooth.json
+++ b/features-json/web-bluetooth.json
@@ -508,7 +508,7 @@
     "1":"Available by enabling the \"Web Bluetooth\" experimental flag in `about:flags`. Currently support [varies by OS](https://github.com/WebBluetoothCG/web-bluetooth/blob/gh-pages/implementation-status.md)",
     "2":"Only in Opera Mobile",
     "3":"Available in [Origin Trials](https://developers.google.com/web/updates/2015/07/interact-with-ble-devices-on-the-web#available-for-origin-trials) for Chrome OS, Android M, and Mac",
-    "4":"Currently support [varies by OS](https://github.com/WebBluetoothCG/web-bluetooth/blob/gh-pages/implementation-status.md)"
+    "4":"Currently support [varies by OS](https://github.com/WebBluetoothCG/web-bluetooth/blob/master/implementation-status.md#chrome)"
   },
   "usage_perc_y":73.58,
   "usage_perc_a":0,


### PR DESCRIPTION
Fixed invalid link for Chrome implementation notes footnote