### PR TITLE
Add WebKit position link to zstd

### DIFF
--- a/features-json/zstd.json
+++ b/features-json/zstd.json
@@ -19,6 +19,10 @@
     {
       "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=zstd",
       "title":"Firefox support bug"
+    },
+    {
+      "url":"https://github.com/WebKit/standards-positions/issues/168",
+      "title":"WebKit position on zstd"
     }
   ],
   "bugs":[


### PR DESCRIPTION
Couldn't find an issue, so https://github.com/WebKit/standards-positions/issues/168 it is 0:-)