### PR TITLE
COLR0 is fixed in STP 183 + Safari 17.2 (PR to replace 6888)

### DIFF
--- a/features-json/colr.json
+++ b/features-json/colr.json
@@ -374,8 +374,8 @@
       "16.6":"y",
       "17.0":"n #4",
       "17.1":"n #4",
-      "17.2":"n #4",
-      "TP":"n #4"
+      "17.2":"y",
+      "TP":"y"
     },
     "opera":{
       "9":"n",
@@ -515,7 +515,7 @@
       "16.6-16.7":"y",
       "17.0":"n #4",
       "17.1":"n #4",
-      "17.2":"n #4"
+      "17.2":"y"
     },
     "op_mini":{
       "all":"n"
@@ -596,7 +596,7 @@
     "1":"Supported only on Safari for macOS High Sierra (10.13)+",
     "2":"Supported only on Windows 8.1+",
     "3":"On Windows pre 8.1 and macOS Sierra (10.12) and below falls back to using FreeType: [Chromium bug 882844](https://bugs.chromium.org/p/chromium/issues/detail?id=882844#c3)",
-    "4":"COLRv0 support vanished with Safari 17: [WebKit Bugzilla Bug 262223](https://bugs.webkit.org/show_bug.cgi?id=262223)"
+    "4":"COLRv0 support was disabled by a regression bug in Safari 17.0 and 17.1: [Issue 262223](https://bugs.webkit.org/show_bug.cgi?id=262223)"
   },
   "usage_perc_y":91.82,
   "usage_perc_a":0,


### PR DESCRIPTION
Updated the status, and revised the footnote to be a bit more professional/objective.