### PR TITLE
fullscreen: add CSS category

### DIFF
--- a/features-json/fullscreen.json
+++ b/features-json/fullscreen.json
@@ -38,6 +38,7 @@
     }
   ],
   "categories":[
+    "CSS",
     "JS API"
   ],
   "stats":{


### PR DESCRIPTION
Fullscreen API also includes the `:fullscreen` pseudo class.

https://fullscreen.spec.whatwg.org/#:fullscreen-pseudo-class