### PR TITLE
Update css-text-box-trim.json

### DIFF
--- a/features-json/css-text-box-trim.json
+++ b/features-json/css-text-box-trim.json
@@ -1,6 +1,6 @@
 {
-  "title":"CSS text-box-trim & text-box-edge",
-  "description":"Provides the ability to remove the vertical space appearing above and below text glyphs, allowing more precise positioning and alignment.\r\n\r\nPreviously specified as the `leading-trim` & `text-edge` properties.\r\n",
+  "title":"CSS Text Box",
+  "description":"CSS `text-box` (and it’s longhands `text-box-trim` & `text-box-edge`) provide the ability to trim extra space over/under text glyphs at the start/end of a block to match specific font-provided metrics. This allows for more precise alignment and positioning of text. ",
   "spec":"https://w3c.github.io/csswg-drafts/css-inline-3/#propdef-leading-trim",
   "status":"wd",
   "links":[
@@ -406,7 +406,7 @@
       "17.6":"n d #1",
       "18.0":"n d #1",
       "18.1":"n d #1",
-      "18.2":"n d #1",
+      "18.2":"y",
       "TP":"y"
     },
     "opera":{
@@ -564,7 +564,7 @@
       "17.6-17.7":"n d #1",
       "18.0":"n d #1",
       "18.1":"n d #1",
-      "18.2":"n d #1"
+      "18.2":"y"
     },
     "op_mini":{
       "all":"n"


### PR DESCRIPTION
Safari 18.2 adds support for `text-box`, `text-box-trim`, and `text-box-edge`. This PR also updates the title of the feature — since the `text-box` shorthand is a better way to use this. And the PR updates the description to explain this includes `text-box-trim`, and `text-box-edge`... and describing more accurately what it does. I also removed the reference to `leading-trim`, since 1) the early draft never shipped in customer-facing browsers, and 2) the name change is very old news.