### PR TITLE
Safari's support for Image Capture API

### DIFF
--- a/features-json/imagecapture.json
+++ b/features-json/imagecapture.json
@@ -18,7 +18,7 @@
     }
   ],
   "bugs":[
-
+  
   ],
   "categories":[
     "DOM",

--- a/features-json/imagecapture.json
+++ b/features-json/imagecapture.json
@@ -18,7 +18,7 @@
     }
   ],
   "bugs":[
-    Safari does not support `grabFrame()`, 
+
   ],
   "categories":[
     "DOM",

--- a/features-json/imagecapture.json
+++ b/features-json/imagecapture.json
@@ -18,7 +18,7 @@
     }
   ],
   "bugs":[
-    
+    Safari does not support `grabFrame()`, 
   ],
   "categories":[
     "DOM",
@@ -419,8 +419,8 @@
       "18.1":"n",
       "18.2":"n",
       "18.3":"n",
-      "18.4":"n",
-      "TP":"a #3"
+      "18.4":"y",
+      "TP":"y"
     },
     "opera":{
       "9":"n",
@@ -579,7 +579,7 @@
       "18.1":"n",
       "18.2":"n",
       "18.3":"n",
-      "18.4":"n"
+      "18.4":"y"
     },
     "op_mini":{
       "all":"n"
@@ -662,8 +662,7 @@
   "notes":"Firefox supports the `takePhoto()` method only (when flag is enabled).",
   "notes_by_num":{
     "1":"Can be enabled via the about:config entry dom.imagecapture.enabled.",
-    "2":"Can be enabled via the Experimental Web Platform Features flag.",
-    "3":"Partial support refers to not supporting `grabFrame()`."
+    "2":"Can be enabled via the Experimental Web Platform Features flag."
   },
   "usage_perc_y":76.56,
   "usage_perc_a":0,

--- a/features-json/imagecapture.json
+++ b/features-json/imagecapture.json
@@ -18,7 +18,7 @@
     }
   ],
   "bugs":[
-  
+    
   ],
   "categories":[
     "DOM",


### PR DESCRIPTION
Image Capture API is supported in Safari 18.4.

This P.R. also removes the "partial support" designation. It was there because of a complaint that Safari’s implementation does not support `grabFrame()`.

Instead Safari supports `takePhoto`, which can do everything `grabFrame` does — plus has an optional PhotoSettings parameter that allows you to apply constraints to the track just while the snapshot is taken, including constraints that aren't appropriate for a live video track, e.g. flash, red-eye reduction, etc. The `takePhoto` method is newer than `grabFrame`, and was created to address its shortcomings.

Safari has the full set of capabilities Image Capture API intends. 