### PR TITLE
LCH and Lab are coming in Chrome & Firefox

### DIFF
--- a/features-json/css-lch-lab.json
+++ b/features-json/css-lch-lab.json
@@ -196,7 +196,7 @@
       "108":"n",
       "109":"n",
       "110":"n",
-      "111":"n"
+      "111":"n d #1"
     },
     "chrome":{
       "4":"n",
@@ -304,9 +304,9 @@
       "107":"n",
       "108":"n",
       "109":"n",
-      "110":"n",
-      "111":"n",
-      "112":"n"
+      "110":"n d #2",
+      "111":"n d #2",
+      "112":"n d #2"
     },
     "safari":{
       "3.1":"n",
@@ -536,7 +536,8 @@
   },
   "notes":"",
   "notes_by_num":{
-    
+    "1":"Can be enabled by setting about:config flag `layout.css.more_color_4.enabled` to true",
+    "2":"Can be enabled via the `#enable-experimental-web-platform-features` flag in `chrome://flags`"
   },
   "usage_perc_y":15.38,
   "usage_perc_a":0,


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1352757#c15

> [status-firefox111](https://bugzilla.mozilla.org/buglist.cgi?f1=cf_status_firefox111&o1=isnotempty): --- → [fixed](https://bugzilla.mozilla.org/buglist.cgi?f1=cf_status_firefox111&o1=equals&v1=fixed)
Resolution: --- → FIXED
Target Milestone: --- → 111 Branch

https://hg.mozilla.org/mozilla-central/diff/3fa8d29c7c448ff587e467ef82764024f53f0b26/modules/libpref/init/StaticPrefList.yaml

> layout.css.more_color_4.enabled

<https://tests.caniuse.com/css-lch-lab>:

![image](https://user-images.githubusercontent.com/2644614/213866059-a6fe1325-05e6-45b9-8eaf-ef9a4e7e2f4c.png)

There's back and forth in [the Chromium bug](https://bugs.chromium.org/p/chromium/issues/detail?id=1333988), but even current Chrome beta 110.0.5481.38:

![image](https://user-images.githubusercontent.com/2644614/213866124-f5a3a085-4301-4bfc-b1fe-4d36b0916bb6.png)

