### PR TITLE
Opus/CAF: clarify that only CBR is supported

### DIFF
--- a/features-json/opus.json
+++ b/features-json/opus.json
@@ -561,7 +561,7 @@
   },
   "notes":"Support refers to this format's use in the `audio` element, not other conditions.\r\n\r\nFor Opera the Linux version may be able to play it when the GStreamer module is up to date and the served mime-type is 'audio/ogg'.",
   "notes_by_num":{
-    "1":"Supported only when packaged in a CAF file and on macOS High Sierra/iOS 11 or later."
+    "1":"Supported only when packaged in a CAF file and on macOS High Sierra/iOS 11 or later (constant bit-rate only)."
   },
   "usage_perc_y":76.12,
   "usage_perc_a":19.26,


### PR DESCRIPTION
VBR CAF can be produced by ffmpeg and theoretically is spec-compliant, but Safari (and macOS Quicktime Player) will refuse to decode. Unfortunately Opus defaults to (constrained) VBR because it works better that way!