### PR TITLE
Fix typo for "Media Queries: Range Syntax"

### DIFF
--- a/features-json/css-media-range-syntax.json
+++ b/features-json/css-media-range-syntax.json
@@ -1,6 +1,6 @@
 {
   "title":"Media Queries: Range Syntax",
-  "description":"Syntax improvements to make media queries using features that have a \"range\" type (like width or height) less verbose. Can be used with ordinary mathematical comparison operators: `>`, `<`, `>=`, or `<=`.\r\n\r\nFor example: `@media (100px <= width <= 1900px)` is the equivalent of `@media (min-width: 100px) and (max-width: 1900px`)`",
+  "description":"Syntax improvements to make media queries using features that have a \"range\" type (like width or height) less verbose. Can be used with ordinary mathematical comparison operators: `>`, `<`, `>=`, or `<=`.\r\n\r\nFor example: `@media (100px <= width <= 1900px)` is the equivalent of `@media (min-width: 100px) and (max-width: 1900px)`",
   "spec":"https://www.w3.org/TR/mediaqueries-4/#mq-range-context",
   "status":"cr",
   "links":[


### PR DESCRIPTION
I noticed that some of the code was improperly placed in a inline code – [link](https://caniuse.com/css-media-range-syntax):

<img width="463" alt="image" src="https://github.com/Fyrd/caniuse/assets/22725671/887ee8b6-962f-445a-b7bb-81423193b895">
