### PR TITLE
Firefox 120 Nightly has started to support HEVC via OS API

### DIFF
--- a/features-json/hevc.json
+++ b/features-json/hevc.json
@@ -9,6 +9,10 @@
       "title":"Firefox support bug (WONTFIX)"
     },
     {
+      "url": "https://bugzilla.mozilla.org/show_bug.cgi?id=1842838",
+      "title":"Firefox support via OS API bug"
+    },
+    {
       "url":"https://en.wikipedia.org/wiki/High_Efficiency_Video_Coding",
       "title":"Wikipedia article"
     },
@@ -202,8 +206,8 @@
       "117":"n",
       "118":"n",
       "119":"n",
-      "120":"n",
-      "121":"n"
+      "120":"n d #6",
+      "121":"n d #6"
     },
     "chrome":{
       "4":"n",
@@ -581,7 +585,8 @@
     "2":"Reported to work in certain Android devices with hardware support",
     "3":"Supported only on macOS High Sierra or later",
     "4":"Supported for all devices on macOS (>= Big Sur 11.0) and Android (>= 5.0) if Edge >= 107, for devices with [hardware support](https://techcommunity.microsoft.com/t5/discussions/updated-dev-channel-build-77-0-211-3-is-live/m-p/745801#M6548) on Windows (>= Windows 10 1709) when [HEVC video extensions from the Microsoft Store](https://apps.microsoft.com/store/detail/hevc-video-extension/9NMZLZ57R3T7) is installed",
-    "5":"Supported for all devices on macOS (>= Big Sur 11.0) and Android (>= 5.0), for devices with [hardware support](https://github.com/StaZhu/enable-chromium-hevc-hardware-decoding) on Windows (>= Windows 8), and for devices with hardware support powered by VAAPI on Linux and ChromeOS"
+    "5":"Supported for all devices on macOS (>= Big Sur 11.0) and Android (>= 5.0), for devices with [hardware support](https://github.com/StaZhu/enable-chromium-hevc-hardware-decoding) on Windows (>= Windows 8), and for devices with hardware support powered by VAAPI on Linux and ChromeOS",
+    "6":"Supported for devices with hardware support (the range is the same as Edge) on Windows in Nightly only"
   },
   "usage_perc_y":21.29,
   "usage_perc_a":68.27,


### PR DESCRIPTION
#6858

It uses the same API as Edge as of now.

https://bugzilla.mozilla.org/show_bug.cgi?id=1853448
https://bugzilla.mozilla.org/show_bug.cgi?id=1859080
https://github.com/StaZhu/enable-chromium-hevc-hardware-decoding#whats-the-tech-diff-compared-with-edge--safari