### PR TITLE
WebKit position on lazy loading via attribute for video & audio moved to positive

### DIFF
--- a/features-json/loading-lazy-media.json
+++ b/features-json/loading-lazy-media.json
@@ -26,7 +26,7 @@
     },
     {
       "url":"https://github.com/WebKit/standards-positions/issues/586",
-      "title":"WebKit Standards Position (positive pending)"
+      "title":"WebKit Standards Position (positive)"
     }
   ],
   "bugs":[


### PR DESCRIPTION
https://github.com/WebKit/standards-positions/issues/586

<img width="1170" height="641" alt="image" src="https://github.com/user-attachments/assets/a8ab64ef-a830-46d6-90f4-7e7accb541f5" />
