### PR TITLE
WebGPU is supported in Safari 17.4+ behind a flag

### DIFF
--- a/features-json/webgpu.json
+++ b/features-json/webgpu.json
@@ -392,10 +392,10 @@
       "17.1":"n",
       "17.2":"n",
       "17.3":"n",
-      "17.4":"n",
-      "17.5":"n",
-      "17.6":"n",
-      "18.0":"n",
+      "17.4":"n d #2",
+      "17.5":"n d #2",
+      "17.6":"n d #2",
+      "18.0":"n d #2",
       "TP":"y"
     },
     "opera":{
@@ -545,10 +545,10 @@
       "17.1":"n",
       "17.2":"n",
       "17.3":"n",
-      "17.4":"n",
-      "17.5":"n",
-      "17.6":"n",
-      "18.0":"n"
+      "17.4":"n d #2",
+      "17.5":"n d #2",
+      "17.6":"n d #2",
+      "18.0":"n d #2"
     },
     "op_mini":{
       "all":"n"
@@ -629,7 +629,7 @@
   "notes":"All major browser engines are working on implementing this spec.",
   "notes_by_num":{
     "1":"Can be enabled in Firefox with the `dom.webgpu.enabled` flag.",
-    "2":"Can be enabled in Safari on MacOS with the `WebGPU` experimental feature.",
+    "2":"Can be enabled in Safari with the `WebGPU` feature flag.",
     "3":"Can be enabled in some Chromium browsers (on Windows, MacOS, Linux) with the `enable-unsafe-webgpu` flag.",
     "4":"Part of an origin trial.",
     "5":"Not enabled on Linux by default."


### PR DESCRIPTION
PR for #7124.

Adding the fact WebGPU is available in Safari 17.4+ on both macOS and iOS, after flipping the feature flag. 

Updated the footnote to not say "macOS" so it can be used now for both. Also, replacing "experimental feature" with "feature flag". The word "experimental" is used by Chrome, not Safari. We call it a "feature flag" — which comes in three flavors "testable", "preview", and "stable". (Testable = can be tested by flipping the feature flag. Preview = on in Safari Technology Preview. Stable = on by default for all users.)