### PR TITLE
fix: known chromium issue with WebTransport

### DIFF
--- a/features-json/webtransport.json
+++ b/features-json/webtransport.json
@@ -22,7 +22,9 @@
     }
   ],
   "bugs":[
-    
+    {
+      "description": "There's [an issue](https://issues.chromium.org/issues/40069954) with excessive throttling of WebTransport connections in chromium browsers that cannot be mitigated by code."
+    }
   ],
   "categories":[
     "JS API"

--- a/features-json/webtransport.json
+++ b/features-json/webtransport.json
@@ -26,7 +26,7 @@
       "description": "There's [an issue](https://issues.chromium.org/issues/40069954) with excessive throttling of WebTransport connections in chromium browsers that cannot be mitigated by code."
     },
     {
-      "description": "[An issue](https://issues.chromium.org/issues/326887753?pli=1) in chromium with dropped messages."
+      "description": "[An issue](https://issues.chromium.org/issues/326887753?pli=1) in chromium where closing the writer side of a stream will close without ensuring all previously sent data is actually sent."
     }
   ],
   "categories":[

--- a/features-json/webtransport.json
+++ b/features-json/webtransport.json
@@ -24,6 +24,9 @@
   "bugs":[
     {
       "description": "There's [an issue](https://issues.chromium.org/issues/40069954) with excessive throttling of WebTransport connections in chromium browsers that cannot be mitigated by code."
+    },
+    {
+      "description": "[An issue](https://issues.chromium.org/issues/326887753?pli=1) in chromium with dropped messages."
     }
   ],
   "categories":[

--- a/features-json/webtransport.json
+++ b/features-json/webtransport.json
@@ -23,10 +23,10 @@
   ],
   "bugs":[
     {
-      "description": "There's [an issue](https://issues.chromium.org/issues/40069954) with excessive throttling of WebTransport connections in chromium browsers that cannot be mitigated by code."
+      "description": "Chromium browsers have [an issue](https://issues.chromium.org/issues/40069954) with excessive throttling of WebTransport connections that cannot be mitigated by code."
     },
     {
-      "description": "[An issue](https://issues.chromium.org/issues/326887753?pli=1) in chromium where closing the writer side of a stream will close without ensuring all previously sent data is actually sent."
+      "description": "Chromium browsers have [an issue](https://issues.chromium.org/issues/326887753?pli=1) where closing the writer side of a stream will close without ensuring all previously sent data is actually sent."
     }
   ],
   "categories":[


### PR DESCRIPTION
This bug makes it difficult to use WebTransport for p2p things in chromium browsers.