### PR TITLE
Added MDN web docs links to details

### DIFF
--- a/features-json/details.json
+++ b/features-json/details.json
@@ -31,6 +31,14 @@
     {
       "url":"https://github.com/javan/details-element-polyfill",
       "title":"Details Element Polyfill"
+    },
+    {
+      "url":"https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/details",
+      "title":"MDN Web Docs - details"
+    },
+    {
+      "url":"https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/summary",
+      "title":"MDN Web Docs - summary"
     }
   ],
   "bugs":[


### PR DESCRIPTION
I added MDN web docs links (both details and summary) within the details element. I put them at the bottom because I figured that was probably the best way for them.