### PR TITLE
Revert "Update firefox note in  jpegxl.json" (#6887) and mention pitfall that the flag has no effect in the other builds than Nightly

### DIFF
--- a/features-json/jpegxl.json
+++ b/features-json/jpegxl.json
@@ -594,7 +594,7 @@
   "notes":"",
   "notes_by_num":{
     "1":"Can be enabled via the `enable-jxl` flag.",
-    "2":"Can be enabled via the `image.jxl.enabled` flag in `about:config`.",
+    "2":"Can be enabled via the `image.jxl.enabled` flag in `about:config` in Nightly only.",
     "3":"Can be enabled via the `--enable-features=JXL` runtime flag."
   },
   "usage_perc_y":3.17,

--- a/features-json/jpegxl.json
+++ b/features-json/jpegxl.json
@@ -594,7 +594,7 @@
   "notes":"",
   "notes_by_num":{
     "1":"Can be enabled via the `enable-jxl` flag.",
-    "2":"Can be enabled via the `image.jxl.enabled` flag in `about:config` in Nightly only.",
+    "2":"Can be enabled via the `image.jxl.enabled` flag in `about:config` in Nightly only. This flag is configurable but has no effect in the other builds.",
     "3":"Can be enabled via the `--enable-features=JXL` runtime flag."
   },
   "usage_perc_y":3.17,


### PR DESCRIPTION
Reverts Fyrd/caniuse#6887

The flag `image.jxl.enabled` is ***still useless*** even in Firefox 120 stable.

![image](https://github.com/Fyrd/caniuse/assets/12870451/b9a78448-14c0-4c48-a569-811f61a7bb49)
![image](https://github.com/Fyrd/caniuse/assets/12870451/e9fff887-5fec-4798-a978-5ff76b94c2cb)

No task to link libjxl even in stable builds is not linked to <https://bugzilla.mozilla.org/show_bug.cgi?id=1539075>.
This means that there have been no changes related to JPEG XL for stable builds.