### PR TITLE
Safari on iOS 17.4 doesn't drop Home Screen web apps after all 😌

### DIFF
--- a/features-json/push-api.json
+++ b/features-json/push-api.json
@@ -517,7 +517,7 @@
       "17.1":"a #6",
       "17.2":"a #6",
       "17.3":"a #6",
-      "17.4":"a #6 #7"
+      "17.4":"a #6"
     },
     "op_mini":{
       "all":"n"
@@ -600,8 +600,7 @@
     "3":"Safari 7.0 - 16.0 supported a custom implementation which remains available in later versions, see [Safari Push Notifications](https://developer.apple.com/notifications/safari-push-notifications/) and [WWDC video](https://web.archive.org/web/20210419000205/https://developer.apple.com/videos/play/wwdc2013/614/)",
     "4":"Disabled on Firefox ESR, but can be re-enabled with the `dom.serviceWorkers.enabled` and `dom.push.enabled` flags",
     "5":"Only available on macOS 13 Ventura or later and only in Safari itself, not WKWebView nor SFSafariViewController",
-    "6":"Requires website to first be [added to the Home Screen](/web-app-manifest). Delivered silently, meaning no sound, vibration, haptics or screen wake.",
-    "7":"Only available outside of the European Union"
+    "6":"Requires website to first be [added to the Home Screen](/web-app-manifest). Delivered silently, meaning no sound, vibration, haptics or screen wake."
   },
   "usage_perc_y":79.04,
   "usage_perc_a":13.92,


### PR DESCRIPTION
- https://9to5mac.com/2024/03/01/apple-home-screen-web-apps-ios-17-eu/
- https://www.macrumors.com/2024/03/01/apple-walks-back-decision-to-disable-eu-web-apps/

https://developer.apple.com/support/dma-and-apps-in-the-eu/

> UPDATE: Previously, Apple announced plans to remove the Home Screen web apps capability in the EU as part of our efforts to comply with the DMA. The need to remove the capability was informed by the complex security and privacy concerns associated with web apps to support alternative browser engines that would require building a new integration architecture that does not currently exist in iOS.
>
> We have received requests to continue to offer support for Home Screen web apps in iOS, therefore we will continue to offer the existing Home Screen web apps capability in the EU. This support means Home Screen web apps continue to be built directly on WebKit and its security architecture, and align with the security and privacy model for native apps on iOS.
> 
> Developers and users who may have been impacted by the removal of Home Screen web apps in the beta release of iOS in the EU can expect the return of the existing functionality for Home Screen web apps with the availability of iOS 17.4 in early March.

This basically reverts https://github.com/Fyrd/caniuse/pull/6974.