### PR TITLE
Chrome 148 is shipping lazy loading via attribute for video & audio

### DIFF
--- a/features-json/loading-lazy-media.json
+++ b/features-json/loading-lazy-media.json
@@ -420,8 +420,8 @@
       "145":"n",
       "146":"n",
       "147":"n d #1",
-      "148":"n d #1",
-      "149":"n d #1"
+      "148":"y",
+      "149":"y"
     },
     "safari":{
       "3.1":"n",
@@ -748,6 +748,6 @@
   "ucprefix":false,
   "parent":"loading-lazy-attr",
   "keywords":"lazy-loading,lazyloading,loading=\"lazy\",loading=\"eager\",video,audio,media,lazy video,lazy audio,lazy media loading,native lazyload",
-  "chrome_id":"",
+  "chrome_id":"5200068565139456",
   "shown":true
 }


### PR DESCRIPTION
- https://groups.google.com/a/chromium.org/g/blink-dev/c/HoqdJM4Xqjc/m/RHzw3hG9AQAJ
- https://chromestatus.com/feature/5200068565139456