### PR TITLE
Update description of HEIF and HEVC formats

### DIFF
--- a/features-json/av1.json
+++ b/features-json/av1.json
@@ -571,7 +571,7 @@
   "usage_perc_y":70.25,
   "usage_perc_a":0,
   "ucprefix":false,
-  "parent":"",
+  "parent":"video",
   "keywords":"",
   "ie_id":"",
   "chrome_id":"5729898442260480",

--- a/features-json/heif.json
+++ b/features-json/heif.json
@@ -555,7 +555,7 @@
   },
   "notes":"",
   "notes_by_num":{
-    "1":"While supported natively since macOS 10.13 High Sierra and iOS 11, the file format does not appear to be supported in Safari."
+    "1":"Was supported natively in macOS/iOS, but was not supported in Safari."
   },
   "usage_perc_y":0,
   "usage_perc_a":0,

--- a/features-json/heif.json
+++ b/features-json/heif.json
@@ -1,6 +1,6 @@
 {
-  "title":"HEIF/ISO Base Media File Format",
-  "description":"HEIF (High Efficiency Image File Format) is a standard developed by the Moving Picture Experts Group (MPEG) for storage and sharing of images and image sequences. Can use `.heif` or `.heic` file extensions.",
+  "title":"HEIF/HEIC image format",
+  "description":"A modern image format based on the [HEVC video format](/hevc). HEIC generally has better compression than [WebP](/webp), JPEG, PNG and GIF. It is hard for browsers to support HEIC because it is [complex and expensive to license](https://en.wikipedia.org/wiki/High_Efficiency_Video_Coding#Patent_licensing). [AVIF](/avif) and [JPEG XL](/jpegxl) provide free licenses and are designed to supersede HEIC.",
   "spec":"https://nokiatech.github.io/heif/technical.html",
   "status":"other",
   "links":[
@@ -561,7 +561,7 @@
   "usage_perc_a":0,
   "ucprefix":false,
   "parent":"",
-  "keywords":"heic",
+  "keywords":"heic,hevc",
   "ie_id":"",
   "chrome_id":"",
   "firefox_id":"",

--- a/features-json/hevc.json
+++ b/features-json/hevc.json
@@ -1,6 +1,6 @@
 {
   "title":"HEVC/H.265 video format",
-  "description":"The High Efficiency Video Coding (HEVC) compression standard is a video compression format intended to succeed H.264",
+  "description":"The High Efficiency Video Coding (HEVC) compression standard is a video compression format intended to succeed H.264. It is hard for browsers to universally support HEVC because it is [complex and expensive to license](https://en.wikipedia.org/wiki/High_Efficiency_Video_Coding#Patent_licensing). HEVC competes with [AV1](/av1) which has similar compression quality and provides a free license.",
   "spec":"https://www.itu.int/rec/T-REC-H.265",
   "status":"other",
   "links":[


### PR DESCRIPTION
When I updated all image descriptions in #5523, I skipped `HEIF` because it was a bit unclear what exactly it was tracking. Now that Safari has restarted developer awareness of it, I wanted to give it a shot.

Main changes:

### Shift focus from `HEIF` to `HEIC` + `HEVC`
`HEIF` is a relatively simple container format that can be used for many things, for example to package `JPEG`- or `AV1`-encoded images. I do not think it makes sense to track support for that here, and thus I have tried to mention it as little as possible.

What people normally think of when they hear `HEIF`, is an `HEIF` container with `HEVC`-encoded content.  This is _theoretically_ what you get if you have an `HEIC` file. The support that @Schweinepriester just added in #6738 is also specifically referring to support for Apple's `HEIC` files with `HEVC`-encoded content. Therefore, I have mentioned those names in the description.

### Mention patent/licensing issues for HEVC and HEIC
When I was researching H.265 a long time ago, I did not understand why browsers only support it on some machines. It seemed to me like it was only a matter of time before it would be fully supported. Now I know that because of licensing, H.265 will likely always have spotty support, and you will always need a fallback codec.
If the caniuse desription had mentioned the licensing issue, I think it would have helped me figure this out much faster.

### Point the user towards `JPEG XL` and `AVIF`
In the other image descriptions, I try to make it clear which formats are "worse" and which formats are "better" to help the developer get a quick overview. In the `HEIF` description, I position both `JPEG XL` and `AVIF` as "better" codecs, even though their compression quality is similar to `HEIF`. I think this is fair, because I am pretty confident that we will see full browser support for `AVIF` and `JPEG XL`, but almost no support for `HEIF` due to its licensing issues. Safari is the only browser supporting it, and they specifically added it to improve compatibility with their _native ecosystem_. I don't think their plan was for the _web ecosystem_ to start using it. 