### PR TITLE
Update Safari usage for logical shorthand

### DIFF
--- a/features-json/css-logical-props.json
+++ b/features-json/css-logical-props.json
@@ -312,7 +312,7 @@
       "13":"a #3 #4",
       "13.1":"a #3 #4",
       "14":"a #3 #4",
-      "14.1":"a #4",
+      "14.1":"a #4 #6",
       "15":"y",
       "15.1":"y",
       "15.2-15.3":"y",
@@ -434,7 +434,7 @@
       "13.3":"a #3 #4",
       "13.4-13.7":"a #3 #4",
       "14.0-14.4":"a #3 #4",
-      "14.5-14.8":"a #4",
+      "14.5-14.8":"a #4 #6",
       "15.0-15.1":"y",
       "15.2-15.3":"y",
       "15.4":"y",
@@ -518,6 +518,7 @@
     "3":"Does not support the `margin-block`, `margin-inline`, `padding-block`, `padding-inline`, or any of the `inset` shorthand properties. Supported in newer Chromium browsers behind the `#enable-experimental-web-platform-features` flag",
     "4":"Does not support the `border-start-start-radius`, `border-start-end-radius`, `border-end-start-radius` and `border-end-end-radius` property.",
     "5":"Does not support the `border-start-start-radius`, `border-start-end-radius`, `border-end-start-radius` and `border-end-end-radius` property."
+    "6":"Does not support the `margin-block`, `margin-inline`, `padding-block`, `padding-inline` shorthand properties when value is a CSS property. Supported when using a length value."
   },
   "usage_perc_y":91.27,
   "usage_perc_a":6.94,


### PR DESCRIPTION
Hi,

I realized during testing that iOS 14.5+ and Safari 14.1 does not support margin-inline/padding-inline/margin-block/padding-block shorthand when the value is set as a CSS property (fixed in Safari 15).

This can be reproduced it here: https://codepen.io/bakura10/pen/wvXzzVR

<img width="508" alt="image" src="https://user-images.githubusercontent.com/1198915/200143894-04238f27-56e5-45de-8fed-60136677e1b2.png">
