### PR TITLE
Changes to descriptions of AVIF and JPEG XL

### DIFF
--- a/features-json/avif.json
+++ b/features-json/avif.json
@@ -1,6 +1,6 @@
 {
   "title":"AVIF image format",
-  "description":"A modern image format based on the [AV1 video format](/av1). AVIF generally has better compression than [WebP](/webp), JPEG, PNG and GIF and is designed to supersede them. AVIF competes with [JPEG XL](/jpegxl) which has similar compression quality and is generally seen as more feature-rich than AVIF.",
+  "description":"A modern image format based on the [AV1 video format](/av1). AVIF generally has better compression than [WebP](/webp), JPEG, PNG and GIF and is designed to supersede them.",
   "spec":"https://aomediacodec.github.io/av1-avif/",
   "status":"other",
   "links":[


### PR DESCRIPTION
Copy the design goals of JPEG XL from https://jpeg.org/jpegxl/.

Remove the comparison between AVIF and JPEG XL, which is not essential to the raison d'être of caniuse: answering the "can I use ...?" question.