### PR TITLE
update to webm opus support since Safari 17.4

### DIFF
--- a/features-json/opus.json
+++ b/features-json/opus.json
@@ -382,10 +382,10 @@
       "17.1":"a #1",
       "17.2":"a #1",
       "17.3":"a #1",
-      "17.4":"a #1",
-      "17.5":"a #1",
-      "17.6":"a #1",
-      "TP":"a #1"
+      "17.4":"a #2",
+      "17.5":"a #3",
+      "17.6":"a #3",
+      "TP":"a #3"
     },
     "opera":{
       "9":"n",
@@ -532,9 +532,9 @@
       "17.1":"a #1",
       "17.2":"a #1",
       "17.3":"a #1",
-      "17.4":"a #1",
-      "17.5":"a #1",
-      "17.6":"a #1"
+      "17.4":"a #2",
+      "17.5":"a #3",
+      "17.6":"a #3"
     },
     "op_mini":{
       "all":"n"
@@ -614,6 +614,8 @@
   "notes":"Support refers to this format's use in the `audio` element, not other conditions.\r\n\r\nFor Opera the Linux version may be able to play it when the GStreamer module is up to date and the served mime-type is 'audio/ogg'.",
   "notes_by_num":{
     "1":"Supported only when packaged in a CAF file and on macOS High Sierra/iOS 11 or later (constant bit-rate only)."
+    "2":"Supported in a WebM container (all bitrates). Has a [known regression](https://bugs.webkit.org/show_bug.cgi?id=245428)."
+    "3":"Supported in a WebM container (all bitrates)."
   },
   "usage_perc_y":79.7,
   "usage_perc_a":17.57,


### PR DESCRIPTION
see docs and discussion at:
* https://stackoverflow.com/questions/70143421/webm-and-opus-in-safari
* https://github.com/Fyrd/caniuse/issues/6805#issuecomment-2102183335
* https://github.com/Fyrd/caniuse/issues/7056#issuecomment-2111259595
* https://developer.apple.com/documentation/safari-release-notes/safari-17_4-release-notes#Media
* https://developer.apple.com/documentation/safari-release-notes/safari-17_5-release-notes#Media