### PR TITLE
jpegxl.json: macOS/iOS Safari does not support animated JXL yet

### DIFF
--- a/features-json/jpegxl.json
+++ b/features-json/jpegxl.json
@@ -384,12 +384,12 @@
       "16.4":"n",
       "16.5":"n",
       "16.6":"n",
-      "17.0":"y",
-      "17.1":"y",
-      "17.2":"y",
-      "17.3":"y",
-      "17.4":"y",
-      "TP":"y"
+      "17.0":"y #4",
+      "17.1":"y #4",
+      "17.2":"y #4",
+      "17.3":"y #4",
+      "17.4":"y #4",
+      "TP":"y #4"
     },
     "opera":{
       "9":"n",
@@ -531,11 +531,11 @@
       "16.4":"n",
       "16.5":"n",
       "16.6-16.7":"n",
-      "17.0":"y",
-      "17.1":"y",
-      "17.2":"y",
-      "17.3":"y",
-      "17.4":"y"
+      "17.0":"y #4",
+      "17.1":"y #4",
+      "17.2":"y #4",
+      "17.3":"y #4",
+      "17.4":"y #4"
     },
     "op_mini":{
       "all":"n"
@@ -615,7 +615,8 @@
   "notes_by_num":{
     "1":"Can be enabled via the `enable-jxl` flag.",
     "2":"Can be enabled via the `image.jxl.enabled` flag in `about:config` in Nightly only. This flag is configurable but has no effect in the other builds.",
-    "3":"Can be enabled via the `--enable-features=JXL` runtime flag."
+    "3":"Can be enabled via the `--enable-features=JXL` runtime flag.",
+    "4":"Supports still images. Animated image sequences are not supported."
   },
   "usage_perc_y":10.73,
   "usage_perc_a":0,


### PR DESCRIPTION
You can check this with the following image using the Safari browser: [Link of animated JXL sample](https://jpegxl.info/test-page/anim-icos.jxl)

It should be animated like this <img width=50 src="https://jpegxl.info/test-page/anim-icos.webp"> but it won't.

###### References
- https://jpegxl.info/test-page/