### PR TITLE
COLRv1: Firefox 105+ flag & add link

### DIFF
--- a/features-json/colr-v1.json
+++ b/features-json/colr-v1.json
@@ -523,7 +523,7 @@
   "notes":"",
   "notes_by_num":{
     "1":"Can be enabled with the \"COLR v1 Fonts\" feature flag under `chrome://flags`",
-    "2":"Firefox actively supports this format and will consider implementing it in the future: [https://mozilla.github.io/standards-positions/#font-colrv1](https://mozilla.github.io/standards-positions/#font-colrv1)"
+    "2":"Firefox actively supports this format and will consider implementing it in the future: [https://mozilla.github.io/standards-positions/#font-colrv1](https://mozilla.github.io/standards-positions/#font-colrv1)",
     "3":"Can be enabled by setting `gfx.font_rendering.colr_v1.enabled` to true"
   },
   "usage_perc_y":70.48,

--- a/features-json/colr-v1.json
+++ b/features-json/colr-v1.json
@@ -27,6 +27,10 @@
     {
       "url":"https://lists.webkit.org/pipermail/webkit-dev/2021-March/031765.html",
       "title":"WebKit position"
+    },
+    {
+      "url":"https://material.io/blog/color-fonts-are-here",
+      "title":"First Batch of Color Fonts Arrives on Google Fonts"
     }
   ],
   "bugs":[
@@ -186,9 +190,9 @@
       "102":"n #2",
       "103":"n #2",
       "104":"n #2",
-      "105":"n #2",
-      "106":"n #2",
-      "107":"n #2"
+      "105":"n d #3",
+      "106":"n d #3",
+      "107":"n d #3"
     },
     "chrome":{
       "4":"n",
@@ -520,6 +524,7 @@
   "notes_by_num":{
     "1":"Can be enabled with the \"COLR v1 Fonts\" feature flag under `chrome://flags`",
     "2":"Firefox actively supports this format and will consider implementing it in the future: [https://mozilla.github.io/standards-positions/#font-colrv1](https://mozilla.github.io/standards-positions/#font-colrv1)"
+    "3":"Can be enabled by setting `gfx.font_rendering.colr_v1.enabled` to true"
   },
   "usage_perc_y":70.48,
   "usage_perc_a":0,


### PR DESCRIPTION
- https://material.io/blog/color-fonts-are-here
- literally matching the MDN entry: https://caniuse.com/?search=colrv1 => https://caniuse.com/mdn-css_at-rules_font-face_opentype_colrv1
- the bug https://bugzilla.mozilla.org/show_bug.cgi?id=1740530 plus changeset https://hg.mozilla.org/integration/autoland/rev/a5e90bc3b2e1
- looks like it might be coming by default in 107, but as there are no changes there yet I will update in the future: https://bugzilla.mozilla.org/show_bug.cgi?id=1791558
- finally, tested using https://tests.caniuse.com/colr-v1 => https://codepen.io/drott_chrome/pen/ExvaYxm
   - firefox [doesn't seem to support CBDT/CBLC](https://caniuse.com/mdn-css_at-rules_font-face_opentype_cbdt_cblc), so
      >  Emoji on left should be vector versions of emoji on right
      
      isn't true, but left matches Chrome

![image](https://user-images.githubusercontent.com/2644614/192168231-68aa6032-ff3d-474a-aaf4-9b0d9fc75357.png)
