### PR TITLE
Chrome 133 supports CSS attr() function for all properties

### DIFF
--- a/features-json/css3-attr.json
+++ b/features-json/css3-attr.json
@@ -366,8 +366,8 @@
       "130":"n",
       "131":"n",
       "132":"n",
-      "133":"n",
-      "134":"n"
+      "133":"y",
+      "134":"y"
     },
     "safari":{
       "3.1":"n",
@@ -663,6 +663,6 @@
   "ucprefix":false,
   "parent":"",
   "keywords":"attr,attribute,function",
-  "chrome_id":"",
+  "chrome_id":"4680129030651904",
   "shown":true
 }


### PR DESCRIPTION
- https://issues.chromium.org/issues/40320391
- https://chromium-review.googlesource.com/c/chromium/src/+/6091991
- https://groups.google.com/a/chromium.org/g/blink-dev/c/2dNLhQN9SNs
- https://wpt.fyi/results/css/css-values?label=master&label=experimental&aligned&q=attr
- https://chromestatus.com/feature/4680129030651904?gate=5932337540366336