### PR TITLE
Edge Insider supports AVIF via runtime flag

### DIFF
--- a/features-json/avif.json
+++ b/features-json/avif.json
@@ -79,8 +79,8 @@
       "111":"n",
       "112":"n",
       "113":"n",
-      "114":"n",
-      "115":"n"
+      "114":"n d #6",
+      "115":"n d #6"
     },
     "firefox":{
       "2":"n",
@@ -573,7 +573,8 @@
     "2":"Supports still images. Animated image sequences are not supported.",
     "3":"Only available on macOS 13 Ventura or later.",
     "4":"Does not support images with noise synthesis.",
-    "5":"Supports only still images by default. Animated image sequences can be enabled via the `image.avif.sequence.enabled` pref in `about:config`."
+    "5":"Supports only still images by default. Animated image sequences can be enabled via the `image.avif.sequence.enabled` pref in `about:config`.",
+    "6":"Can be enabled via the `--enable-features=msEdgeAVIF` runtime flag in insider channels."
   },
   "usage_perc_y":83.84,
   "usage_perc_a":0.9,


### PR DESCRIPTION
https://www.neowin.net/news/microsoft-edge-is-finally-getting-avif-support-long-after-firefox-google-chrome-and-safari/

At one time Dev and Beta supported it, but I forget when they dropped it.