### PR TITLE
Update css-anchor-positioning for a Safari bug

### DIFF
--- a/features-json/css-anchor-positioning.json
+++ b/features-json/css-anchor-positioning.json
@@ -452,7 +452,7 @@
       "18.3":"n",
       "18.4":"n",
       "18.5-18.6":"n",
-      "26.0":"y",
+      "26.0":"a #3",
       "26.1":"y",
       "TP":"y"
     },
@@ -708,7 +708,8 @@
   "notes":"",
   "notes_by_num":{
     "1":"Can be enabled via the `#enable-experimental-web-platform-features` flag in `chrome://flags`",
-    "2":"Can be enabled using the `layout.css.anchor-positioning.enabled` flag. Enabled by default in Firefox Nightly only"
+    "2":"Can be enabled using the `layout.css.anchor-positioning.enabled` flag. Enabled by default in Firefox Nightly only",
+    "3": "There's a [bug with `position: fixed` and non-initial containing blocks](https://codepen.io/pavelp/pen/KwVPrrB)."
   },
   "usage_perc_y":74.18,
   "usage_perc_a":0,


### PR DESCRIPTION
Adds a link to a reproduction.

The bug is currently fixed in Safari Technology Preview, so I didn't file a webkit bug.

In the real world, the library I'm maintaining has to do browser sniffing
because some of its functionality is broken due to this bug with anchor positioning in Safari:
https://github.com/pomerantsev/accented/blob/4312cae5b4dde15b09806e84b3ced3e18ea997ac/packages/accented/src/utils/supports-anchor-positioning.ts#L1-L8