### PR TITLE
U2F API is being removed in Firefox

### DIFF
--- a/features-json/u2f.json
+++ b/features-json/u2f.json
@@ -197,7 +197,7 @@
       "108":"y",
       "109":"y",
       "110":"y",
-      "111":"y"
+      "111":"n d #2"
     },
     "chrome":{
       "4":"n",
@@ -538,7 +538,7 @@
   "notes":"The U2F API is [being decommissioned](https://www.yubico.com/blog/google-chrome-u2f-api-decommission-what-the-change-means-for-your-users-and-how-to-prepare/) (only the API, not the U2F protocol) and superseded by [WebAuthn](/webauthn).",
   "notes_by_num":{
     "1":"Requires the \"FIDO U2F (Universal 2nd Factor)\" Chrome extension",
-    "2":"Support can be enabled with the \"security.webauth.u2f\" flag",
+    "2":"Support can be enabled with the `security.webauth.u2f` flag",
     "3":"Supported [via the internal CryptoTokenExtension.](https://github.com/google/u2f-ref-code/blob/master/u2f-gae-demo/war/js/u2f-api.js)"
   },
   "usage_perc_y":22.22,


### PR DESCRIPTION
<https://bugzilla.mozilla.org/show_bug.cgi?id=1809333>

> So we can set the default value of security.webauth.u2f to false in 111.

> [status-firefox111](https://bugzilla.mozilla.org/buglist.cgi?f1=cf_status_firefox111&o1=isnotempty): --- → [fixed](https://bugzilla.mozilla.org/buglist.cgi?f1=cf_status_firefox111&o1=equals&v1=fixed)
Resolution: --- → FIXED
Target Milestone: --- → 111 Branch

<https://hg.mozilla.org/integration/autoland/rev/8e01a52267b3>