### PR TITLE
Update firefox note in  jpegxl.json

### DIFF
--- a/features-json/jpegxl.json
+++ b/features-json/jpegxl.json
@@ -592,7 +592,7 @@
   "notes":"",
   "notes_by_num":{
     "1":"Can be enabled via the `enable-jxl` flag.",
-    "2":"Can be enabled via the `image.jxl.enabled` flag in `about:config` in Nightly only.",
+    "2":"Can be enabled via the `image.jxl.enabled` flag in `about:config`.",
     "3":"Can be enabled via the `--enable-features=JXL` runtime flag."
   },
   "usage_perc_y":3.17,


### PR DESCRIPTION
Now jpegxl can be enabled in stable version of firefox also (not only in nightly) so the note should be updated.