### PR TITLE
Add known bug for `content-visibility` in Safari

### DIFF
--- a/features-json/css-content-visibility.json
+++ b/features-json/css-content-visibility.json
@@ -18,7 +18,9 @@
     }
   ],
   "bugs":[
-    
+    {
+      "description": "[WebKit Bug 283846](https://bugs.webkit.org/show_bug.cgi?id=283846): in Safari, the `auto` value does not keep skipped content findable with the find-in-page feature."
+    }
   ],
   "categories":[
     "CSS"


### PR DESCRIPTION
[Safari has a bug](https://bugs.webkit.org/show_bug.cgi?id=283846) where content skipped using `content-visibility: auto` is not findable using the find-in-page feature as [it’s spec’d to](https://drafts.csswg.org/css-contain/#valdef-content-visibility-auto) ([a _MUST_ requirement](https://datatracker.ietf.org/doc/html/rfc2119#section-1)). This PR adds a known issue for the `content-visibility` feature at-large which both links to the bug report and includes a concise description of it.

I’ve already highlighted the issue in the browser-compat-data (https://github.com/mdn/browser-compat-data/pull/25781), so that it shows the implementation as partial for `content-visibility: auto` specifically.