### PR TITLE
Return Firefox 154+ is enabling CSS Text Box by default in Nightly only

### DIFF
--- a/features-json/css-text-box-trim.json
+++ b/features-json/css-text-box-trim.json
@@ -264,8 +264,8 @@
       "151":"n",
       "152":"n",
       "153":"n",
-      "154":"n",
-      "155":"n"
+      "154":"n d #3",
+      "155":"n d #3"
     },
     "chrome":{
       "4":"n",
@@ -740,7 +740,8 @@
   "notes":"",
   "notes_by_num":{
     "1":"Available behind a [Safari feature flag](https://developer.apple.com/documentation/safari-developer-tools/feature-flag-settings).",
-    "2":"Can be enabled via the `#text-box-trim` flag in `chrome://flags`"
+    "2":"Can be enabled via the `#text-box-trim` flag in `chrome://flags`",
+    "3":"Can be enabled via the `layout.css.text-box.enabled` flag in `about:config`. Enabled by default in Nightly only."
   },
   "usage_perc_y":80.11,
   "usage_perc_a":0,


### PR DESCRIPTION
the changes from https://github.com/Fyrd/caniuse/pull/7540 were also lost 😢 