### PR TITLE
Updated HEVC support status to make it more accurate

### DIFF
--- a/features-json/hevc.json
+++ b/features-json/hevc.json
@@ -540,8 +540,8 @@
     "1":"Supported only for devices with [hardware support](https://answers.microsoft.com/en-us/insider/forum/insider_apps-insider_wmp/windows-10-hevc-playback-yes-or-no/3c1ab780-a6b2-4b77-ac0f-9faeefd4680d)",
     "2":"Reported to work in certain Android devices with hardware support",
     "3":"Supported only on macOS High Sierra or later",
-    "4":"Supported on macOS (Edge >= 107, OS >= Big Sur 11.0) and Windows(>= Windows 10 1709) when [HEVC video extensions from the Microsoft Store](https://apps.microsoft.com/store/detail/hevc-video-extension/9NMZLZ57R3T7) is installed for devices with [hardware support](https://techcommunity.microsoft.com/t5/discussions/updated-dev-channel-build-77-0-211-3-is-live/m-p/745801#M6548)",
-    "5":"Supported on Windows(>= Windows 8), macOS(>= Big Sur 11.0), Android, Linux(Chrome >= 108.0.5354.0) and Chrome OS platforms with [hardware support](https://github.com/StaZhu/enable-chromium-hevc-hardware-decoding)"
+    "4":"Supported for all devices on macOS (>= Big Sur 11.0) and Android (>= 5.0) if Edge >= 107, for devices with [hardware support](https://techcommunity.microsoft.com/t5/discussions/updated-dev-channel-build-77-0-211-3-is-live/m-p/745801#M6548) on Windows (>= Windows 10 1709) when [HEVC video extensions from the Microsoft Store](https://apps.microsoft.com/store/detail/hevc-video-extension/9NMZLZ57R3T7) is installed",
+    "5":"Supported for all devices on macOS (>= Big Sur 11.0) and Android (>= 5.0), for devices with [hardware support](https://github.com/StaZhu/enable-chromium-hevc-hardware-decoding) on Windows (>= Windows 8), and for devices with hardware support powered by VAAPI on Linux and ChromeOS"
   },
   "usage_perc_y":18.19,
   "usage_perc_a":69.32,


### PR DESCRIPTION
1. Actually macOS and Android also bundled a software decoder, on these platforms, as long as the system version meets the requirements, all devices will support it.
2. Linux and ChromeOS's support is very limited, since Chromium currently only support VAAPI for HEVC.