### PR TITLE
Remove -moz-outline-radius note

### DIFF
--- a/features-json/outline.json
+++ b/features-json/outline.json
@@ -577,6 +577,7 @@
       "3.0-3.1":"y"
     }
   },
+  "notes":"",
   "notes_by_num":{
     "1":"Also supports the value of `invert` for `outline-color`. (support of this value is optional for browsers)",
     "2":"Does not support `outline-offset`."

--- a/features-json/outline.json
+++ b/features-json/outline.json
@@ -577,7 +577,6 @@
       "3.0-3.1":"y"
     }
   },
-  "notes":"Firefox also supports the non-standard `-moz-outline-radius` property that acts similar to `border-radius`.",
   "notes_by_num":{
     "1":"Also supports the value of `invert` for `outline-color`. (support of this value is optional for browsers)",
     "2":"Does not support `outline-offset`."


### PR DESCRIPTION
The support for `-moz-outline-radius` properties [has been removed](https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/88#css) in Firefox 88.