### PR TITLE
Font-weight problem on macOS 13 with Firefox 107

### DIFF
--- a/features-json/fontface.json
+++ b/features-json/fontface.json
@@ -19,6 +19,9 @@
     },
     {
       "description":"Android 2.2 - 3.0 are reported not to support `local()` value"
+    },
+    {
+      "description":"macOS 13, Firefox 107 - using `local()` the `font-weight` is not working."
     }
   ],
   "categories":[


### PR DESCRIPTION
If you use Firefox 107 on macOS 13 with `local()` to load the local font if present, it will break the font-weight property, and all of the font-weight will be 400. 

I couldn't find any related information online. It would be good if someone could validate the statement above.