### PR TITLE
Update webkit links for cookie-store-api

### DIFF
--- a/features-json/cookie-store-api.json
+++ b/features-json/cookie-store-api.json
@@ -19,6 +19,14 @@
     {
       "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=1475599",
       "title":"Firefox support bug"
+    },
+    {
+      "url":"https://github.com/WebKit/standards-positions/issues/36",
+      "title":"WebKit position"
+    },
+    {
+      "url": "https://bugs.webkit.org/show_bug.cgi?id=258504",
+      "title":"WebKit support bug"
     }
   ],
   "bugs":[


### PR DESCRIPTION
https://github.com/WebKit/standards-positions/issues/36
https://bugs.webkit.org/show_bug.cgi?id=258504