### PR TITLE
Firefox is shipping more WebGPU

### DIFF
--- a/features-json/webgpu.json
+++ b/features-json/webgpu.json
@@ -251,10 +251,10 @@
       "142":"a d #1 #6",
       "143":"a d #1 #6",
       "144":"a d #1 #6",
-      "145":"a d #1 #6",
-      "146":"a d #1 #6",
-      "147":"a d #1 #6",
-      "148":"a d #1 #6"
+      "145":"a d #1 #8",
+      "146":"a d #1 #8",
+      "147":"a d #1 #8",
+      "148":"a d #1 #8"
     },
     "chrome":{
       "4":"n",
@@ -711,7 +711,8 @@
     "4":"Part of an origin trial.",
     "5":"Not enabled on Linux by default.",
     "6":"Only enabled by default on Windows.",
-    "7":"Partial support refers to only being enabled by default on macOS 26 Tahoe or later."
+    "7":"Partial support refers to only being enabled by default on macOS 26 Tahoe or later.",
+    "8":"Only enabled by default on Windows as well as macOS 26 Tahoe or later on Apple Silicon."
   },
   "usage_perc_y":77.94,
   "usage_perc_a":1.59,


### PR DESCRIPTION
Fixes https://github.com/Fyrd/caniuse/issues/7422.

Links from there and more I dug up:
- https://github.com/gpuweb/gpuweb/wiki/Implementation-Status#firefox
- https://www.firefox.com/en-US/firefox/145.0/releasenotes/#:~:text=The-,WebGPU,-DOM%20API%20(
- https://bugzilla.mozilla.org/show_bug.cgi?id=1849913#c3
- https://hg.mozilla.org/mozilla-central/rev/c4ce9cf590ea

I think it would be fair to mark it as full support, given how Chrome is handled, when there is no constraint to the macOS version nor architecture anymore - or that becomes obsolete because Firefox isn't supported on it anymore. I suppose that will be a while.