### PR TITLE
Remove note stating SSE 4.1 is required for WASM SIMD

### DIFF
--- a/features-json/wasm-simd.json
+++ b/features-json/wasm-simd.json
@@ -642,7 +642,7 @@
       "3.0-3.1":"u"
     }
   },
-  "notes":"WebAssembly SIMD requires a processor with SSE 4.1 if using the x86-64 architecture.",
+  "notes":"",
   "notes_by_num":{
     
   },


### PR DESCRIPTION
WASM is just a specification. Nothing in it requires any features from the host CPU; you can always emulate complex WASM features using simpler CPU instructions.

The PR that originally added this note (#7167) referenced a discussion in Wasmtime: bytecodealliance/wasmtime#3809. However, nothing in that issue means that it's impossible to implement WASM SIMD without SSE 4.1. It just means that _Wasmtime_ specifically didn't want to at the time, because it's harder. In fact, according to bytecodealliance/wasmtime#3810 they do now support SIMD instructions on CPUs without any optional extensions.

I haven't investigated whether any browsers or runtimes other than Wasmtime impose CPU requirements to use WASM SIMD. But if they do, such notes should probably go on the browser and not on the feature.