### PR TITLE
Firefox is enabling CSS3 attr() function for all properties in Nightly

### DIFF
--- a/features-json/css3-attr.json
+++ b/features-json/css3-attr.json
@@ -268,8 +268,8 @@
       "149":"n",
       "150":"n",
       "151":"n",
-      "152":"n",
-      "153":"n"
+      "152":"n d #1",
+      "153":"n d #1"
     },
     "chrome":{
       "4":"n",
@@ -739,7 +739,7 @@
   },
   "notes":"See the [generated content](/css-gencontent) table for support for `attr()` for the `content` property.",
   "notes_by_num":{
-    
+    "1":"Can be enabled via the `layout.css.attr.enabled` flag in `about:config`. Enabled by default in Nightly only."
   },
   "usage_perc_y":69.18,
   "usage_perc_a":0,


### PR DESCRIPTION
- https://bugzilla.mozilla.org/show_bug.cgi?id=2038939#c8
- https://hg-edge.mozilla.org/mozilla-central/rev/7599d7389de4