### PR TITLE
Update Web Bluetooth implementation status links

### DIFF
--- a/features-json/web-bluetooth.json
+++ b/features-json/web-bluetooth.json
@@ -548,10 +548,10 @@
   },
   "notes":"",
   "notes_by_num":{
-    "1":"Available by enabling the \"Web Bluetooth\" experimental flag in `about:flags`. Currently support [varies by OS](https://github.com/WebBluetoothCG/web-bluetooth/blob/gh-pages/implementation-status.md)",
+    "1":"Available by enabling the \"Web Bluetooth\" experimental flag in `about:flags`. Currently support [varies by OS](https://github.com/WebBluetoothCG/web-bluetooth/blob/main/implementation-status.md)",
     "2":"Only in Opera Mobile",
     "3":"Available in [Origin Trials](https://developers.google.com/web/updates/2015/07/interact-with-ble-devices-on-the-web#available-for-origin-trials) for Chrome OS, Android M, and Mac",
-    "4":"Currently support [varies by OS](https://github.com/WebBluetoothCG/web-bluetooth/blob/master/implementation-status.md#chrome)"
+    "4":"Currently support [varies by OS](https://github.com/WebBluetoothCG/web-bluetooth/blob/main/implementation-status.md#chrome)"
   },
   "usage_perc_y":73.92,
   "usage_perc_a":0,


### PR DESCRIPTION
Update two of the links to the implementation status page to use the `main` branch. (The link using the `master` branch was still working, but consistency is good)