### PR TITLE
loading=lazy bugs

### DIFF
--- a/features-json/loading-lazy-attr.json
+++ b/features-json/loading-lazy-attr.json
@@ -30,8 +30,14 @@
       "description":"Safari 16.1 and below displays a gray border while lazy loading images ([243601](https://bugs.webkit.org/show_bug.cgi?id=243601))"
     },
     {
-      "description":"Chromium-based browsers have a memory leak when lazy loading images ([1213045](https://bugs.chromium.org/p/chromium/issues/detail?id=1213045))"
-    }
+      "description": "Safari does not load lazy loaded elements before printing ([224547](https://bugs.webkit.org/show_bug.cgi?id=224547)). Chromium fixed a similar bug in January 2022 ([875403](https://bugs.chromium.org/p/chromium/issues/detail?id=875403))."
+    },
+    {
+      "description":"Chromium-based browsers have a memory leak when lazy loading images ([1213045](https://bugs.chromium.org/p/chromium/issues/detail?id=1213045)). This issue was fixed in late 2023 for release M116."
+    },
+    {
+      "description": "Firefox requires the loading attribute to be set BEFORE the src element ([1647077](https://bugzilla.mozilla.org/show_bug.cgi?id=1647077))"
+    },
   ],
   "categories":[
     "HTML5"

--- a/features-json/loading-lazy-attr.json
+++ b/features-json/loading-lazy-attr.json
@@ -37,7 +37,7 @@
     },
     {
       "description": "Firefox requires the loading attribute to be set BEFORE the src element ([1647077](https://bugzilla.mozilla.org/show_bug.cgi?id=1647077))"
-    },
+    }
   ],
   "categories":[
     "HTML5"

--- a/features-json/loading-lazy-attr.json
+++ b/features-json/loading-lazy-attr.json
@@ -36,7 +36,7 @@
       "description":"Chromium-based browsers have a memory leak when lazy loading images ([1213045](https://bugs.chromium.org/p/chromium/issues/detail?id=1213045)). This issue was fixed in late 2023 for release M116."
     },
     {
-      "description": "Firefox requires the loading attribute to be set BEFORE the src element ([1647077](https://bugzilla.mozilla.org/show_bug.cgi?id=1647077))"
+      "description": "Firefox requires the loading attribute to be set BEFORE the src element for Javascript created images ([1647077](https://bugzilla.mozilla.org/show_bug.cgi?id=1647077))"
     }
   ],
   "categories":[


### PR DESCRIPTION
Updates for loading=lazy bugs

- Safari doesn't load lazy elements when you print
- Firefox requires the loading attribute to be defined before the src attribute
- The chrome mem leak got fixed