### PR TITLE
Decorators: add link to Bugzilla

### DIFF
--- a/features-json/decorators.json
+++ b/features-json/decorators.json
@@ -19,7 +19,11 @@
     {
       "url":"https://babeljs.io/docs/en/babel-plugin-proposal-decorators",
       "title":"Babel plug-in for decorators"
-    }
+    },
+    {
+      "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=1781212",
+      "title":"Bug on Firefox support"
+    },
   ],
   "bugs":[
     

--- a/features-json/decorators.json
+++ b/features-json/decorators.json
@@ -23,7 +23,7 @@
     {
       "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=1781212",
       "title":"Bug on Firefox support"
-    },
+    }
   ],
   "bugs":[
     


### PR DESCRIPTION
Mozilla currently working on adding decorators [TC39/proposal decorators](https://github.com/tc39/proposal-decorators)

I didn't find any information about other vendors