### PR TITLE
Fix grammar in css-text-box-trim.json

### DIFF
--- a/features-json/css-text-box-trim.json
+++ b/features-json/css-text-box-trim.json
@@ -1,6 +1,6 @@
 {
   "title":"CSS Text Box",
-  "description":"CSS `text-box` (and it\u2019s longhands `text-box-trim` & `text-box-edge`) provide the ability to trim extra space over/under text glyphs at the start/end of a block to match specific font-provided metrics. This allows for more precise alignment and positioning of text. ",
+  "description":"CSS `text-box` (and its longhands `text-box-trim` & `text-box-edge`) provide the ability to trim extra space over/under text glyphs at the start/end of a block to match specific font-provided metrics. This allows for more precise alignment and positioning of text. ",
   "spec":"https://w3c.github.io/csswg-drafts/css-inline-3/#propdef-leading-trim",
   "status":"wd",
   "links":[


### PR DESCRIPTION
Fix grammar ("it's" == "it is"; "its" is the possessive form which was originally intended)