### PR TITLE
Firefox 121 stable can enable HEVC via flag

### DIFF
--- a/features-json/hevc.json
+++ b/features-json/hevc.json
@@ -208,11 +208,11 @@
       "117":"n",
       "118":"n",
       "119":"n",
-      "120":"n d #6",
-      "121":"n d #6",
-      "122":"n d #6",
-      "123":"n d #6",
-      "124":"n d #6"
+      "120":"n #6",
+      "121":"n d #7",
+      "122":"n d #7",
+      "123":"n d #7",
+      "124":"n d #7"
     },
     "chrome":{
       "4":"n",
@@ -598,7 +598,8 @@
     "3":"Supported only on macOS High Sierra or later",
     "4":"Supported for all devices on macOS (>= Big Sur 11.0) and Android (>= 5.0) if Edge >= 107, for devices with [hardware support](https://techcommunity.microsoft.com/t5/discussions/updated-dev-channel-build-77-0-211-3-is-live/m-p/745801#M6548) on Windows (>= Windows 10 1709) when [HEVC video extensions from the Microsoft Store](https://apps.microsoft.com/store/detail/hevc-video-extension/9NMZLZ57R3T7) is installed",
     "5":"Supported for all devices on macOS (>= Big Sur 11.0) and Android (>= 5.0), for devices with [hardware support](https://github.com/StaZhu/enable-chromium-hevc-hardware-decoding) on Windows (>= Windows 8), and for devices with hardware support powered by VAAPI on Linux and ChromeOS",
-    "6":"Supported for devices with hardware support (the range is the same as Edge) on Windows in Nightly only"
+    "6":"Supported for devices with hardware support (the range is the same as Edge) on Windows in Nightly only. 10-bit or higher colors are not supported.",
+    "7":"Supported for devices with hardware support (the range is the same as Edge) on Windows only. Enabled by default in Nightly and can be enabled via the `media.wmf.hevc.enabled` pref in `about:config`. 10-bit or higher colors are not supported."
   },
   "usage_perc_y":21.24,
   "usage_perc_a":68.6,


### PR DESCRIPTION
2nd phase of #6858 

![image](https://github.com/Fyrd/caniuse/assets/12870451/b95adefc-9507-4b9c-a719-0601ac60af30)

![image](https://github.com/Fyrd/caniuse/assets/12870451/e8541047-1887-423f-b0fb-8aa94b94bc4c)

I rolled back my Firefox to 120 once but could not play HEVC even with the flag.

10bit or higher colors are not supported.

https://bugzilla.mozilla.org/show_bug.cgi?id=1839107

https://codepen.io/danm8675123/pen/abNavqG

![image](https://github.com/Fyrd/caniuse/assets/12870451/2bb5972a-716d-442d-8e07-5815b747f4e4)
