### PR TITLE
Update that Safari 16.4 Web Push Notifications are delivered without …

### DIFF
--- a/features-json/push-api.json
+++ b/features-json/push-api.json
@@ -544,7 +544,7 @@
     "4":"Disabled on Firefox ESR, but can be re-enabled with the `dom.serviceWorkers.enabled` and `dom.push.enabled` flags",
     "5":"Partial implementation can be enabled via \"Push API\" in the Experimental Features menu",
     "6":"Only available on macOS 13 Ventura or later and only in Safari itself, not WKWebView nor SFSafariViewController",
-    "7":"Requires website to first be [added to the Home Screen](/web-app-manifest)"
+    "7":"Requires website to first be [added to the Home Screen](/web-app-manifest). Delivered silently, meaning no sound, vibration, haptics or screen wake."
   },
   "usage_perc_y":77.31,
   "usage_perc_a":2.65,


### PR DESCRIPTION
As said in the title. Notifications aren't that useful if the user isn't actually notified. You don't get alerted when your phone is locked or you are not looking. When locked it will appear when you unlock the iPhone. It would be useful to know before implementing something that is basically useless. 