### PR TITLE
Remove es7 from decorators keywords

### DIFF
--- a/features-json/decorators.json
+++ b/features-json/decorators.json
@@ -544,7 +544,7 @@
   "usage_perc_a":0,
   "ucprefix":false,
   "parent":"",
-  "keywords":"es7 decorators,JavaScript Class and Property Decorators",
+  "keywords":"decorators,JavaScript Class and Property Decorators",
   "ie_id":"",
   "chrome_id":"",
   "firefox_id":"",


### PR DESCRIPTION
Early on as the decorators proposal first got momentum, it was (wrongfully) assumed that decorators would make it into ES7. That is not the case and searches for "es7" on caniuse today will bring up decorators even though they're not part of ES7.