### PR TITLE
web-bluetooth: note userland iOS/iPadOS Safari extension support

### DIFF
--- a/features-json/web-bluetooth.json
+++ b/features-json/web-bluetooth.json
@@ -23,6 +23,10 @@
     {
       "url":"https://mozilla.github.io/standards-positions/#web-bluetooth",
       "title":"Mozilla Specification Positions: Harmful"
+    },
+    {
+      "url":"https://github.com/wklm/ioswebble-sdk",
+      "title":"iOSWebBLE (Safari extension polyfill that adds navigator.bluetooth on iOS/iPadOS Safari)"
     }
   ],
   "bugs":[
@@ -742,7 +746,7 @@
       "3.0-3.1":"n"
     }
   },
-  "notes":"",
+  "notes":"Safari on iOS and iPadOS has no native support. A third-party Safari web extension, iOSWebBLE, polyfills `navigator.bluetooth` in JavaScript by bridging to CoreBluetooth, so a website can use Web Bluetooth once a user installs and enables the extension. This is userland support and not part of WebKit, so the support status above stays unsupported.",
   "notes_by_num":{
     "1":"Available by enabling the \"Web Bluetooth\" experimental flag in `about:flags`. Currently support [varies by OS](https://github.com/WebBluetoothCG/web-bluetooth/blob/main/implementation-status.md)",
     "2":"Only in Opera Mobile",


### PR DESCRIPTION
## What

Adds a note (and one reference link) to the Web Bluetooth feature explaining that iOS/iPadOS Safari can run `navigator.bluetooth` via a third-party Safari web extension, iOSWebBLE, which polyfills the API in JavaScript by bridging to CoreBluetooth.

This is userland support only. It is **not** part of WebKit. Accordingly, **no support flags are changed**: every `safari` and `ios_saf` version stays `n` (unsupported). The change is limited to the `notes` field (previously empty) and a single new entry in `links`.

## Why

caniuse already models polyfill/userland support (the `p` support value, and notes/links naming third-party polyfills such as PWACompat, the WebVR polyfill, and TouchPolyfill). People targeting iOS Safari frequently assume Web Bluetooth is impossible there; a short, honest note that an opt-in extension exists is useful context without overstating native support.

## Diff

- `features-json/web-bluetooth.json`: set the empty `notes` field to one sentence describing the userland extension (and stating support stays unsupported), and add one `links` entry to the open-source repo github.com/wklm/ioswebble-sdk. Validated with npm run validate.