### PR TITLE
Tiny indirect typo improvement to HTML Media Capture

### DIFF
--- a/features-json/html-media-capture.json
+++ b/features-json/html-media-capture.json
@@ -502,7 +502,7 @@
   },
   "notes":"",
   "notes_by_num":{
-    "1":"iOS6-10 do not support the capture attribute used to force capture straight from the device's camera or microphone. Also note that default video dimensions are 480x320 (4:3).",
+    "1":"Does not support the capture attribute used to force capture straight from the device's camera or microphone. Also note that default video dimensions are 480x320 (4:3).",
     "2":"Android 2.2-2.3 do not support the capture attribute",
     "3":"Supports a \"capture\" button for any `<input type=\"file\"> field, regardless of the whether the capture attribute is used."
   },


### PR DESCRIPTION
Arrived here via https://austingil.com/html-capture-attribute/ 0:-)

Support on iOS seems to have improved, the `capture` attribute might even be supported, but I'm not fully convinced everything works 100 % after checking the [tests](https://tests.caniuse.com/html-media-capture), so I didn't touch it (yet?).