### PR TITLE
chore: update status for webauthn on firefox mobile

### DIFF
--- a/features-json/webauthn.json
+++ b/features-json/webauthn.json
@@ -583,7 +583,7 @@
       "127":"y"
     },
     "and_ff":{
-      "127":"a #4"
+      "127":"a #7"
     },
     "ie_mob":{
       "10":"n",
@@ -634,7 +634,8 @@
     "3":"Can be enabled in Settings under the Safari > Advanced > Experimental Features menu.",
     "4":"Partial support refers to FIDO2 devices not working in all operating systems if a PIN is set.",
     "5":"Experimental feature not yet enabled in WKWebView-based browsers including Chrome for iOS.",
-    "6":"Partial support refers to TouchID not being supported."
+    "6":"Partial support refers to TouchID not being supported.",
+    "7":"Does not support direct attestations"
   },
   "usage_perc_y":93.48,
   "usage_perc_a":2.72,


### PR DESCRIPTION
Removing `#4`, since using an authenticator with a PIN definitely is supported, see screenshot.

Also adding `#7` since firefox on mobile doesn't support direct attestations due to them having an extra privacy requirement, which they haven't implemented the UI for.

Firefox on mobile working fine with a FIDO 2 authenticator with PIN enabled:
![image](https://github.com/user-attachments/assets/0e28dfe4-c3c2-4e9e-867c-57bcc6ee2313)
