### PR TITLE
Update "Opus" to "Opus audio format"

### DIFF
--- a/features-json/opus.json
+++ b/features-json/opus.json
@@ -1,5 +1,5 @@
 {
-  "title":"Opus",
+  "title":"Opus audio format",
   "description":"Royalty-free open audio codec by IETF, which incorporated SILK from Skype and CELT from Xiph.org, to serve higher sound quality and lower latency at the same bitrate.",
   "spec":"https://tools.ietf.org/html/rfc6716",
   "status":"other",


### PR DESCRIPTION
This update makes opus title similiar to other audio codecs like aac, flac, and vorbis.