### PR TITLE
WebGPU only being enabled by default on macOS 26 Tahoe or later

### DIFF
--- a/features-json/webgpu.json
+++ b/features-json/webgpu.json
@@ -441,9 +441,9 @@
       "18.3":"n d #2",
       "18.4":"n d #2",
       "18.5-18.6":"n d #2",
-      "26.0":"y",
-      "26.1":"y",
-      "TP":"y"
+      "26.0":"a #7",
+      "26.1":"a #7",
+      "TP":"a #7"
     },
     "opera":{
       "9":"n",
@@ -701,7 +701,8 @@
     "3":"Can be enabled in some Chromium browsers (on Windows, MacOS, Linux) with the `enable-unsafe-webgpu` flag.",
     "4":"Part of an origin trial.",
     "5":"Not enabled on Linux by default.",
-    "6":"Only enabled by default on Windows"
+    "6":"Only enabled by default on Windows.",
+    "7":"Partial support refers to only being enabled by default on macOS 26 Tahoe or later."
   },
   "usage_perc_y":72.36,
   "usage_perc_a":1.27,


### PR DESCRIPTION
Fixes #7390, all details there. Didn't test myself, but because of the webkit bug little doubt is left, imho.