### PR TITLE
Update Chrome HEVC Linux support status

### DIFF
--- a/features-json/hevc.json
+++ b/features-json/hevc.json
@@ -512,7 +512,7 @@
     "2":"Reported to work in certain Android devices with hardware support",
     "3":"Supported only on macOS High Sierra or later",
     "4":"Supported only on Windows(>= Windows 10 1709) and only when [HEVC video extensions from the Microsoft Store](https://apps.microsoft.com/store/detail/hevc-video-extension/9NMZLZ57R3T7) is installed for devices with [hardware support](https://techcommunity.microsoft.com/t5/discussions/updated-dev-channel-build-77-0-211-3-is-live/m-p/745801#M6548)",
-    "5":"Supported on Windows(>= Windows 8), macOS(>= Big Sur 11.0), Android, and Chrome OS platforms with [hardware support](https://github.com/StaZhu/enable-chromium-hevc-hardware-decoding)"
+    "5":"Supported on Windows(>= Windows 8), macOS(>= Big Sur 11.0), Android, Linux(Chrome >= 108.0.5354.0) and Chrome OS platforms with [hardware support](https://github.com/StaZhu/enable-chromium-hevc-hardware-decoding)"
   },
   "usage_perc_y":18.02,
   "usage_perc_a":4.89,


### PR DESCRIPTION
Linux support will also be added since `108.0.5354.0`