### PR TITLE
Update WebGPU feature support details

### DIFF
--- a/features-json/webgpu.json
+++ b/features-json/webgpu.json
@@ -256,15 +256,15 @@
       "142":"a d #1 #6",
       "143":"a d #1 #6",
       "144":"a d #1 #6",
-      "145":"a d #1 #8",
-      "146":"a d #1 #8",
-      "147":"a d #1 #8",
-      "148":"a d #1 #8",
-      "149":"a d #1 #8",
-      "150":"a d #1 #8",
-      "151":"a d #1 #8",
-      "152":"a d #1 #8",
-      "153":"a d #1 #8"
+      "145":"a d #1 #7",
+      "146":"a d #1 #7",
+      "147":"a d #1 #7",
+      "148":"a d #1 #7",
+      "149":"a d #1 #7",
+      "150":"a d #1 #7",
+      "151":"a d #1 #7",
+      "152":"a d #1 #7",
+      "153":"a d #1 #7"
     },
     "chrome":{
       "4":"n",
@@ -740,8 +740,7 @@
     "4":"Part of an origin trial.",
     "5":"Not enabled on Linux by default.",
     "6":"Only enabled by default on Windows.",
-    "7":"Partial support refers to only being enabled by default on macOS 26 Tahoe or later.",
-    "8":"Only enabled by default on Windows as well as macOS 26 Tahoe or later on Apple Silicon."
+    "7":"Only enabled by default on Windows as well as macOS 26 Tahoe or later on Apple Silicon."
   },
   "usage_perc_y":81.15,
   "usage_perc_a":3.13,


### PR DESCRIPTION
It doesn't make any sense to say "Partial support refers to only being enabled by default on macOS 26 Tahoe or later." because Safari 26 isn't available on any other version of macOS, so it's fully supported in Safari 26, not partially supported.