### PR TITLE
Improve description of `:has()` + add a resource

### DIFF
--- a/features-json/css-has.json
+++ b/features-json/css-has.json
@@ -1,12 +1,16 @@
 {
   "title":":has() CSS relational pseudo-class",
-  "description":"Only select elements containing specified content. For example, `a:has(>img)` selects all `<a>` elements that contain an `<img>` child.",
+  "description":"Select elements containing specific content. For example, `a:has(img)` selects all `<a>` elements that contain an `<img>` child.",
   "spec":"https://drafts.csswg.org/selectors-4/#relational",
   "status":"wd",
   "links":[
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/:has",
       "title":"MDN Web Docs - :has"
+    },
+    {
+      "url":"https://webkit.org/blog/13096/css-has-pseudo-class/",
+      "title":"Using :has() as a CSS Parent Selector and much more"
     },
     {
       "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=418039",


### PR DESCRIPTION
Currently the description for `:has()` says:
>Only select elements containing specified content. For example, `a:has(>img)` selects all `<a>` elements that contain an `<img>` child.

First, `a:has(>img)` doesn't select all `<a>` elements that contain an `<img>`. It will only select those that have an `<img>` as a direct child. Because it's `>img` instead of `img`. 

The easiest way to fix this without adding complexity is to simply remove the `>` and make it:  
>For example, `a:has(img)` selects all `<a>` elements that contain an `<img>` child.

Second, I think the first sentence could be a bit more clear. I propose:
> Select elements containing specific content. For example, `a:has(img)` selects all `<a>` elements that contain an `<img>` child.

In addition, I added a link to resources to include an [in-depth tutorial](https://webkit.org/blog/13096/css-has-pseudo-class/) on how to use :has() that walks developers through specific examples.