### PR TITLE
@scope rule is defined in an official working draft spec

### DIFF
--- a/features-json/css-cascade-scope.json
+++ b/features-json/css-cascade-scope.json
@@ -2,7 +2,7 @@
   "title":"Scoped Styles: the @scope rule",
   "description":"Allows CSS rules to be scoped to part of the document, with upper and lower limits described by selectors.",
   "spec":"https://drafts.csswg.org/css-cascade-6/#scoped-styles",
-  "status":"unoff",
+  "status":"wd",
   "links":[
     {
       "url":"https://css.oddbird.net/scope/explainer/",


### PR DESCRIPTION
It would also be great if a search for 'scope' would produce this as the top result, instead of the deprecated 2014 feature. Is that possible?