### PR TITLE
Firefox >= 127 supports rel="dns-prefetch" in HTTPS too

### DIFF
--- a/features-json/link-rel-dns-prefetch.json
+++ b/features-json/link-rel-dns-prefetch.json
@@ -19,7 +19,7 @@
   ],
   "bugs":[
     {
-      "description":"Firefox only performs `dns-prefetch` on HTTP origins. The feature [is disabled on HTTPS](https://bugzilla.mozilla.org/show_bug.cgi?id=1596935)."
+      "description":"Firefox < 127 only performs `dns-prefetch` on HTTP origins. The feature [is disabled on HTTPS](https://bugzilla.mozilla.org/show_bug.cgi?id=1596935)."
     }
   ],
   "categories":[
@@ -218,10 +218,10 @@
       "124":"a #2",
       "125":"a #2",
       "126":"a #2",
-      "127":"a #2",
-      "128":"a #2",
-      "129":"a #2",
-      "130":"a #2"
+      "127":"y",
+      "128":"y",
+      "129":"y",
+      "130":"y"
     },
     "chrome":{
       "4":"y",
@@ -626,7 +626,7 @@
   "notes":"",
   "notes_by_num":{
     "1":"IE9 [supported `dns-prefetch` as `prefetch`](https://blogs.msdn.com/b/ieinternals/archive/2012/03/01/ie10-beta-consumer-preview-minor-changes-changelist.aspx) as the former wasn\u2019t defined yet.",
-    "2":"Firefox only supports `dns-prefetch` on HTTP origins. HTTPS is unsupported."
+    "2":"Firefox < 127 only supports `dns-prefetch` on HTTP origins. HTTPS is unsupported."
   },
   "usage_perc_y":80.51,
   "usage_perc_a":2.46,


### PR DESCRIPTION
See the latest updates in https://bugzilla.mozilla.org/show_bug.cgi?id=1596935 or the Firefox 127 release notes: https://www.mozilla.org/en-US/firefox/127.0/releasenotes/