### PR TITLE
Safari TP 154: `:dir()` by default

### DIFF
--- a/features-json/css-dir-pseudo.json
+++ b/features-json/css-dir-pseudo.json
@@ -323,7 +323,7 @@
       "15.6":"n",
       "16.0":"n",
       "16.1":"n",
-      "TP":"n d #2"
+      "TP":"y"
     },
     "opera":{
       "9":"n",
@@ -514,8 +514,7 @@
   },
   "notes":"",
   "notes_by_num":{
-    "1":"Can be enabled via the `#enable-experimental-web-platform-features` flag",
-    "2":"Can be enabled under the Experimental Features menu"
+    "1":"Can be enabled via the `#enable-experimental-web-platform-features` flag"
   },
   "usage_perc_y":3.41,
   "usage_perc_a":0,


### PR DESCRIPTION
<https://webkit.org/blog/13207/release-notes-for-safari-technology-preview-154/>:

> Enabled `:dir` by default ([254051@main](https://commits.webkit.org/254051@main), [254106@main](https://commits.webkit.org/254106@main), [253878@main](https://commits.webkit.org/253878@main), [253881@main](https://commits.webkit.org/253881@main), [253896@main](https://commits.webkit.org/253896@main))

<https://tests.caniuse.com/css-dir-pseudo>:

<img width="1154" alt="image" src="https://user-images.githubusercontent.com/2644614/192058368-f5a06dbb-80d3-4866-b036-d8da5be229e0.png">

Also, WPT: https://wpt.fyi/results/?label=master&label=experimental&aligned=&view=subtest&q=dir+pseudo

🎉 