### PR TITLE
Update HEVC support page

### DIFF
--- a/features-json/hevc.json
+++ b/features-json/hevc.json
@@ -174,9 +174,9 @@
       "102":"n",
       "103":"n",
       "104":"n",
-      "105":"n",
-      "106":"n",
-      "107":"n"
+      "105":"a #5",
+      "106":"a #5",
+      "107":"a #5"
     },
     "chrome":{
       "4":"n",
@@ -465,7 +465,7 @@
       "64":"n #2"
     },
     "and_chr":{
-      "105":"n #2"
+      "105":"a #2"
     },
     "and_ff":{
       "104":"n"
@@ -509,7 +509,8 @@
     "1":"Supported only for devices with [hardware support](https://answers.microsoft.com/en-us/insider/forum/insider_apps-insider_wmp/windows-10-hevc-playback-yes-or-no/3c1ab780-a6b2-4b77-ac0f-9faeefd4680d)",
     "2":"Reported to work in certain Android devices with hardware support",
     "3":"Supported only on macOS High Sierra or later",
-    "4":"Supported only for devices with [hardware support](https://techcommunity.microsoft.com/t5/discussions/updated-dev-channel-build-77-0-211-3-is-live/m-p/745801#M6548)"
+    "4":"Supported only for devices with [hardware support](https://techcommunity.microsoft.com/t5/discussions/updated-dev-channel-build-77-0-211-3-is-live/m-p/745801#M6548)",
+    "5":"Supported on chrome platformws [with hardware](https://bugs.chromium.org/p/chromium/issues/detail?id=460703)"
   },
   "usage_perc_y":18.05,
   "usage_perc_a":4.81,

--- a/features-json/hevc.json
+++ b/features-json/hevc.json
@@ -510,7 +510,7 @@
     "2":"Reported to work in certain Android devices with hardware support",
     "3":"Supported only on macOS High Sierra or later",
     "4":"Supported only for devices with [hardware support](https://techcommunity.microsoft.com/t5/discussions/updated-dev-channel-build-77-0-211-3-is-live/m-p/745801#M6548)",
-    "5":"Supported on chrome platformws [with hardware](https://bugs.chromium.org/p/chromium/issues/detail?id=460703)"
+    "5":"Supported on chrome platforms with [hardware support](https://bugs.chromium.org/p/chromium/issues/detail?id=460703)"
   },
   "usage_perc_y":18.05,
   "usage_perc_a":4.81,


### PR DESCRIPTION
https://bitmovin.com/google-adds-hevc-support-chrome/
https://bugs.chromium.org/p/chromium/issues/detail?id=460703

Validated on Chrome (105) on windows. macOS and Android. 