### PR TITLE
Add "jxr" keyword to JPEG XR

### DIFF
--- a/features-json/jpegxr.json
+++ b/features-json/jpegxr.json
@@ -570,7 +570,7 @@
   "usage_perc_a":0,
   "ucprefix":false,
   "parent":"",
-  "keywords":"jpeg-xr",
+  "keywords":"jpeg-xr,jxr",
   "ie_id":"",
   "chrome_id":"",
   "firefox_id":"",


### PR DESCRIPTION
- (DE) https://www.gamestar.de/artikel/neues-update-fuer-windows-11-soll-euren-desktop-hintergrund-so-viel-besser-machen,3398929.html
- https://blogs.windows.com/windows-insider/2023/08/04/announcing-windows-11-insider-preview-build-25921/

  > You can now set JXR files to be your desktop background and if you have an HDR display, they will render in full HDR.


- https://en.wikipedia.org/wiki/JPEG_XR

  > JPEG XR (.JXR) format

If you search for "jxr" currently, [the entry for JPEG XR](https://caniuse.com/jpegxr) isn't found: https://caniuse.com/?search=jxr

Fixing that 🙃