### PR TITLE
Add partial support for AVIF in Edge Dev/Canary 

### DIFF
--- a/features-json/avif.json
+++ b/features-json/avif.json
@@ -79,9 +79,7 @@
       "111":"n",
       "112":"n",
       "113":"n",
-      "114":"n",
-      "115":"n",
-      "116":"a #6"
+      "114":"n"
     },
     "firefox":{
       "2":"n",
@@ -560,14 +558,13 @@
       "3.0-3.1":"n"
     }
   },
-  "notes":"",
+  "notes":"Supported in Edge 116 and newer only on Windows 11 (Moment 3 or Later)",
   "notes_by_num":{
     "1":"Can be enabled in Firefox via the `image.avif.enabled` pref in `about:config`.",
     "2":"Supports still images. Animated image sequences are not supported.",
     "3":"Only available on macOS 13 Ventura or later.",
     "4":"Does not support images with noise synthesis.",
     "5":"Supports only still images by default. Animated image sequences can be enabled via the `image.avif.sequence.enabled` pref in `about:config`.",
-    "6":"Only available on Windows 11 Moment 3 or Later"
   },
   "usage_perc_y":82.33,
   "usage_perc_a":1.64,

--- a/features-json/avif.json
+++ b/features-json/avif.json
@@ -79,7 +79,9 @@
       "111":"n",
       "112":"n",
       "113":"n",
-      "114":"n"
+      "114":"n",
+      "115":"n",
+      "116":"n d #6"
     },
     "firefox":{
       "2":"n",
@@ -564,7 +566,8 @@
     "2":"Supports still images. Animated image sequences are not supported.",
     "3":"Only available on macOS 13 Ventura or later.",
     "4":"Does not support images with noise synthesis.",
-    "5":"Supports only still images by default. Animated image sequences can be enabled via the `image.avif.sequence.enabled` pref in `about:config`."
+    "5":"Supports only still images by default. Animated image sequences can be enabled via the `image.avif.sequence.enabled` pref in `about:config`.",
+    "6":"Can be enabled in Edge on Windows 10 or later by installing the [AV1 Video Extension from the Microsoft Store](https://www.microsoft.com/store/productId/9MVZQVXJBQ9V)"
   },
   "usage_perc_y":82.33,
   "usage_perc_a":1.64,

--- a/features-json/avif.json
+++ b/features-json/avif.json
@@ -564,7 +564,7 @@
     "2":"Supports still images. Animated image sequences are not supported.",
     "3":"Only available on macOS 13 Ventura or later.",
     "4":"Does not support images with noise synthesis.",
-    "5":"Supports only still images by default. Animated image sequences can be enabled via the `image.avif.sequence.enabled` pref in `about:config`.",
+    "5":"Supports only still images by default. Animated image sequences can be enabled via the `image.avif.sequence.enabled` pref in `about:config`."
   },
   "usage_perc_y":82.33,
   "usage_perc_a":1.64,

--- a/features-json/avif.json
+++ b/features-json/avif.json
@@ -81,7 +81,7 @@
       "113":"n",
       "114":"n",
       "115":"n",
-      "116":"n d #6"
+      "116":"a #6"
     },
     "firefox":{
       "2":"n",
@@ -567,7 +567,7 @@
     "3":"Only available on macOS 13 Ventura or later.",
     "4":"Does not support images with noise synthesis.",
     "5":"Supports only still images by default. Animated image sequences can be enabled via the `image.avif.sequence.enabled` pref in `about:config`.",
-    "6":"Can be enabled in Edge on Windows 10 or later by installing the [AV1 Video Extension from the Microsoft Store](https://www.microsoft.com/store/productId/9MVZQVXJBQ9V)"
+    "6":"Only available on Windows 11 Moment 3 or Later"
   },
   "usage_perc_y":82.33,
   "usage_perc_a":1.64,


### PR DESCRIPTION
It doesn't work in Edge 116 (Dev/Canary) on Windows 10 21H2.
It works in Edge 116 (Dev/Canary) on Windows 11 Moment 3 (22621.1848). 

To be confirmed if Moment 3 is the key factor here?
It doesn't work in Edge 114 (Stable) on Windows 11 Moment 3 (22621.1848). 

Need some help with the validation here too, since Edge Canary is not part of the data model yet.