### PR TITLE
Fix IntersectionObserver Polyfill link

### DIFF
--- a/features-json/intersectionobserver.json
+++ b/features-json/intersectionobserver.json
@@ -9,7 +9,7 @@
       "title":"MDN Web Docs - Intersection Observer"
     },
     {
-      "url":"https://github.com/w3c/IntersectionObserver/tree/master/polyfill",
+      "url":"https://github.com/w3c/IntersectionObserver",
       "title":"Polyfill"
     },
     {


### PR DESCRIPTION
<https://github.com/w3c/IntersectionObserver/tree/main/polyfill> is 404 now with no obvious way to get to the repo (you have to edit the URL), therefore directly link to <https://github.com/w3c/IntersectionObserver> :)