### PR TITLE
Firefox 132 adds Cookie Store API behind flag

### DIFF
--- a/features-json/cookie-store-api.json
+++ b/features-json/cookie-store-api.json
@@ -236,8 +236,8 @@
       "129":"n",
       "130":"n",
       "131":"n",
-      "132":"n",
-      "133":"n"
+      "132":"n d #2",
+      "133":"n d #2"
     },
     "chrome":{
       "4":"n",
@@ -644,7 +644,8 @@
   },
   "notes":"",
   "notes_by_num":{
-    "1":"Can be enabled with the `#enable-experimental-web-platform-features` flag."
+    "1":"Can be enabled with the `#enable-experimental-web-platform-features` flag.",
+    "2":"Can be enabled with the `dom.cookieStore.enabled` flag."
   },
   "usage_perc_y":74.48,
   "usage_perc_a":0,


### PR DESCRIPTION
- https://bugzilla.mozilla.org/show_bug.cgi?id=1475599#c28
- https://hg.mozilla.org/integration/autoland/diff/d55b6525d7b24d90ac7e1b092e4fef698cc244fe/modules/libpref/init/StaticPrefList.yaml
- https://wpt.fyi/results/cookie-store?label=master&label=experimental&aligned=
- https://tests.caniuse.com/cookie-store-api