### PR TITLE
Update Temporal's Firefox implementation bug

### DIFF
--- a/features-json/temporal.json
+++ b/features-json/temporal.json
@@ -13,7 +13,7 @@
       "title":"Chromium implementation bug"
     },
     {
-      "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=1519167",
+      "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=1839673",
       "title":"Firefox implementation bug"
     },
     {


### PR DESCRIPTION
The linked bug was closed more than a year ago, and a new [META] one has been opened.
In my opinion the newly linked bug gives a better understanding of the status of the implementation efforts going forward in Firefox.