### PR TITLE
Add link to support tables for individual codec strings

### DIFF
--- a/features-json/webcodecs.json
+++ b/features-json/webcodecs.json
@@ -23,6 +23,10 @@
     {
       "url":"https://w3c.github.io/webcodecs/samples/",
       "title":"WebCodecs samples"
+    },
+    {
+      "url": "https://webcodecsfundamentals.org/datasets/codec-support-table/",
+      "title": "Support table for individual codec strings"
     }
   ],
   "bugs":[


### PR DESCRIPTION
To use the WebCodecs API you also need to specify a valid codec string like `avc1.42001e.` Neither MDN or W3C has a list of these codec strings, let alone which browsers support which, so I compiled a [dataset](https://webcodecsfundamentals.org/datasets/codec-support/) and added the following [support table](https://webcodecsfundamentals.org/datasets/codec-support-table/) indicating support for 1087 different codec strings across all the major browsers/operating systems. 

The tables are too big to host on a single caniuse page, like here's one of 1087 pages: https://webcodecsfundamentals.org/codecs/avc1.420020.html

Adding a link in CanIuse as it seems like a natural place for developers to look for this kind of info