### PR TITLE
Chrome 131 supports `currentcolor` in Relative Color & more

### DIFF
--- a/features-json/css-relative-colors.json
+++ b/features-json/css-relative-colors.json
@@ -227,9 +227,9 @@
       "128":"a #2",
       "129":"a #2",
       "130":"a #2",
-      "131":"a #2",
-      "132":"a #2",
-      "133":"a #2"
+      "131":"y",
+      "132":"y",
+      "133":"y"
     },
     "chrome":{
       "4":"n",
@@ -640,13 +640,13 @@
   "notes":"",
   "notes_by_num":{
     "1":"Can be enabled in Chrome via the `#enable-experimental-web-platform-features` flag in `chrome://flags`",
-    "2":"Does not support `currentcolor` or system color keywords"
+    "2":"Does not support `currentcolor` or system color keywords ([Firefox bug 1893966](https://bugzilla.mozilla.org/show_bug.cgi?id=1893966))"
   },
   "usage_perc_y":0.17,
   "usage_perc_a":85.92,
   "ucprefix":false,
   "parent":"",
   "keywords":"",
-  "chrome_id":"5205844613922816",
+  "chrome_id":"5205844613922816,4755025804132352",
   "shown":true
 }


### PR DESCRIPTION
- https://chromestatus.com/feature/4755025804132352
- https://issues.chromium.org/issues/325309578
- https://bugzilla.mozilla.org/show_bug.cgi?id=1893966

Not entirely sure about the system color aspect, but seemingly those WPT tests are the only ones: https://wpt.fyi/results/css/css-color?label=experimental&label=master&aligned&view=interop&q=label%3Ainterop-2024-relative-color