### PR TITLE
 Make GitHub recognize the repo sources are largely JSON

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 * text=auto
+*.json	linguist-detectable


### PR DESCRIPTION
This change causes GitHub to recognize that the repo sources are currently 99.9% JSON and 0.1% JavaScript.

Otherwise, without this change, the GitHub UI incorrectly shows the repo sources as being 100% JavaScript.

See [github/linguist@master/docs/overrides.md#detectable](https://github.com/github/linguist/blob/master/docs/overrides.md#detectable), and see the similar change (but for Markdown) merged into mdn/content: https://github.com/mdn/content/pull/14123

And see https://github.com/bashamega/caniuse  for what the GitHub UI will show after this change is merged: