### PR TITLE
Add a memory leak bug in Chrome for the lazy loading attribute

### DIFF
--- a/features-json/loading-lazy-attr.json
+++ b/features-json/loading-lazy-attr.json
@@ -28,6 +28,9 @@
   "bugs":[
     {
       "description":"Safari 16.1 and below displays a gray border while lazy loading images ([243601](https://bugs.webkit.org/show_bug.cgi?id=243601))"
+    },
+    {
+      "description":"Chromium-based browsers have a memory leak when lazy loading images ([1213045](https://bugs.chromium.org/p/chromium/issues/detail?id=1213045))"
     }
   ],
   "categories":[


### PR DESCRIPTION
`loading=lazy` has [a memory leak in Chrome](https://bugs.chromium.org/p/chromium/issues/detail?id=1213045) that still hasn't been fixed.