### PR TITLE
Updates to Mutation events in light of deprecation

### DIFF
--- a/features-json/mutation-events.json
+++ b/features-json/mutation-events.json
@@ -1,12 +1,12 @@
 {
   "title":"Mutation events",
   "description":"Deprecated mechanism for listening to changes made to the DOM, replaced by Mutation Observers.",
-  "spec":"https://www.w3.org/TR/DOM-Level-3-Events/#legacy-mutationevent-events",
+  "spec":"https://www.w3.org/TR/2024/WD-uievents-20240906/#legacy-mutationevent-events",
   "status":"wd",
   "links":[
     {
-      "url":"https://developer.mozilla.org/en-US/docs/Web/Guide/Events/Mutation_events",
-      "title":"MDN Web Docs - Mutation events"
+      "url":"https://developer.mozilla.org/en-US/docs/Web/API/MutationEvent",
+      "title":"MDN Web Docs - MutationEvent"
     }
   ],
   "bugs":[
@@ -80,9 +80,9 @@
       "124":"a #1",
       "125":"a #1",
       "126":"a #1",
-      "127":"a #1",
-      "128":"a #1",
-      "129":"a #1"
+      "127":"n d",
+      "128":"n d",
+      "129":"n d"
     },
     "firefox":{
       "2":"n",
@@ -343,12 +343,12 @@
       "124":"a #1",
       "125":"a #1",
       "126":"a #1",
-      "127":"a #1",
-      "128":"a #1",
-      "129":"a #1",
-      "130":"a #1",
-      "131":"a #1",
-      "132":"a #1"
+      "127":"n d",
+      "128":"n d",
+      "129":"n d",
+      "130":"n d",
+      "131":"n d",
+      "132":"n d"
     },
     "safari":{
       "3.1":"u",
@@ -566,7 +566,7 @@
       "4.2-4.3":"a #1",
       "4.4":"a #1",
       "4.4.3-4.4.4":"a #1",
-      "129":"a #1"
+      "129":"n d"
     },
     "bb":{
       "7":"a #1",
@@ -582,7 +582,7 @@
       "80":"a #1"
     },
     "and_chr":{
-      "129":"a #1"
+      "129":"n d"
     },
     "and_ff":{
       "130":"a #2"
@@ -629,7 +629,7 @@
       "3.0-3.1":"a #2"
     }
   },
-  "notes":"See also support for [Mutation Observer](https://caniuse.com/#feat=mutationobserver), which replaces mutation events and does not have the same performance drawbacks.",
+  "notes":"Mutation events are deprecated and have been removed from the Spec as of 2024-09-07. See instead support for [Mutation Observer](https://caniuse.com/mutationobserver), which replaces mutation events and does not have the same performance drawbacks.",
   "notes_by_num":{
     "1":"Does not support `DOMAttrModified`",
     "2":"Does not support `DOMNodeInsertedIntoDocument` & `DOMNodeRemovedFromDocument`"
@@ -639,6 +639,6 @@
   "ucprefix":false,
   "parent":"",
   "keywords":"DOMAttrModified,DOMCharacterDataModified,DOMNodeInserted,DOMNodeInsertedIntoDocument,DOMNodeRemoved,DOMNodeRemovedFromDocument,DOMSubtreeModified",
-  "chrome_id":"",
+  "chrome_id":"5083947249172480",
   "shown":true
 }

--- a/features-json/mutation-events.json
+++ b/features-json/mutation-events.json
@@ -629,7 +629,7 @@
       "3.0-3.1":"a #2"
     }
   },
-  "notes":"Mutation events are deprecated and have been removed from the Spec as of 2024-09-07. See instead support for [Mutation Observer](https://caniuse.com/mutationobserver), which replaces mutation events and does not have the same performance drawbacks.",
+  "notes":"Mutation events are deprecated and have been removed from the Spec as of 2024-09-07. Instead see support for [Mutation Observer](https://caniuse.com/mutationobserver), which replaces mutation events and does not have the same performance drawbacks.",
   "notes_by_num":{
     "1":"Does not support `DOMAttrModified`",
     "2":"Does not support `DOMNodeInsertedIntoDocument` & `DOMNodeRemovedFromDocument`"


### PR DESCRIPTION
Fixes https://github.com/Fyrd/caniuse/issues/7182.

A lot of context there^ already, but for completeness links I came across while digging:
- https://www.w3.org/standards/history/uievents/
   - https://www.w3.org/TR/2024/WD-uievents-20240906/#legacy-mutationevent-events still in the spec
   - https://www.w3.org/TR/2024/WD-uievents-20240907/ removed
- https://chromestatus.com/feature/5083947249172480
- https://github.com/mozilla/standards-positions/issues/807
- https://github.com/WebKit/standards-positions/issues/192