### PR TITLE
Declarative Shadow DOM: add Firefox bugzilla URL

### DIFF
--- a/features-json/declarative-shadow-dom.json
+++ b/features-json/declarative-shadow-dom.json
@@ -15,6 +15,10 @@
     {
       "url":"https://bugs.webkit.org/show_bug.cgi?id=249513",
       "title":"WebKit support bug"
+    },
+    {
+      "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=1712140",
+      "title":"Firefox implementation bug"
     }
   ],
   "bugs":[


### PR DESCRIPTION
Hi, I want to add a link to the firefox bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1712140