### PR TITLE
Update css-display-contents.json

### DIFF
--- a/features-json/css-display-contents.json
+++ b/features-json/css-display-contents.json
@@ -349,15 +349,15 @@
       "15.5":"a #1",
       "15.6":"a #1",
       "16.0":"a #2 #3",
-      "16.1":"a #3",
-      "16.2":"a #3",
-      "16.3":"a #3",
-      "16.4":"a #3",
-      "16.5":"a #3",
-      "16.6":"a #3",
-      "17.0":"y",
-      "17.1":"y",
-      "TP":"y"
+      "16.1":"a #2 #3",
+      "16.2":"a #2 #3",
+      "16.3":"a #2 #3",
+      "16.4":"a #2 #3",
+      "16.5":"a #2 #3",
+      "16.6":"a #2 #3",
+      "17.0":"a #2",
+      "17.1":"a #2",
+      "TP":"a #2"
     },
     "opera":{
       "9":"n",
@@ -573,7 +573,7 @@
   "notes":"",
   "notes_by_num":{
     "1":"Partial support refers to [severe implementation bugs](https://hiddedevries.nl/en/blog/2018-04-21-more-accessible-markup-with-display-contents) that renders content inaccessible for many element types.",
-    "2":"Buttons are not accessible with `display: contents` applied. See issues for [Chromium](https://bugs.chromium.org/p/chromium/issues/detail?id=1366037), [Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1791648), and [WebKit](https://bugs.webkit.org/show_bug.cgi?id=243486)",
+    "2":"Buttons are not accessible with `display: contents` applied. See issues for [Chromium](https://bugs.chromium.org/p/chromium/issues/detail?id=1366037), [Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1791648), and [WebKit](https://bugs.webkit.org/show_bug.cgi?id=255149)",
     "3":"HTML tables and nodes with ARIA roles `directory`, `grid`, `treegrid`, `table`, `row`, `gridcell`, `cell`, `columnheader`, `tree`, and `treeitem` are not accessible with `display: contents` applied. See WebKit bugs [239478](https://bugs.webkit.org/show_bug.cgi?id=239478), [239479](https://bugs.webkit.org/show_bug.cgi?id=239479), [239478](https://bugs.webkit.org/show_bug.cgi?id=239478), and [257458](https://bugs.webkit.org/show_bug.cgi?id=257458)"
   },
   "usage_perc_y":0.81,


### PR DESCRIPTION
* Confirmed bug with keyboard-inaccessible buttons persists in Safari 17 through TP 180 (Safari 17.4 beta).
* Updated the list of bugs to reference the WebKit bug reporting this from April 2023.