### PR TITLE
Rename: CSS Paint API -> CSS Painting API

### DIFF
--- a/features-json/css-paint-api.json
+++ b/features-json/css-paint-api.json
@@ -1,5 +1,5 @@
 {
-  "title":"CSS Paint API",
+  "title":"CSS Painting API",
   "description":"Allows programmatic generation of images used by CSS",
   "spec":"https://drafts.css-houdini.org/css-paint-api/",
   "status":"cr",


### PR DESCRIPTION
CSS Painting API is the official name used by the [W3C Candidate Recommendation Draft][1]. Using the official name in a search on the caniuse.com website yields no results.

[1]: https://www.w3.org/TR/css-paint-api-1/