### PR TITLE
Chrome 112: CSS Nesting

### DIFF
--- a/features-json/css-nesting.json
+++ b/features-json/css-nesting.json
@@ -298,7 +298,7 @@
       "109":"n d #1",
       "110":"n d #1",
       "111":"n d #1",
-      "112":"n d #1"
+      "112":"y"
     },
     "safari":{
       "3.1":"n",
@@ -536,7 +536,7 @@
   "parent":"",
   "keywords":"&,@nest,nested css",
   "ie_id":"",
-  "chrome_id":"",
+  "chrome_id":"5800613594529792",
   "firefox_id":"",
   "webkit_id":"",
   "shown":true


### PR DESCRIPTION
- https://mastodon.social/@intenttoship@botsin.space/109720903039657818
- https://groups.google.com/a/chromium.org/g/blink-dev/c/eFCrkiLynfU/m/JLsh3zQuAAAJ
- https://chromestatus.com/feature/5800613594529792

> Estimated milestones
> DevTrial on desktop 109
> DevTrial on Android 109
> Shipping 112

Chrome Canary is still at 111 right now, so https://tests.caniuse.com/css-nesting isn't testable, but I don't think it's blocking this PR as I'm sure we'll adjust if needed.
(Esp. since the syntax is still in flux.)