### PR TITLE
CSS font-variant-alternates: Add Chromium support bug & fix caniuse link

### DIFF
--- a/features-json/font-variant-alternates.json
+++ b/features-json/font-variant-alternates.json
@@ -7,6 +7,10 @@
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-alternates",
       "title":"MDN Web Docs - font-variant-alternates"
+    },
+    {
+      "url":"https://bugs.chromium.org/p/chromium/issues/detail?id=716567",
+      "title":"Chromium support bug"
     }
   ],
   "bugs":[
@@ -504,7 +508,7 @@
   },
   "notes":"",
   "notes_by_num":{
-    "1":"Low-level syntax available in [font-feature-settings](https://caniuse.com/#feat=font-feature) property equivalent to OpenType features: salt, ss01 through ss20, cv01 through cv99, swsh, cswh, ornm, nalt",
+    "1":"Low-level syntax available in [font-feature-settings](/font-feature) property equivalent to OpenType features: salt, ss01 through ss20, cv01 through cv99, swsh, cswh, ornm, nalt",
     "2":"Experimental support available by enabling the layout.css.font-features.enabled flag"
   },
   "usage_perc_y":21.87,


### PR DESCRIPTION
Inspired by https://twitter.com/jensimmons/status/1590025285168074753 I looked at https://caniuse.com/font-variant-alternates and Chromium, found https://bugs.chromium.org/p/chromium/issues/detail?id=716567.