### PR TITLE
iOS bug with Screen Wake Lock API

### DIFF
--- a/features-json/wake-lock.json
+++ b/features-json/wake-lock.json
@@ -23,7 +23,7 @@
   ],
   "bugs":[
     {
-      "description":"on iOS does not work in standalone (aka PWA) mode, only works in actual browser"
+      "description":"on iOS does not work in web app (aka PWA) mode, only works in actual browser. Bug report: https://bugs.webkit.org/show_bug.cgi?id=254545"
     }
   ],
   "categories":[

--- a/features-json/wake-lock.json
+++ b/features-json/wake-lock.json
@@ -22,7 +22,9 @@
     }
   ],
   "bugs":[
-    
+    {
+      "description":"on iOS does not work in standalone (aka PWA) mode, only works in actual browser"
+    }
   ],
   "categories":[
     "JS API"


### PR DESCRIPTION
on iOS it does not work in standalone (aka PWA) mode, only works in the actual browser. Tested on iOS 17. I think it is important to mention because it reduces possible use cases