### PR TITLE
Mozilla position on Web Serial API is neutral

### DIFF
--- a/features-json/web-serial.json
+++ b/features-json/web-serial.json
@@ -14,7 +14,7 @@
     },
     {
       "url":"https://mozilla.github.io/standards-positions/#webserial",
-      "title":"Mozilla position: harmful"
+      "title":"Mozilla position: neutral"
     },
     {
       "url":"https://webkit.org/tracking-prevention/",


### PR DESCRIPTION
https://mozilla.github.io/standards-positions/#webserial

<img width="1788" height="1052" alt="image" src="https://github.com/user-attachments/assets/c20c9ba6-f314-47fa-b205-2ad77c3dcf01" />

https://github.com/mozilla/standards-positions/issues/336

<img width="1868" height="1235" alt="image" src="https://github.com/user-attachments/assets/6328a6d9-8c64-4ebf-8afe-16c6bd56e4ee" />

---

originally I arrived here via

- https://mastodon.social/@evilpie@hachyderm.io/116391564494978413
- https://bugzilla.mozilla.org/show_bug.cgi?id=2010930

but looks like it's addon-gated as well currently, so not sure if there's precedent for a note for that case…