### PR TITLE
Chrome 144 is shipping Temporal

### DIFF
--- a/features-json/temporal.json
+++ b/features-json/temporal.json
@@ -706,7 +706,7 @@
       "3.0-3.1":"n"
     }
   },
-  "notes":"All browsers are working on implementing this.",
+  "notes":"",
   "notes_by_num":{
     "1":"Supported in Firefox Nightly behind the `javascript.options.experimental.temporal` flag, enabled by default since 137"
   },


### PR DESCRIPTION
Fixes https://github.com/Fyrd/caniuse/issues/7395, see info there - most important perhaps https://chromestatus.com/feature/5668291307634688.

also removing the redundant(?) note on https://caniuse.com/temporal:

<img width="650" height="212" alt="image" src="https://github.com/user-attachments/assets/7f48bc0c-c415-4832-91f9-e831c8417686" />

how is

> All major browser engines are working on implementing this spec.

edited or the appearance controlled though? 🤔