### PR TITLE
Fix broken links to kangax.github.io/compat-table/

### DIFF
--- a/features-json/es5.json
+++ b/features-json/es5.json
@@ -5,7 +5,7 @@
   "status":"other",
   "links":[
     {
-      "url":"https://kangax.github.io/compat-table/es5/",
+      "url":"https://compat-table.github.io/compat-table/es5/",
       "title":"Detailed compatibility tables & tests"
     },
     {
@@ -581,7 +581,7 @@
       "3.0-3.1":"y"
     }
   },
-  "notes":"As the specification includes many JavaScript features, un-numbered partial support varies widely and is shown in detail on the [ECMAScript 5 compatibility tables](http://kangax.github.io/compat-table/es5/) by Kangax.",
+  "notes":"As the specification includes many JavaScript features, un-numbered partial support varies widely and is shown in detail on the [ECMAScript 5 compatibility tables](https://compat-table.github.io/compat-table/es5/) by Kangax.",
   "notes_by_num":{
     "1":"Does not support `parseInt()` ignoring leading zeros. ",
     "2":"Does not support Strict mode",

--- a/features-json/es6.json
+++ b/features-json/es6.json
@@ -577,10 +577,10 @@
       "3.0-3.1":"y #2"
     }
   },
-  "notes":"As ES6 refers to a huge specification and browsers have various levels of support, \"Supported\" means at least 95% of the spec is supported. \"Partial support\" refers to at least 10% of the spec being supported. For full details see the [Kangax ES6 support table](https://kangax.github.io/compat-table/es6/).",
+  "notes":"As ES6 refers to a huge specification and browsers have various levels of support, \"Supported\" means at least 95% of the spec is supported. \"Partial support\" refers to at least 10% of the spec being supported. For full details see the [Kangax ES6 support table](https://compat-table.github.io/compat-table/es6/).",
   "notes_by_num":{
     "1":"Notable partial support in IE11 includes (at least some) support for `const`, `let`, block-level function declaration, typed arrays, `Map`, `Set` and `WeakMap`.",
-    "2":"Does not support [tail call optimization](https://kangax.github.io/compat-table/es6/#test-proper_tail_calls_%28tail_call_optimisation%29)",
+    "2":"Does not support [tail call optimization](https://compat-table.github.io/compat-table/es6/#test-proper_tail_calls_%28tail_call_optimisation%29)",
     "3":"Only has partial Symbol support and partial support for `RegExp.prototype` properties"
   },
   "usage_perc_y":95.9,


### PR DESCRIPTION
Apparently, the https://github.com/kangax/compat-table repo has been transferred to https://github.com/compat-table/compat-table. Although the URL https://kangax.github.io/compat-table/ is redirected to https://compat-table.github.io/compat-table/, links like https://kangax.github.io/compat-table/es6/ or https://kangax.github.io/compat-table/es5/ are actually broken, so we need to update them.