### PR TITLE
Firefox 111: CSS color() function as well

### DIFF
--- a/features-json/css-color-function.json
+++ b/features-json/css-color-function.json
@@ -189,8 +189,8 @@
       "108":"n",
       "109":"n",
       "110":"n",
-      "111":"n",
-      "112":"n"
+      "111":"n d #3",
+      "112":"n d #3"
     },
     "chrome":{
       "4":"n",
@@ -539,7 +539,8 @@
   "notes":"For this function to work properly, the device screen and OS also needs to support the color space being used.",
   "notes_by_num":{
     "1":"Only supports `display-p3` predefined color profile.",
-    "2":"Available behind the [Experimental Web Platform features](chrome://flags/#enable-experimental-web-platform-features) flag"
+    "2":"Available behind the [Experimental Web Platform features](chrome://flags/#enable-experimental-web-platform-features) flag",
+    "3":"Can be enabled by setting about:config flag `layout.css.more_color_4.enabled` to true"
   },
   "usage_perc_y":16.21,
   "usage_perc_a":2.17,


### PR DESCRIPTION
- https://github.com/mdn/content/blob/main/files/en-us/mozilla/firefox/releases/111/index.md#css
- https://github.com/mdn/content/issues/24395
- https://github.com/mdn/content/pull/25015

> CSS color functions `color()`, `lab()`, `lch()`, `oklab()`, and `oklch()` are now supported. These features are disabled by default and can be enabled by setting the preference `layout.css.more_color_4.enabled` to true. For more information, see the [CSS color value](https://github.com/mdn/content/blob/main/en-US/docs/Web/CSS/color_value) documentation ([Firefox bug 1352757](https://bugzil.la/1352757) and [Firefox bug 1128204](https://bugzil.la/1128204)).

(Don't know why it's not yet on <https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/111>…)

<https://tests.caniuse.com/css-color-function> with the flag enabled:

![image](https://user-images.githubusercontent.com/2644614/223487350-6e15e406-a387-475a-aa63-bdf584a69316.png)

🎉 