### PR TITLE
PNG no longer a WD

### DIFF
--- a/features-json/apng.json
+++ b/features-json/apng.json
@@ -2,7 +2,7 @@
   "title":"Animated PNG (APNG)",
   "description":"Like animated GIFs, but allowing 24-bit colors and alpha transparency",
   "spec":"https://www.w3.org/TR/png",
-  "status":"wd",
+  "status":"cr",
   "links":[
     {
       "url":"https://en.wikipedia.org/wiki/APNG",


### PR DESCRIPTION
PNG has been Candidate Recommendation since 21 September 2023

https://www.w3.org/TR/2023/CR-png-3-20230921/