### PR TITLE
Mark Zstandard as partial supported for Safari 26+

### DIFF
--- a/features-json/zstd.json
+++ b/features-json/zstd.json
@@ -449,8 +449,8 @@
       "18.3":"n",
       "18.4":"n",
       "18.5-18.6":"n",
-      "26.0":"n",
-      "TP":"n"
+      "26.0":"a #2",
+      "TP":"a #2"
     },
     "opera":{
       "9":"n",
@@ -619,7 +619,7 @@
       "18.3":"n",
       "18.4":"n",
       "18.5-18.6":"n",
-      "26.0":"n"
+      "26.0":"a #2"
     },
     "op_mini":{
       "all":"n"
@@ -702,7 +702,8 @@
   },
   "notes":"",
   "notes_by_num":{
-    "1":"Enabled through the `enable-zstd-content-encoding` feature flag in `chrome://flags`"
+    "1":"Enabled through the `enable-zstd-content-encoding` feature flag in `chrome://flags`",
+    "2":"Partial support refers to supporting Zstandard, but not requesting it"
   },
   "usage_perc_y":68.29,
   "usage_perc_a":0,


### PR DESCRIPTION
Fixes https://github.com/Fyrd/caniuse/issues/7360.

As we got RCs today

- https://www.macrumors.com/2025/09/09/apple-seeds-ios-26-rc/
- https://www.macrumors.com/2025/09/09/apple-seeds-macos-tahoe-rc/

I gave Zstandard on Safari 26 another test and it's the same as since Beta 2 - supported but not advertised/requested:

TODO

Technically I have only tested on iPadOS and assume it's the same across the board.