### PR TITLE
CSS line-clamp edited to include link to MDN article

### DIFF
--- a/features-json/css-line-clamp.json
+++ b/features-json/css-line-clamp.json
@@ -7,6 +7,10 @@
     {
       "url":"https://css-tricks.com/line-clampin/",
       "title":"CSS Tricks article"
+    },
+    {
+      "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/line-clamp",
+      "title":"MDN Web Docs - line-clamp"
     }
   ],
   "bugs":[


### PR DESCRIPTION
The MDN article for CSS line-clamp was missing, so I added it.