### PR TITLE
Updates to viewport units

### DIFF
--- a/features-json/viewport-unit-variants.json
+++ b/features-json/viewport-unit-variants.json
@@ -1,6 +1,6 @@
 {
-  "title":"Large, Small, and Dynamic viewport units",
-  "description":"Viewport units similar to `vw` and `vh` that are based on shown or hidden browser UI states to address shortcomings of the original units. Currently defined as the `lvh`, `lvw`, `svh`, `svw`, `dvh`, `dvw` units.",
+  "title":"Small, Large, and Dynamic viewport units",
+  "description":"Viewport units similar to `vw` and `vh` that are based on shown or hidden browser UI states to address shortcomings of the original units. Currently defined as the `sv*` units (`svb`, `svh`, `svi`, `svmax`, `svmin`, `svw`), `lv*` units (`lvb`, `lvh`, `lvi`, `lvmax`, `lvmin`, `lvw`), `dv*` units (`dvb`, `dvh`, `dvi`, `dvmax`, `dvmin`, `dvw`) and the logical `vi`/`vb` units.",
   "spec":"https://www.w3.org/TR/css-values-4/#viewport-variants",
   "status":"wd",
   "links":[
@@ -538,7 +538,7 @@
   "parent":"",
   "keywords":"",
   "ie_id":"",
-  "chrome_id":"",
+  "chrome_id":"5170718078140416",
   "firefox_id":"",
   "webkit_id":"",
   "shown":true


### PR DESCRIPTION
> sv* units, lv* units, dv* units and the logical vi/vb units.

stolen from https://chromestatus.com/feature/5170718078140416.

> `sv*` units (`svb`, `svh`, `svi`, `svmax`, `svmin`, `svw`), `lv*` units (`lvb`, `lvh`, `lvi`, `lvmax`, `lvmin`, `lvw`), `dv*` units (`dvb`, `dvh`, `dvi`, `dvmax`, `dvmin`, `dvw`) and the logical `vi`/`vb` units

is a bit unwieldy, but I thought it would be good to have them all for search results? Or move the bulk to tags?

MDN: https://developer.mozilla.org/en-US/docs/Web/CSS/length

![image](https://user-images.githubusercontent.com/2644614/210023036-d7c569dd-8a62-4a74-b391-49aa744d64a4.png)

Random side note: https://trac.webkit.org/changeset/286458/webkit/

---

It would probably be nice to update https://tests.caniuse.com/viewport-unit-variants as well to cover more/all units :)