### PR TITLE
Update HEVC support status

### DIFF
--- a/features-json/hevc.json
+++ b/features-json/hevc.json
@@ -458,7 +458,7 @@
       "4.2-4.3":"n",
       "4.4":"n",
       "4.4.3-4.4.4":"n",
-      "107":"n #2"
+      "107":"a #5"
     },
     "bb":{
       "7":"n",
@@ -474,7 +474,7 @@
       "72":"n #2"
     },
     "and_chr":{
-      "107":"n #2"
+      "107":"a #5"
     },
     "and_ff":{
       "106":"n"
@@ -519,7 +519,7 @@
     "1":"Supported only for devices with [hardware support](https://answers.microsoft.com/en-us/insider/forum/insider_apps-insider_wmp/windows-10-hevc-playback-yes-or-no/3c1ab780-a6b2-4b77-ac0f-9faeefd4680d)",
     "2":"Reported to work in certain Android devices with hardware support",
     "3":"Supported only on macOS High Sierra or later",
-    "4":"Supported only on Windows(>= Windows 10 1709) and only when [HEVC video extensions from the Microsoft Store](https://apps.microsoft.com/store/detail/hevc-video-extension/9NMZLZ57R3T7) is installed for devices with [hardware support](https://techcommunity.microsoft.com/t5/discussions/updated-dev-channel-build-77-0-211-3-is-live/m-p/745801#M6548)",
+    "4":"Supported on macOS (Edge >= 107, OS >= Big Sur 11.0) and Windows(>= Windows 10 1709) when [HEVC video extensions from the Microsoft Store](https://apps.microsoft.com/store/detail/hevc-video-extension/9NMZLZ57R3T7) is installed for devices with [hardware support](https://techcommunity.microsoft.com/t5/discussions/updated-dev-channel-build-77-0-211-3-is-live/m-p/745801#M6548)",
     "5":"Supported on Windows(>= Windows 8), macOS(>= Big Sur 11.0), Android, Linux(Chrome >= 108.0.5354.0) and Chrome OS platforms with [hardware support](https://github.com/StaZhu/enable-chromium-hevc-hardware-decoding)"
   },
   "usage_perc_y":18.44,


### PR DESCRIPTION
1. Edge Mac support HEVC since version 107.
2. Chrome Android support HEVC since version 107.