### PR TITLE
Update css-grid.json for Safari bugs

### DIFF
--- a/features-json/css-grid.json
+++ b/features-json/css-grid.json
@@ -479,19 +479,19 @@
       "13.2":"y",
       "13.3":"y",
       "13.4-13.7":"y",
-      "14.0-14.4":"y",
-      "14.5-14.8":"y",
-      "15.0-15.1":"y",
-      "15.2-15.3":"y",
-      "15.4":"y",
-      "15.5":"y",
-      "15.6":"y",
-      "16.0":"y",
-      "16.1":"y",
-      "16.2":"y",
-      "16.3":"y",
-      "16.4":"y",
-      "16.5":"y"
+      "14.0-14.4":"a #5",
+      "14.5-14.8":"a #5",
+      "15.0-15.1":"a #5",
+      "15.2-15.3":"a #5",
+      "15.4":"a #5",
+      "15.5":"a #5",
+      "15.6":"a #5",
+      "16.0":"a #5",
+      "16.1":"a #5",
+      "16.2":"a #5",
+      "16.3":"a #5",
+      "16.4":"a #5",
+      "16.5":"a #5"
     },
     "op_mini":{
       "all":"n"
@@ -570,7 +570,8 @@
     "1":"Enabled in Chrome through the \"experimental Web Platform features\" flag in chrome://flags",
     "2":"Partial support in IE refers to supporting an [older version](https://www.w3.org/TR/2011/WD-css3-grid-layout-20110407/) of the specification.",
     "3":"Enabled in Firefox through the `layout.css.grid.enabled ` flag",
-    "4":"There are some bugs with overflow ([1356820](https://bugzilla.mozilla.org/show_bug.cgi?id=1356820), [1348857](https://bugzilla.mozilla.org/show_bug.cgi?id=1348857), [1350925](https://bugzilla.mozilla.org/show_bug.cgi?id=1350925))"
+    "4":"There are some bugs with overflow ([1356820](https://bugzilla.mozilla.org/show_bug.cgi?id=1356820), [1348857](https://bugzilla.mozilla.org/show_bug.cgi?id=1348857), [1350925](https://bugzilla.mozilla.org/show_bug.cgi?id=1350925))",
+    "5":"Safari 14 through 16, and probably earlier versions, will not allow VoiceOver swipe or read-all navigation of tables that have `display: grid` on the `<tr>`s [257458](https://bugs.webkit.org/show_bug.cgi?id=257458)."
   },
   "usage_perc_y":96.49,
   "usage_perc_a":0.43,


### PR DESCRIPTION
Added information about Safari/iOS issues with tables that use `display:grid`. Includes link to Safari bug https://bugs.webkit.org/show_bug.cgi?id=257458.