### PR TITLE
Firefox 153 is enabling JPEG XL by default in Nightly only

### DIFF
--- a/features-json/jpegxl.json
+++ b/features-json/jpegxl.json
@@ -285,7 +285,7 @@
       "150":"n d #2 #5",
       "151":"n d #2",
       "152":"n d #7",
-      "153":"n d #7"
+      "153":"n d #8"
     },
     "chrome":{
       "4":"n",
@@ -761,7 +761,8 @@
     "4":"Supports still images. Animated image sequences are not supported.",
     "5":"Partial support refers to not supporting progressive decoding.",
     "6":"Can be enabled via `chrome://flags/#enable-jxl-image-format`.",
-    "7":"Can be enabled via the `image.jxl.enabled` flag in `about:config`."
+    "7":"Can be enabled via the `image.jxl.enabled` flag in `about:config`.",
+    "8":"Can be enabled via the `image.jxl.enabled` flag in `about:config`. Enabled by default in Nightly only."
   },
   "usage_perc_y":0,
   "usage_perc_a":15.34,


### PR DESCRIPTION
- https://bugzilla.mozilla.org/show_bug.cgi?id=2040074
- https://bugzilla.mozilla.org/show_bug.cgi?id=2040074#c8
- https://hg-edge.mozilla.org/mozilla-central/rev/38c3fcb6e06d

let me know if I shouldn't add that many notes 0:-)