### PR TITLE
Fix known issue link to greensock forum

### DIFF
--- a/features-json/requestanimationframe.json
+++ b/features-json/requestanimationframe.json
@@ -23,7 +23,7 @@
   ],
   "bugs":[
     {
-      "description":"There's [an issue](http://forums.greensock.com/topic/6639-tweens-not-working-on-ios6/?p=24455#entry24455) with requestAnimationFrame on iOS6, the bug still appears to exist in 6.1.3"
+      "description":"There's [an issue](https://greensock.com/forums/topic/6639-tweens-not-working-on-ios6/#comment-24455) with requestAnimationFrame on iOS6, the bug still appears to exist in 6.1.3"
     }
   ],
   "categories":[


### PR DESCRIPTION
As their forum url changed it broke the url.