### PR TITLE
Safari Technology Preview supports WebGPU

### DIFF
--- a/features-json/webgpu.json
+++ b/features-json/webgpu.json
@@ -392,7 +392,7 @@
       "17.5":"n",
       "17.6":"n",
       "18.0":"n",
-      "TP":"n d #6"
+      "TP":"y"
     },
     "opera":{
       "9":"n",
@@ -627,8 +627,7 @@
     "2":"Can be enabled in Safari on MacOS with the `WebGPU` experimental feature.",
     "3":"Can be enabled in some Chromium browsers (on Windows, MacOS, Linux) with the `enable-unsafe-webgpu` flag.",
     "4":"Part of an origin trial.",
-    "5":"Not enabled on Linux by default.",
-    "6":"Can be enabled via the Develop menu."
+    "5":"Not enabled on Linux by default."
   },
   "usage_perc_y":71.4,
   "usage_perc_a":0,


### PR DESCRIPTION
It shipped in Safari Technology Preview 190, in March 2024.