### PR TITLE
Firefox supports service workers in private browsing since FF138

### DIFF
--- a/features-json/serviceworkers.json
+++ b/features-json/serviceworkers.json
@@ -18,9 +18,7 @@
     }
   ],
   "bugs":[
-    {
-      "description":"Service Workers are currently [not supported](https://bugzilla.mozilla.org/show_bug.cgi?id=1320796) in Firefox's Private Browsing mode."
-    }
+    
   ],
   "categories":[
     "JS API"


### PR DESCRIPTION
remove outdated bug entry (see #7363)