### PR TITLE
Clarifications regarding accessibility and `display: contents` 

### DIFF
--- a/features-json/css-display-contents.json
+++ b/features-json/css-display-contents.json
@@ -314,9 +314,9 @@
       "15.4":"a #2",
       "15.5":"a #2",
       "15.6":"a #2",
-      "16.0":"a #2",
-      "16.1":"a #2",
-      "TP":"a #2"
+      "16.0":"y #4 #5",
+      "16.1":"y #5",
+      "TP":"y #5"
     },
     "opera":{
       "9":"n",
@@ -433,8 +433,8 @@
       "15.4":"a #2",
       "15.5":"a #2",
       "15.6":"a #2",
-      "16.0":"y",
-      "16.1":"y"
+      "16.0":"y #4 #5",
+      "16.1":"y #5"
     },
     "op_mini":{
       "all":"n"
@@ -506,9 +506,12 @@
   },
   "notes":"",
   "notes_by_num":{
-    "1":"Enabled in Chrome through the \"experimental Web Platform features\" flag in chrome://flags",
-    "2":"Partial support refers to [severe implementation bug](https://hiddedevries.nl/en/blog/2018-04-21-more-accessible-markup-with-display-contents) that renders the content inaccessible.",
-    "3":"Safari support is buggy, see [WebKit bug 188259](https://bugs.webkit.org/show_bug.cgi?id=188259) & [WebKit bug 193567](https://bugs.webkit.org/show_bug.cgi?id=193567)"
+    "1":"Enabled through the \"experimental Web Platform features\" flag in `chrome://flags`.",
+    "2":"Partial support refers to [severe implementation bug](https://hiddedevries.nl/en/blog/2018-04-21-more-accessible-markup-with-display-contents) that renders content inaccessible.",
+    "3":"Buggy support. See [188259](https://bugs.webkit.org/show_bug.cgi?id=188259) and [193567](https://bugs.webkit.org/show_bug.cgi?id=193567)"
+    "4":"Buttons are not accessible with `display: contents` applied. See [243486](https://bugs.webkit.org/show_bug.cgi?id=243486)"
+    "5":"HTML Tables are not accessible with `display: contents` applied. See [239479](https://bugs.webkit.org/show_bug.cgi?id=239479) and [239478](https://bugs.webkit.org/show_bug.cgi?id=239478)"
+
   },
   "usage_perc_y":75.41,
   "usage_perc_a":19.9,

--- a/features-json/css-display-contents.json
+++ b/features-json/css-display-contents.json
@@ -508,8 +508,8 @@
   "notes_by_num":{
     "1":"Enabled through the \"experimental Web Platform features\" flag in `chrome://flags`.",
     "2":"Partial support refers to [severe implementation bug](https://hiddedevries.nl/en/blog/2018-04-21-more-accessible-markup-with-display-contents) that renders content inaccessible.",
-    "3":"Buggy support. See [188259](https://bugs.webkit.org/show_bug.cgi?id=188259) and [193567](https://bugs.webkit.org/show_bug.cgi?id=193567)"
-    "4":"Buttons are not accessible with `display: contents` applied. See [243486](https://bugs.webkit.org/show_bug.cgi?id=243486)"
+    "3":"Buggy support. See [188259](https://bugs.webkit.org/show_bug.cgi?id=188259) and [193567](https://bugs.webkit.org/show_bug.cgi?id=193567)",
+    "4":"Buttons are not accessible with `display: contents` applied. See [243486](https://bugs.webkit.org/show_bug.cgi?id=243486)",
     "5":"HTML Tables are not accessible with `display: contents` applied. See [239479](https://bugs.webkit.org/show_bug.cgi?id=239479) and [239478](https://bugs.webkit.org/show_bug.cgi?id=239478)"
 
   },


### PR DESCRIPTION
Here's a pull request with clearer details about what is and is not accessible when `display: contents` is applied to elements in Safari 16.0, Safari 16.1, and Safari Technology Preview.