### PR TITLE
Replace Travis CI badge with GitHub Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # caniuse
-[![Build Status](https://travis-ci.org/Fyrd/caniuse.svg?branch=master)](https://travis-ci.org/Fyrd/caniuse)
+[![Build Status](https://github.com/Fyrd/caniuse/actions/workflows/main.yml/badge.svg?branch=main)](https://github.com/Fyrd/caniuse/actions/)
 
 ## About
 


### PR DESCRIPTION
Hi!
Let's replace the broken Travis CI badge in README.md with the [GitHub Actions badge](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge).

### [Before](https://github.com/Fyrd/caniuse#readme)
![image](https://github.com/Fyrd/caniuse/assets/22644149/e38fb042-9570-4e6c-9a56-15e128ebbd4f)

### [After](https://github.com/a-chabin/caniuse/tree/update-badge#readme)
![image](https://github.com/Fyrd/caniuse/assets/22644149/5b540830-83f2-46ee-be86-e655df207084)

