### PR TITLE
add relative color support in chrome canary

### DIFF
--- a/features-json/css-relative-colors.json
+++ b/features-json/css-relative-colors.json
@@ -320,8 +320,8 @@
       "115":"n",
       "116":"n",
       "117":"n",
-      "118":"n",
-      "119":"n"
+      "118":"n d #1",
+      "119":"n d #1"
     },
     "safari":{
       "3.1":"n",
@@ -572,7 +572,7 @@
   },
   "notes":"",
   "notes_by_num":{
-    
+    "1":"Can be enabled in Chrome via the `#enable-experimental-web-platform-features` flag in `chrome://flags`"
   },
   "usage_perc_y":11.39,
   "usage_perc_a":0,


### PR DESCRIPTION
https://bugs.chromium.org/p/chromium/issues/detail?id=1274133#c11

Tested [this codepen](https://codepen.io/argyleink/pen/VwrKRrY) chrome (118.0.5980.1) and edge (118.0.2071.0) canary