### PR TITLE
Fix Android intent link in Web Share API

### DIFF
--- a/features-json/web-share.json
+++ b/features-json/web-share.json
@@ -658,7 +658,7 @@
   "notes":"",
   "notes_by_num":{
     "1":"Implemented old [Web Intents](https://dvcs.w3.org/hg/web-intents/raw-file/tip/spec/Overview-respec.html)",
-    "2":"[Android intent:// URLs](https://developer.chrome.com/multidevice/android/intents) can be used instead",
+    "2":"[Android intent:// URLs](https://developer.chrome.com/docs/android/intents) can be used instead",
     "3":"Only supported on Windows",
     "4":"Only supported on Windows and Chrome OS",
     "5":"Did not support share click that would trigger a [fetch call](https://bugs.webkit.org/show_bug.cgi?id=197779)",


### PR DESCRIPTION
Footnote 2 for the Web Share API ends on a 404 on Chrome developer documentation.

The current link is: https://developer.chrome.com/multidevice/android/intents

The correct link should be: https://developer.chrome.com/docs/android/intents

This fixes #7130