### PR TITLE
Removing redundant note from WebGPU

### DIFF
--- a/features-json/webgpu.json
+++ b/features-json/webgpu.json
@@ -657,6 +657,7 @@
       "3.0-3.1":"n d #1"
     }
   },
+  "notes":"",
   "notes_by_num":{
     "1":"Can be enabled in Firefox with the `dom.webgpu.enabled` flag.",
     "2":"Can be enabled in Safari with the `WebGPU` feature flag.",

--- a/features-json/webgpu.json
+++ b/features-json/webgpu.json
@@ -657,7 +657,6 @@
       "3.0-3.1":"n d #1"
     }
   },
-  "notes":"All major browser engines are working on implementing this spec.",
   "notes_by_num":{
     "1":"Can be enabled in Firefox with the `dom.webgpu.enabled` flag.",
     "2":"Can be enabled in Safari with the `WebGPU` feature flag.",


### PR DESCRIPTION
I noticed the page for WebGPU says "All major browser engines are working on implementing this spec. All major browser engines are working on implementing this spec."

Hm. The same sentence twice? I came here to fix it. But in JSON, it's only there once. Interesting. Well, this note isn't needed at all in Feb 2025, since seeing feature flags for both WebKit and Gecko browsers tells the same story. So I'm deleting it, expecting that will fix the bug as well.

<img width="1152" alt="Screenshot 2025-02-28 at 1 42 08 PM" src="https://github.com/user-attachments/assets/8cc19107-e7e1-4703-ad52-e481e7f51d72" />