### PR TITLE
Firefox enables more HEVC

### DIFF
--- a/features-json/hevc.json
+++ b/features-json/hevc.json
@@ -238,8 +238,8 @@
       "134":"n d #7",
       "135":"n d #7",
       "136":"n d #7",
-      "137":"n d #7",
-      "138":"n d #7"
+      "137":"a #8",
+      "138":"a #8"
     },
     "chrome":{
       "4":"n",
@@ -670,7 +670,8 @@
     "4":"Supported for all devices on macOS (>= Big Sur 11.0) and Android (>= 5.0) if Edge >= 107, for devices with [hardware support](https://techcommunity.microsoft.com/t5/discussions/updated-dev-channel-build-77-0-211-3-is-live/m-p/745801#M6548) on Windows (>= Windows 10 1709) when [HEVC video extensions from the Microsoft Store](https://apps.microsoft.com/store/detail/hevc-video-extension/9NMZLZ57R3T7) is installed",
     "5":"Supported for all devices on macOS (>= Big Sur 11.0) and Android (>= 5.0), for devices with [hardware support](https://github.com/StaZhu/enable-chromium-hevc-hardware-decoding) on Windows (>= Windows 8), and for devices with hardware support powered by VAAPI on Linux and ChromeOS",
     "6":"Supported for devices with hardware support (the range is the same as Edge) on Windows in Nightly only. 10-bit or higher colors are not supported.",
-    "7":"Supported for devices with hardware support (the range is the same as Edge) on Windows only. Enabled by default in Nightly and can be enabled via the `media.wmf.hevc.enabled` pref in `about:config`. 10-bit or higher colors are not supported."
+    "7":"Supported for devices with hardware support (the range is the same as Edge) on Windows only. Enabled by default in Nightly and can be enabled via the `media.wmf.hevc.enabled` pref in `about:config`. 10-bit or higher colors are not supported.",
+    "8":"Supported for devices with hardware support, software fallback in some cases. See [details here on MDN](https://developer.mozilla.org/en-US/docs/Web/Media/Guides/Formats/Video_codecs#hevc_h.265)."
   },
   "usage_perc_y":19.81,
   "usage_perc_a":71.93,


### PR DESCRIPTION
- all via https://github.com/mdn/content/commit/4f6e436684338f9e1256108b456d28b28c9726b0
- didn't bother to unfurl the details below 137
- does note 8 strike the balance of usefulness and vagueness?
  - thought better link to their docs instead of maintaining them here as well…
  - once this part https://github.com/mdn/content/commit/4f6e436684338f9e1256108b456d28b28c9726b0#diff-f5860e33aa3a50f159eb13611e4d750e9b7995d8eaf398bd15816afe1c60f964 is live on https://developer.mozilla.org/en-US/docs/Web/Media/Guides/Formats/Video_codecs#hevc_h.265, I'd try to more precisely text-link there

<https://tests.caniuse.com/hevc> looks good for one case at least

![image](https://github.com/user-attachments/assets/2cd248f3-10a3-498f-9b6e-0d9b81c616fa)
