### PR TITLE
Safari: not honoring <base> in dynamic imports in inlined modules

### DIFF
--- a/features-json/es6-module-dynamic-import.json
+++ b/features-json/es6-module-dynamic-import.json
@@ -26,7 +26,9 @@
     }
   ],
   "bugs":[
-    
+    {
+      "description": "Safari [does not honor `<base>`](https://bugs.webkit.org/show_bug.cgi?id=201692) when `moduleName` (specifier) is relative (starts with `./`) in inline scripts"
+    }
   ],
   "categories":[
     "JS"


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=201692

Description is an extraction from comments in the bug ([only dynamic imports](https://bugs.webkit.org/show_bug.cgi?id=201692#c1), [inlined modules](https://bugs.webkit.org/show_bug.cgi?id=201692#c3)).
Today I bumped into that problem myself