### PR TITLE
SSE 4.1 required note

### DIFF
--- a/features-json/wasm-simd.json
+++ b/features-json/wasm-simd.json
@@ -625,7 +625,7 @@
       "3.0-3.1":"u"
     }
   },
-  "notes":"",
+  "notes":"WebAssembly SIMD requires a processor with SSE 4.1.",
   "notes_by_num":{
     
   },

--- a/features-json/wasm-simd.json
+++ b/features-json/wasm-simd.json
@@ -625,7 +625,7 @@
       "3.0-3.1":"u"
     }
   },
-  "notes":"WebAssembly SIMD requires a processor with SSE 4.1.",
+  "notes":"WebAssembly SIMD requires a processor with SSE 4.1 if using the x86-64 architecture.",
   "notes_by_num":{
     
   },


### PR DESCRIPTION
WASM  SIMD requires SSE 4.1 to run.  This PR adds a note to this effect.
see https://github.com/bytecodealliance/wasmtime/issues/3809