### PR TITLE
Correcting definition of A2HS

### DIFF
--- a/features-json/web-app-manifest.json
+++ b/features-json/web-app-manifest.json
@@ -1,6 +1,6 @@
 {
   "title":"Add to home screen (A2HS)",
-  "description":"The ability for a user to \"install\" a website and use it as if it was a natively installed app.",
+  "description":"The ability for a user to \"install\" a website and use it as if it was a natively installed app. To enable this behaviour, a website must serve a valid Web App Manifest.",
   "spec":"https://www.w3.org/TR/appmanifest/",
   "status":"wd",
   "links":[

--- a/features-json/web-app-manifest.json
+++ b/features-json/web-app-manifest.json
@@ -1,6 +1,6 @@
 {
   "title":"Add to home screen (A2HS)",
-  "description":"The ability for a user to \"install\" a website and use it as if it was a natively installed app. To enable this behaviour, a website must serve a valid Web App Manifest and load it's assets through a [Service Worker](https://caniuse.com/#feat=serviceworkers).",
+  "description":"The ability for a user to \"install\" a website and use it as if it was a natively installed app.",
   "spec":"https://www.w3.org/TR/appmanifest/",
   "status":"wd",
   "links":[


### PR DESCRIPTION
Removing this part of the definition of A2HS:
>To enable this behaviour, a website must serve a valid Web App Manifest and load it's assets through a [Service Worker](https://caniuse.com/#feat=serviceworkers).

That is the definition in some browsers, but not others. A simpler definition is better — especially to reflect the variation between implementations. Safari has never required a Service Worker for Add to Home Screen.