### PR TITLE
Fix: HEVC is officially supported since M107 not M105

### DIFF
--- a/features-json/hevc.json
+++ b/features-json/hevc.json
@@ -279,8 +279,8 @@
       "102":"n",
       "103":"n",
       "104":"n",
-      "105":"a #5",
-      "106":"a #5",
+      "105":"n",
+      "106":"n",
       "107":"a #5",
       "108":"a #5",
       "109":"a #5"
@@ -450,7 +450,7 @@
       "4.2-4.3":"n",
       "4.4":"n",
       "4.4.3-4.4.4":"n",
-      "105":"n #2"
+      "107":"a #5"
     },
     "bb":{
       "7":"n",
@@ -510,8 +510,8 @@
     "1":"Supported only for devices with [hardware support](https://answers.microsoft.com/en-us/insider/forum/insider_apps-insider_wmp/windows-10-hevc-playback-yes-or-no/3c1ab780-a6b2-4b77-ac0f-9faeefd4680d)",
     "2":"Reported to work in certain Android devices with hardware support",
     "3":"Supported only on macOS High Sierra or later",
-    "4":"Supported only for devices with [hardware support](https://techcommunity.microsoft.com/t5/discussions/updated-dev-channel-build-77-0-211-3-is-live/m-p/745801#M6548)",
-    "5":"Supported on chrome platforms with [hardware support](https://bugs.chromium.org/p/chromium/issues/detail?id=460703)"
+    "4":"Supported only on Windows(>= Windows 10 1709) and only when [HEVC video extensions from the Microsoft Store](https://apps.microsoft.com/store/detail/hevc-video-extension/9NMZLZ57R3T7) is installed for devices with [hardware support](https://techcommunity.microsoft.com/t5/discussions/updated-dev-channel-build-77-0-211-3-is-live/m-p/745801#M6548)",
+    "5":"Supported on Windows(>= Windows 8), macOS(>= Big Sur 11.0), Android, and Chrome OS platforms with [hardware support](https://github.com/StaZhu/enable-chromium-hevc-hardware-decoding)"
   },
   "usage_perc_y":18.05,
   "usage_perc_a":46.91,


### PR DESCRIPTION
1. HEVC support will be enabled by default since M107 not M105(https://chromiumdash.appspot.com/commit/f46f3399d7ff1119f1f1b9026d31110d7e5b9d8a), the current page is incorrect. Some user who are using chrome below version 107 but greater than version 104 maybe able to use the feature by passing `--enable-features=PlatformHEVCDecoderSupport` switch argument or by randomly hited "finch experment", but in general, not everyone can use it now.
2. Update the correct os and version detail that chrome current supports and also update the link to its support detail.
3. Update `Microsoft Edge` need to install `HEVC video extension` and only on Windows can use the feature.
4. Android support should also be started from M107.