### PR TITLE
Chrome 108: CSS `color()` function behind flag 🎉 

### DIFF
--- a/features-json/css-color-function.json
+++ b/features-json/css-color-function.json
@@ -288,8 +288,8 @@
       "105":"n",
       "106":"n",
       "107":"n",
-      "108":"n",
-      "109":"n"
+      "108":"n d #2",
+      "109":"n d #2"
     },
     "safari":{
       "3.1":"n",
@@ -513,7 +513,8 @@
   },
   "notes":"For this function to work properly, the device screen and OS also needs to support the color space being used.",
   "notes_by_num":{
-    "1":"Only supports `display-p3` predefined color profile."
+    "1":"Only supports `display-p3` predefined color profile.",
+    "2":"Available behind the [Experimental Web Platform features](chrome://flags/#enable-experimental-web-platform-features) flag"
   },
   "usage_perc_y":15.23,
   "usage_perc_a":2.94,


### PR DESCRIPTION
@svgeesus in <https://bugzilla.mozilla.org/show_bug.cgi?id=1128204#c11>:

> Noting that this is now implemented in Chrome 108 under the experimental flag, in addition to having shipped in Safari.
>
> https://wpt.fyi/results/css/css-color?label=master&label=experimental&aligned&view=subtest

And indeed, with the flag enabled <https://tests.caniuse.com/css-color-function> shows:

![image](https://user-images.githubusercontent.com/2644614/196915766-96039afc-e201-499a-a009-7094efdb59f3.png)

🎉 