### PR TITLE
Add description to css-stick

### DIFF
--- a/features-json/css-sticky.json
+++ b/features-json/css-sticky.json
@@ -35,13 +35,7 @@
     },
     {
       "description":"A parent with overflow set to `auto` will prevent `position: sticky` from working in Safari"
-    },
-    {
-      "description":"(Google Chrome)If the parent element has the properties position: absolute and overflow: visible, and the parent element's parent element has the property overflow: hidden, the relative position seems to become relative to the top-level window."
     }
-
-
-    
   ],
   "categories":[
     "CSS"

--- a/features-json/css-sticky.json
+++ b/features-json/css-sticky.json
@@ -35,7 +35,13 @@
     },
     {
       "description":"A parent with overflow set to `auto` will prevent `position: sticky` from working in Safari"
+    },
+    {
+      "description":"(Google Chrome)If the parent element has the properties position: absolute and overflow: visible, and the parent element's parent element has the property overflow: hidden, the relative position seems to become relative to the top-level window."
     }
+
+
+    
   ],
   "categories":[
     "CSS"
@@ -608,7 +614,7 @@
       "3.0-3.1":"y"
     }
   },
-  "notes":"Any ancestor between the sticky element and its user-scrollable container with overflow computed as anything but `visible`/`clip` will effectively prevent sticking behavior.",
+  "notes":"`sticks` to its nearest ancestor that has a `scrolling mechanism` (created when overflow is hidden, scroll, auto, or overlay), even if that ancestor isn't the nearest actually scrolling ancestor",
   "notes_by_num":{
     "1":"Can be enabled in Firefox by setting the about:config preference layout.css.sticky.enabled to true",
     "2":"Enabled through the \"experimental Web Platform features\" flag",


### PR DESCRIPTION
If the parent element has the properties position: absolute and overflow: visible, and the parent element's parent element has the property overflow: hidden, the relative position seems to become relative to the top-level window.
[Sticky test html.zip](https://github.com/Fyrd/caniuse/files/13988999/Sticky.test.html.zip)

 Google Chrome 120.0.6099.225
![20240119203335](https://github.com/Fyrd/caniuse/assets/37351410/020a1a95-d0dc-4aa7-be27-e6758d376e86)
Safari on iOS 17.2.1
![20240119203455](https://github.com/Fyrd/caniuse/assets/37351410/807d66e5-e9b6-4f32-a63d-f1e217a582a7)

